### PR TITLE
Updating xshot for cullingandlod

### DIFF
--- a/Scripts/ExpectedScreenshots/CullingAndLod/screenshot_1.ppm
+++ b/Scripts/ExpectedScreenshots/CullingAndLod/screenshot_1.ppm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2384eccf7d3d139e5467b7f7c01c42671fbea85f8785fb8dbeeea39e95e133e
+oid sha256:8ea3411921b0a10fa812a152382709995bd5ae4265f899f4c90a8bc10444ac76
 size 750015


### PR DESCRIPTION
Updating the screenshot for culling and lod sample. Slight lighting change due to changing from spots to disk.

ASV test now passes for both Vulkan and D3D12

https://jira.agscollab.com/browse/ATOM-15213
