### PR TITLE
Update engine refspec/branch to stabilization/2106

### DIFF
--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -20,8 +20,8 @@ PROJECT_REPOSITORY_NAME = 'o3de-atom-sampleviewer'
 PROJECT_ORGANIZATION_NAME = 'aws-lumberyard'
 ENGINE_REPOSITORY_NAME = 'o3de'
 ENGINE_ORGANIZATION_NAME = 'aws-lumberyard'
-ENGINE_BRANCH_DEFAULT = 'main'
-ENGINE_REFSPEC_DEFAULT = 'origin/main'
+ENGINE_BRANCH_DEFAULT = 'stabilization/2106'
+ENGINE_REFSPEC_DEFAULT = 'origin/stabilization/2106'
 
 def pipelineProperties = []
 


### PR DESCRIPTION
Jenkinsfile in the stabilization/2106 was pointing to the older refspec (main). This change updates this and points to stabilization/2106 in the meantime, at least until 6/25 at @wintermute-motherbrain request. 