### PR TITLE
fix and overlooked workspace.paths.engine() to .project()

### DIFF
--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
@@ -57,7 +57,7 @@ class TestAutomationWarpSuite:
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=200)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:
             expected_screenshots_path = os.path.join(
-                workspace.paths.engine_root(), "AtomSampleViewer", "Scripts", "ExpectedScreenshots")
+                workspace.paths.project(), "Scripts", "ExpectedScreenshots")
             test_screenshots_path = os.path.join(
                 workspace.paths.project(), "user", "Scripts", "Screenshots")
             raise AtomSampleViewerException(


### PR DESCRIPTION
fix an overlooked exception handler path for workspace.paths.project() so that we correctly log