### PR TITLE
Update screenshot for multiscene sample

### DIFF
--- a/Scripts/ExpectedScreenshots/MultiScene/Start_MultiScene2.png
+++ b/Scripts/ExpectedScreenshots/MultiScene/Start_MultiScene2.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e78dc8c7a735985ce9ef002d9044f6e4b2df5acbb4483a15a68fa0d9b5413f51
-size 223658
+oid sha256:7be4c648c3280baf7e146b39968aa846dc72e3553cd9d861883c2f99e9669834
+size 225863


### PR DESCRIPTION
Notes
* Something about scene illumination has changed. Updating the screenshot seems like the best approach since the change isn't crucial to the functionality of the sample itself.
* Previous screenshot comparison:
![image](https://user-images.githubusercontent.com/43485729/123494184-cd0e1500-d5d3-11eb-8e81-002ab5176ea2.png)


Testing
* ASV fullsuite
![image](https://user-images.githubusercontent.com/43485729/123493447-5243fa80-d5d1-11eb-9d8c-e5b655e327d6.png)
* msa_rpi_test failure is a known issue with an upcoming fix.