### PR TITLE
fixed LYTT call for path to project to handle project centric pathing

### DIFF
--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
@@ -34,7 +34,7 @@ class TestAutomationWarpSuite:
     def test_AutomatedReviewWARPTestSuite(self, request, workspace, launcher_platform, rhi, project, atomsampleviewer_log_monitor):
         # Script call setup.
         test_script = '_AutomatedReviewWARPTestSuite_.bv.lua'
-        test_script_path = os.path.join(workspace.paths.engine_root(), project, 'Scripts', test_script)
+        test_script_path = os.path.join(workspace.paths.project(), 'Scripts', test_script)
         if not os.path.exists(test_script_path):
             raise AtomSampleViewerException(f'Test script does not exist in path: {test_script_path}')
         cmd = os.path.join(workspace.paths.build_directory(),


### PR DESCRIPTION
this fixes an LYTT call for path to the script so that projects can exist outside of the engine.
ran tests locally for WARP
.\scripts\ctest\ctest_entrypoint.cmd --build-path atom_main --suite main --ctest-executable "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe" --config profile --tests-regex "AtomSampleViewer::PythonWARPTests" --generate-xml
Starting 'main' suite: The default set of tests, covers most of all testing.
Executing CTest None time(s) with command:
  C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe --build-config profile --output-on-failure --parallel 8 --no-tests=error --label-exclude ^(SUITE_smoke|SUITE_periodic|SUITE_benchmark|SUITE_sandbox)$ -T Test --tests-regex AtomSampleViewer::PythonWARPTests
in working directory:
  atom_main

Cannot find file: C:/workspace/o3de/atom_main/DartConfiguration.tcl
   Site:
   Build name: (empty)
Cannot find file: C:/workspace/o3de/atom_main/DartConfiguration.tcl
Test project C:/workspace/o3de/atom_main
    Start 47: AtomSampleViewer::PythonWARPTests.main::TEST_RUN
1/1 Test #47: AtomSampleViewer::PythonWARPTests.main::TEST_RUN ...   Passed  216.42 sec

100% tests passed, 0 tests failed out of 1