### PR TITLE
Update TextureAtlas gem dependency for tools

### DIFF
--- a/Gem/Code/tool_dependencies.cmake
+++ b/Gem/Code/tool_dependencies.cmake
@@ -12,7 +12,7 @@
 # Extracted from Editor.xml
 set(GEM_DEPENDENCIES
     Gem::Maestro.Editor
-    Gem::TextureAtlas
+    Gem::TextureAtlas.Editor
     Gem::LmbrCentral.Editor
     Gem::LyShine.Editor
     Gem::SceneProcessing.Editor


### PR DESCRIPTION
The TextureAtlas gem now has an Editor target, so updated tools dependency to reflect that.
(Alternately, TextureAtlas and LyShine can be removed from the dependencies list if they're not being used for this project.)