### PR TITLE
Use project registration for AR to fix test paths

### DIFF
--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -371,7 +371,7 @@ def Build(Map options, String platform, String type, String workspace) {
     }
     else {
         dir("${currentDir}") {
-            palSh("scripts/o3de${scriptExt} register -p ${workspace}/${PROJECT_REPOSITORY_NAME}", "Registering project ${PROJECT_REPOSITORY_NAME}") // o3de.sh will work under Windows in a Cygwin environment
+            palSh("scripts/o3de${scriptExt} register --project-path ${workspace}/${PROJECT_REPOSITORY_NAME}", "Registering project ${PROJECT_REPOSITORY_NAME}") // o3de.sh will work under Windows in a Cygwin environment
         }
     }
     def command = "${pathToEngine}${options.BUILD_ENTRY_POINT} --platform ${platform} --type ${type}"


### PR DESCRIPTION
This will register the project paths prior to build, in order for automated tests to utilize its path in either project or engine centric builds

Note: This will currently fail AR due to failing tests unrelated to the path