### PR TITLE
Removing unneeded m_isSkinnedMeshWithMotion from mesh descriptor.

### DIFF
--- a/Gem/Code/Source/DynamicMaterialTestComponent.cpp
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.cpp
@@ -99,7 +99,6 @@ namespace AtomSampleViewer
 
         Render::MeshHandleDescriptor meshDescriptor;
         meshDescriptor.m_modelAsset = m_modelAsset;
-        meshDescriptor.m_isSkinnedMeshWithMotion = false;
         meshDescriptor.m_isRayTracingEnabled = false;
         auto meshHandle = GetMeshFeatureProcessor()->AcquireMesh(meshDescriptor, materialMap);
         GetMeshFeatureProcessor()->SetTransform(meshHandle, transform);

--- a/Gem/Code/Source/SkinnedMeshContainer.cpp
+++ b/Gem/Code/Source/SkinnedMeshContainer.cpp
@@ -180,7 +180,7 @@ namespace AtomSampleViewer
             {
                 AZ::Render::MeshHandleDescriptor meshDescriptor;
                 meshDescriptor.m_modelAsset = renderData.m_skinnedMeshInstance->m_model->GetModelAsset();
-                meshDescriptor.m_isSkinnedMeshWithMotion = true;
+                meshDescriptor.m_isRayTracingEnabled = false;
                 renderData.m_meshHandle =
                     AZStd::make_shared<AZ::Render::MeshFeatureProcessorInterface::MeshHandle>(m_meshFeatureProcessor->AcquireMesh(
                         meshDescriptor, materialMap));


### PR DESCRIPTION
See https://github.com/aws-lumberyard/o3de/pull/1491