### PR TITLE
ATOM-15066 Lighting Too Bright On Some ASV Screenshot Tests

### DIFF
--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -23,6 +23,8 @@
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 
+#include <Automation/ScriptRunnerBus.h>
+
 #include <AzCore/Math/MatrixUtils.h>
 
 #include <AzCore/Component/Entity.h>
@@ -39,6 +41,15 @@
 
 namespace AtomSampleViewer
 {
+    using namespace AZ;
+
+    namespace
+    {
+        const char* BunnyModelFilePath = "objects/bunny.azmodel";
+        const char* ShaderBallModelFilePath = "objects/shaderball_simple.azmodel";
+        const char* CubeModelFilePath = "testdata/objects/cube/cube.azmodel";
+    };
+
     //////////////////////////////////////////////////////////////////////////
     // SecondWindowedScene
 
@@ -154,8 +165,11 @@ namespace AtomSampleViewer
         const auto LoadMesh = [this](const char* modelPath) -> Render::MeshFeatureProcessorInterface::MeshHandle
         {
             AZ_Assert(m_meshFeatureProcessor, "Cannot find mesh feature processor on scene");
-            auto meshAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(modelPath, RPI::AssetUtils::TraceLevel::Assert);
-            Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = m_meshFeatureProcessor->AcquireMesh(meshAsset);
+            auto meshAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(modelPath, RPI::AssetUtils::TraceLevel::Assert);            
+            auto materialAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath,
+                RPI::AssetUtils::TraceLevel::Assert);
+            auto material = AZ::RPI::Material::FindOrCreate(materialAsset);
+            Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = m_meshFeatureProcessor->AcquireMesh(meshAsset, material);
 
             return meshHandle;
         };
@@ -164,7 +178,7 @@ namespace AtomSampleViewer
         {
             for (uint32_t i = 0u; i < ShaderBallCount; i++)
             {
-                m_shaderBallMeshHandles.push_back(LoadMesh("objects/shaderball_simple.azmodel"));
+                m_shaderBallMeshHandles.push_back(LoadMesh(ShaderBallModelFilePath));
                 auto updateShaderBallTransform = [this, i](Data::Instance<RPI::Model> model)
                 {
                     const Aabb& aabb = model->GetAabb();
@@ -192,7 +206,7 @@ namespace AtomSampleViewer
             const Vector3 nonUniformScale{ 24.f, 24.f, 1.0f };
             const Vector3 translation{ 0.f, 0.f, 0.0f };
             const auto transform = Transform::CreateTranslation(translation);
-            m_floorMeshHandle = LoadMesh("testdata/objects/cube/cube.azmodel");
+            m_floorMeshHandle = LoadMesh(CubeModelFilePath);
             m_meshFeatureProcessor->SetTransform(m_floorMeshHandle, transform, nonUniformScale);
         }
 
@@ -427,15 +441,37 @@ namespace AtomSampleViewer
         using namespace AZ;
 
         // Setup primary camera controls
-        Debug::CameraControllerRequestBus::Event(GetCameraEntityId(), &Debug::CameraControllerRequestBus::Events::Enable,
-            azrtti_typeid<Debug::NoClipControllerComponent>());
+        Debug::CameraControllerRequestBus::Event(
+            GetCameraEntityId(), &Debug::CameraControllerRequestBus::Events::Enable, azrtti_typeid<Debug::NoClipControllerComponent>());
+        
+        m_defaultIbl.PreloadAssets();
 
+        // preload assets
+        AZStd::vector<AssetCollectionAsyncLoader::AssetToLoadInfo> assetList = {
+            { DefaultPbrMaterialPath, azrtti_typeid<RPI::MaterialAsset>() },
+            { BunnyModelFilePath, azrtti_typeid<RPI::ModelAsset>() },
+            { CubeModelFilePath, azrtti_typeid<RPI::ModelAsset>() },
+            { ShaderBallModelFilePath, azrtti_typeid<RPI::ModelAsset>() }
+        };
+
+        PreloadAssets(assetList);
+
+        ScriptRunnerRequestBus::Broadcast(&ScriptRunnerRequests::PauseScriptWithTimeout, 120.0f);
+    }
+        
+    void MultiSceneExampleComponent::OnAllAssetsReadyActivate()
+    {
+        using namespace AZ;
         RPI::ScenePtr scene = RPI::RPISystemInterface::Get()->GetDefaultScene();
 
         // Setup Main Mesh Entity
         {
-            auto bunnyAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>("objects/bunny.azmodel", RPI::AssetUtils::TraceLevel::Assert);
-            m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(bunnyAsset);
+            auto materialAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath,
+                RPI::AssetUtils::TraceLevel::Assert);
+            auto material = AZ::RPI::Material::FindOrCreate(materialAsset);
+            auto bunnyAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::ModelAsset>(BunnyModelFilePath,
+                RPI::AssetUtils::TraceLevel::Assert);
+            m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(bunnyAsset, material);
             GetMeshFeatureProcessor()->SetTransform(m_meshHandle, Transform::CreateRotationZ(Constants::Pi));
         }
 
@@ -448,7 +484,8 @@ namespace AtomSampleViewer
         {
             OpenSecondSceneWindow();
         }
-
+        
+        ScriptRunnerRequestBus::Broadcast(&ScriptRunnerRequests::ResumeScript);
         TickBus::Handler::BusConnect();
     }
 

--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -131,6 +131,9 @@ namespace AtomSampleViewer
         // AZ::TickBus::Handler overrides ...
         void OnTick(float deltaTime, AZ::ScriptTimePoint timePoint) override;
 
+        // CommonSampleComponentBase overrides ...
+        void OnAllAssetsReadyActivate() override;
+
         void OpenSecondSceneWindow();
 
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;

--- a/Scripts/ExpectedScreenshots/MultiScene/Start_MultiScene1.png
+++ b/Scripts/ExpectedScreenshots/MultiScene/Start_MultiScene1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bbb06e9e5933540d296383bc1665729888c346c4a97319667765bdb64f1b8c68
-size 45119
+oid sha256:81f7bd730608ab3e2203d0f2386183b727bbdb1d39aaf8f5c92b20ed7ee534e0
+size 57307

--- a/Scripts/ExpectedScreenshots/MultiScene/Start_MultiScene2.png
+++ b/Scripts/ExpectedScreenshots/MultiScene/Start_MultiScene2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c937bf596b2ac02ba374de04fa04e99387916baa8a3637cb4fccb87e9409b72
-size 255992
+oid sha256:e78dc8c7a735985ce9ef002d9044f6e4b2df5acbb4483a15a68fa0d9b5413f51
+size 223658


### PR DESCRIPTION
Switched to use default PBR material for meshes instread of using fbx's own materials so the rendering won't be effected by the materials exported by FBX builder