### PR TITLE
Fix warning that local variable shadows function param

### DIFF
--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -558,8 +558,8 @@ namespace AtomSampleViewer
             mipAsset.BlockUntilLoadComplete();
             imageMipAssets.emplace_back(mipAsset);
 
-            const RHI::ImageSubresourceLayout layout = mipAsset->GetSubImageLayout(0);
-            imageSubresourceLayouts.emplace_back(layout);
+            const RHI::ImageSubresourceLayout subImageLayout = mipAsset->GetSubImageLayout(0);
+            imageSubresourceLayouts.emplace_back(subImageLayout);
         }
 
         // Validate the compatibility of the image sub resources


### PR DESCRIPTION
Local variable called "layout" is shadowing the function parameter also called "layout".

Giving the local variable a name to suppress the warning

NOJIRA