### PR TITLE
[ATOM-15783] Ressurecting the old sphere used in area light tests to fix the test script.

### DIFF
--- a/Gem/Code/Source/AreaLightExampleComponent.h
+++ b/Gem/Code/Source/AreaLightExampleComponent.h
@@ -83,7 +83,7 @@ namespace AtomSampleViewer
         struct Configuration
         {
             LightType m_lightType = Point;
-            AZStd::string m_modelAssetPath = "models/sphere.azmodel";
+            AZStd::string m_modelAssetPath = "objects/test/area_light_test_sphere.azmodel";
             uint32_t m_count = 1;
 
             float m_intensity = 30.0f;

--- a/Objects/test/area_light_test_sphere.fbx
+++ b/Objects/test/area_light_test_sphere.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a476e99b55cf2a76fef6775c5a57dad29f8ffcb942c625bab04c89051a72a560
+size 62626


### PR DESCRIPTION
Moving the sphere fbx used in area light tests to ASV, and naming it specifically for area light tests to hopefully avoid this problem in the future.