### PR TITLE
Fixing bad syntax error in shadowtest.bv.lua

### DIFF
--- a/Scripts/ShadowTest.bv.lua
+++ b/Scripts/ShadowTest.bv.lua
@@ -34,7 +34,7 @@ function DisablePositionalLights()
     IdleFrames(1)
     SetImguiValue('Blue', true)
     SetImguiValue('Intensity##Positional', 0.0)
-endif
+end
 
 function TestDirectionalLight()
 


### PR DESCRIPTION
Chris Santora noticed this bad syntax error in one of my last PRs.

Ran the sample test ok
AP compiles this fine now

NOJIRA