### PR TITLE
ATOM-13723 BaseViewer DynamicMaterialTest Crash With Many Objects on dx12

### DIFF
--- a/Gem/Code/Source/Platform/Windows/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/EntityLatticeTestComponent_Traits_Platform.h
@@ -13,4 +13,4 @@
 #define ENTITY_LATTICE_TEST_COMPONENT_WIDTH                     5
 #define ENTITY_LATTICE_TEST_COMPONENT_HEIGHT                    5
 #define ENTITY_LATTICE_TEST_COMPONENT_DEPTH                     5
-#define ENTITY_LATTEST_TEST_COMPONENT_MAX                       20
+#define ENTITY_LATTEST_TEST_COMPONENT_MAX                       10


### PR DESCRIPTION
Reduce the max number from 20 to 10 in each dimension.
Based on the discussion here:
https://github.com/aws-lumberyard/o3de/pull/1257