### PR TITLE
[ATOM-15483] Shader Build Pipeline: Fix "include" file discovery in

### DIFF
--- a/Config/shader_global_build_options.json
+++ b/Config/shader_global_build_options.json
@@ -6,7 +6,7 @@
         "PreprocessorOptions" : {
             "predefinedMacros": ["AZSL=17"],
             "projectIncludePaths": [
-                "AtomSampleViewer",
+                // The root of the current game project is always the first include path.
                 // These include paths are already part of the automatic include folders list.
                 // By specifying them here, we are boosting the priority of these folders above all the other automatic include folders.
                 // (This is not necessary for the project, but just shown as a usage example.)

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -1,0 +1,52 @@
+#
+# All or portions of this file Copyright (c) Amazon.com, Inc. or its affiliates or
+# its licensors.
+#
+# For complete copyright and license terms please see the LICENSE at the root of this
+# distribution (the "License"). All use of this software is governed by the License,
+# or, if provided, by the license below or the license accompanying this file. Do not
+# remove or modify any license notices. This file is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#
+# This file is copied during engine registration. Edits to this file will be lost next
+# time a registration happens.
+
+include_guard()
+
+# Read the engine name from the project_json file
+file(READ ${CMAKE_CURRENT_LIST_DIR}/project.json project_json)
+string(JSON LY_ENGINE_NAME_TO_USE ERROR_VARIABLE json_error GET ${project_json} engine)
+if(json_error)
+    message(FATAL_ERROR "Unable to read key 'engine' from 'project.json', error: ${json_error}")
+endif()
+
+# Read the list of paths from ~.o3de/o3de_manifest.json
+file(TO_CMAKE_PATH "$ENV{USERPROFILE}" home_directory) # Windows
+if((NOT home_directory) OR (NOT EXISTS ${home_directory}))
+    file(TO_CMAKE_PATH "$ENV{HOME}" home_directory)# Unix
+endif()
+
+if (NOT home_directory)
+    message(FATAL_ERROR "Cannot find user home directory, the o3de manifest cannot be found")
+endif()
+# Set manifest path to path in the user home directory
+set(manifest_path ${home_directory}/.o3de/o3de_manifest.json)
+
+if(EXISTS ${manifest_path})
+    file(READ ${manifest_path} manifest_json)
+    string(JSON engines_count ERROR_VARIABLE json_error LENGTH ${manifest_json} engines)
+    if(json_error)
+        message(FATAL_ERROR "Unable to read key 'engines' from '${manifest_path}', error: ${json_error}")
+    endif()
+
+    math(EXPR engines_count "${engines_count}-1")
+    foreach(engine_path_index RANGE ${engines_count})
+        string(JSON engine_path ERROR_VARIABLE json_error GET ${manifest_json} engines ${engine_path_index})
+        if(${json_error})
+            message(FATAL_ERROR "Unable to read engines[${engine_path_index}] '${manifest_path}', error: ${json_error}")
+        endif()
+        if(engine_path)
+            list(APPEND CMAKE_MODULE_PATH "${engine_path}/cmake")
+        endif()
+    endforeach()
+endif()

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -34,7 +34,7 @@ class TestAutomationMainSuite:
     def test_AutomatedReviewTestSuite(self, request, workspace, launcher_platform, rhi, atomsampleviewer_log_monitor):
         # Script call setup.
         test_script = '_AutomatedReviewTestSuite_.bv.lua'
-        test_script_path = os.path.join(workspace.paths.engine_root(), 'AtomSampleViewer', 'Scripts', test_script)
+        test_script_path = os.path.join(workspace.paths.project(), 'Scripts', test_script)
         if not os.path.exists(test_script_path):
             raise AtomSampleViewerException(f'Test script does not exist in path: {test_script_path}')
         cmd = os.path.join(workspace.paths.build_directory(),
@@ -57,7 +57,7 @@ class TestAutomationMainSuite:
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=200)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:
             expected_screenshots_path = os.path.join(
-                workspace.paths.engine_root(), "AtomSampleViewer", "Scripts", "ExpectedScreenshots")
+                workspace.paths.project(), "Scripts", "ExpectedScreenshots")
             test_screenshots_path = os.path.join(
                 workspace.paths.project(), "user", "Scripts", "Screenshots")
             raise AtomSampleViewerException(


### PR DESCRIPTION
        <Game>/Config/shader_global_build_options.json

Imported fix by @lumberyard-employee-dm from main branch.

Specifying the game project root dir in Config/shader_global_build_options.json
is not needed anymore because the engine adds it by default.

Signed-off-by: garrieta <garrieta@amazon.com>