### PR TITLE
Remove duplicate registration of ScriptAsset

### DIFF
--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -105,16 +105,6 @@ namespace AtomSampleViewer
         ReadTimeoutShutdown();
 
         WriteStartupLog();
-
-        // Register .luac assets
-        if (AZ::Data::AssetCatalogRequests* assetCatalog = AZ::Data::AssetCatalogRequestBus::FindFirstHandler())
-        {
-            assetCatalog->EnableCatalogForAsset(AZ::AzTypeInfo<AZ::ScriptAsset>::Uuid());
-        }
-        else
-        {
-            AZ_Assert(false, "AssetCatalogRequestBus handler not found.");
-        }
     }
 
     void AtomSampleViewerApplication::OnSampleManagerActivated()


### PR DESCRIPTION
Note:
- ScriptAssets are already registered in LmbrCentral.cpp line 367
- ASV runs without errors showing on the terminal