### PR TITLE
Fixed MSAA and Checkboard pipelines and screenshots

### DIFF
--- a/Passes/CheckerboardPipeline.pass
+++ b/Passes/CheckerboardPipeline.pass
@@ -9,7 +9,7 @@
             "Slots": [
                 {
                     "Name": "SwapChainOutput",
-                    "SlotType": "Output",
+                    "SlotType": "InputOutput",
                     "ScopeAttachmentUsage": "RenderTarget"
                 }
             ],

--- a/Passes/MSAA_2x_RPI_Pipeline.pass
+++ b/Passes/MSAA_2x_RPI_Pipeline.pass
@@ -10,7 +10,7 @@
             "Slots": [
                 {
                     "Name": "SwapChainOutput",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 }
             ],
             "PassRequests": [

--- a/Passes/MSAA_4x_RPI_Pipeline.pass
+++ b/Passes/MSAA_4x_RPI_Pipeline.pass
@@ -10,7 +10,7 @@
             "Slots": [
                 {
                     "Name": "SwapChainOutput",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 }
             ],
             "PassRequests": [

--- a/Passes/MSAA_8x_RPI_Pipeline.pass
+++ b/Passes/MSAA_8x_RPI_Pipeline.pass
@@ -10,7 +10,7 @@
             "Slots": [
                 {
                     "Name": "SwapChainOutput",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 }
             ],
             "PassRequests": [

--- a/Passes/MSAA_RPI_Pipeline_Core.pass
+++ b/Passes/MSAA_RPI_Pipeline_Core.pass
@@ -13,7 +13,7 @@
                 },
                 {
                     "Name": "SwapChainOutput",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 }
             ],
             "PassRequests": [

--- a/Passes/No_MSAA_RPI_Pipeline.pass
+++ b/Passes/No_MSAA_RPI_Pipeline.pass
@@ -9,7 +9,7 @@
             "Slots": [
                 {
                     "Name": "SwapChainOutput",
-                    "SlotType": "Output"
+                    "SlotType": "InputOutput"
                 }
             ],
             "PassRequests": [


### PR DESCRIPTION
Fixed MSAA and Checkboard pipelines. Swap chain attachment needed to be InputOutput for passes to use it as a size and format source.