### PR TITLE
[ATOM-15868] Modify CullingAndLodPerf script to collect benchmark metadata.

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -22,7 +22,7 @@
 #include <Automation/ImageComparisonConfig.h>
 #include <Utils/ImGuiAssetBrowser.h>
 
-namespace AZ 
+namespace AZ
 {
     class ScriptContext;
     class ScriptDataContext;
@@ -59,7 +59,7 @@ namespace AtomSampleViewer
 
         void Activate();
         void Deactivate();
-        
+
         void SetCameraEntity(AZ::Entity* cameraEntity);
 
         void TickScript(float deltaTime);
@@ -68,7 +68,7 @@ namespace AtomSampleViewer
         void OpenScriptRunnerDialog();
 
         void RunMainTestSuite(const AZStd::string& suiteFilePath, bool exitOnTestEnd, int randomSeed);
-        
+
     private:
 
         void ShowScriptRunnerDialog();
@@ -140,6 +140,7 @@ namespace AtomSampleViewer
         static void Script_CapturePassTimestamp(AZ::ScriptDataContext& dc);
         static void Script_CapturePassPipelineStatistics(AZ::ScriptDataContext& dc);
         static void Script_CaptureCpuProfilingStatistics(AZ::ScriptDataContext& dc);
+        static void Script_CaptureBenchmarkMetadata(AZ::ScriptDataContext& dc);
 
         // Camera...
         static void Script_ArcBallCameraController_SetCenter(AZ::Vector3 center);
@@ -207,6 +208,7 @@ namespace AtomSampleViewer
         void OnCaptureQueryTimestampFinished(bool result, const AZStd::string& info) override;
         void OnCaptureQueryPipelineStatisticsFinished(bool result, const AZStd::string& info) override;
         void OnCaptureCpuProfilingStatisticsFinished(bool result, const AZStd::string& info) override;
+        void OnCaptureBenchmarkMetadataFinished(bool result, const AZStd::string& info) override;
 
         void AbortScripts(const AZStd::string& reason);
 

--- a/Scripts/CullingandAndLodPerf.bv.lua
+++ b/Scripts/CullingandAndLodPerf.bv.lua
@@ -20,6 +20,7 @@ ResizeViewport(800, 800)
 IDLE_COUNT = 100
 FRAME_COUNT = 100
 
+CaptureBenchmarkMetadata('CullingAndLod', g_performanceStatsOutputFolder .. '/benchmark_metadata.json')
 Print('Idling for ' .. tostring(IDLE_COUNT) .. ' frames..')
 IdleFrames(IDLE_COUNT)
 Print('Capturing timestamps for ' .. tostring(FRAME_COUNT) .. ' frames...')


### PR DESCRIPTION
Sample JSON file `atomsampleviewer/user/scripts/performancestats/CullingAndLod/benchmark_metadata.json` output:

```json
{
    "Type": "JsonSerialization",
    "Version": 1,
    "ClassName": "BenchmarkMetadataSerializer",
    "ClassData": {
        "benchmarkName": "CullingAndLod",
        "gpuInfo": {
            "description": "NVIDIA GeForce RTX 3070 Laptop GPU",
            "driverVersion": 1935081472
        }
    }
}
```

`driverVersion` will hopefully be decrypted into a human-readable format in the future.

Needs to be merged after aws-lumberyard/o3de#1597