### PR TITLE
Fix frame visualizer not closing

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1002,7 +1002,7 @@ namespace AtomSampleViewer
     {
         AZ::RHI::Device* rhiDevice = Utils::GetRHIDevice().get();
         m_imguiFrameGraphVisualizer.Init(rhiDevice);
-        m_imguiFrameGraphVisualizer.Draw(m_showFrameGraphVisualizer);
+        m_imguiFrameGraphVisualizer.Draw(&m_showFrameGraphVisualizer);
     }
 
     void SampleComponentManager::ShowCpuProfilerWindow()


### PR DESCRIPTION
Fixes [issue](https://jira.agscollab.com/browse/ATOM-15682) with frame visualizer not closing.

Depends on engine-centric PR [link](https://github.com/aws-lumberyard/o3de/pull/1383) to function correctly.