### PR TITLE
Atom/scottmur/atom 15680

### DIFF
--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -46,7 +46,9 @@ class TestAutomationMainSuite:
         # Execute test.
         process_utils.safe_check_call(cmd, stderr=subprocess.STDOUT, encoding='UTF-8', shell=True)
         try:
-            unexpected_lines = ["Script: Screenshot check failed. Diff score"]  # "Diff score" ensures legit failure.
+            unexpected_lines = ["Script: Screenshot check failed. Diff score",  # "Diff score" ensures legit failure.
+                                "Trace::Error",
+                                "Trace::Assert"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=200)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -48,9 +48,10 @@ class TestAutomationMainSuite:
         try:
             unexpected_lines = ["Script: Screenshot check failed. Diff score",  # "Diff score" ensures legit failure.
                                 "Trace::Error",
-                                "Trace::Assert"]
+                                "Trace::Assert",
+                                "Traceback (most recent call last):"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
-                unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=200)
+                unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=240)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:
             expected_screenshots_path = os.path.join(
                 workspace.paths.project(), "Scripts", "ExpectedScreenshots")

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_periodic_suite.py
@@ -48,7 +48,8 @@ class TestAutomationPeriodicSuite:
         try:
             unexpected_lines = ["Script: Screenshot check failed. Diff score",  # "Diff score" ensures legit failure.
                                 "Trace::Error",
-                                "Trace::Assert"]
+                                "Trace::Assert",
+                                "Traceback (most recent call last):"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=600)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_periodic_suite.py
@@ -46,7 +46,9 @@ class TestAutomationPeriodicSuite:
         # Execute test.
         process_utils.safe_check_call(cmd, stderr=subprocess.STDOUT, encoding='UTF-8', shell=True)
         try:
-            unexpected_lines = ["Script: Screenshot check failed. Diff score"]  # "Diff score" ensures legit failure.
+            unexpected_lines = ["Script: Screenshot check failed. Diff score",  # "Diff score" ensures legit failure.
+                                "Trace::Error",
+                                "Trace::Assert"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=600)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
@@ -47,7 +47,9 @@ class TestAutomationWarpSuite:
         # Execute test.
         process_utils.safe_check_call(cmd, stderr=subprocess.STDOUT, encoding='UTF-8', shell=True)
         try:
-            unexpected_lines = ["Script: Screenshot check failed. Diff score"]  # "Diff score" ensures legit failure.
+            unexpected_lines = ["Script: Screenshot check failed. Diff score",  # "Diff score" ensures legit failure.
+                                "Trace::Error",
+                                "Trace::Assert"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=200)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
@@ -49,9 +49,10 @@ class TestAutomationWarpSuite:
         try:
             unexpected_lines = ["Script: Screenshot check failed. Diff score",  # "Diff score" ensures legit failure.
                                 "Trace::Error",
-                                "Trace::Assert"]
+                                "Trace::Assert",
+                                "Traceback (most recent call last):"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
-                unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=200)
+                unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=50)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:
             expected_screenshots_path = os.path.join(
                 workspace.paths.project(), "Scripts", "ExpectedScreenshots")

--- a/Standalone/PythonTests/CMakeLists.txt
+++ b/Standalone/PythonTests/CMakeLists.txt
@@ -16,7 +16,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         TEST_REQUIRES gpu
         TEST_SUITE main
         TEST_SERIAL
-        TIMEOUT 300
+        TIMEOUT 600
         RUNTIME_DEPENDENCIES
             AssetProcessor
             AssetProcessorBatch


### PR DESCRIPTION
adding trace lines to the unexpected lines list.

increasing some timeouts and reducing others so that runs do not timeout.

warp only runs dx12 once using warp software rasterizer so its game launcher timeout should be lower to wrap up testing in time for the cmakelists timeout
the main tests run both dx12 and vulkan so the game launcher timeout must be less than half the cmakelists timeout. I've chosen 240 for the game launcher and 600 for the cmakelists as this seems to handle execution time. this suite has some compare failures that are outside the scope of this change.

    Start 48: AtomSampleViewer::PythonWARPTests.main::TEST_RUN
1/1 Test #48: AtomSampleViewer::PythonWARPTests.main::TEST_RUN ...   Passed   73.59 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
FRAMEWORK_pytest    =  73.59 sec*proc (1 test)
SUITE_main          =  73.59 sec*proc (1 test)

Total Test time (real) =  73.95 sec

Test stability summary:
All tests were executed 5 times and passed 100% of the time.



|atomsampleviewer.log| 2021-07-09T15:08:27{0000000000003F98}[    Automation]     Script: Screenshot check failed. Failed to open 'C:/workspace/AtomSampleViewer/user/scripts/screenshotslocalbaseline/vulkan/PassTree/specularResolved.png'.
.bv.luac: asserts 0, general errors 0, screenshot failures 3
|atomsampleviewer.log| 2021-07-09T15:08:27{0000000000003F98}[AtomSampleViewer]     Test failure scripts/msaa_rpi_test.bv.luac: asserts 0, general errors 144, screenshot failures 0
|atomsampleviewer.log| 2021-07-09T15:08:27{0000000000003F98}[AtomSampleViewer]     Test failure scripts/shadowtest.bv.luac: asserts 0, general errors 0, screenshot failures 2
|atomsampleviewer.log| 2021-07-09T15:08:27{0000000000003F98}[AtomSampleViewer]     Test failure scripts/shadowedsponzatest.bv.luac: asserts 0, general errors 0, screenshot failures 1
|atomsampleviewer.log| 2021-07-09T15:08:27{0000000000003F98}[AtomSampleViewer]     4 tests failed
15:08:32 [    INFO] Finished log monitoring for '200' seconds, validating results.
expected_lines_not_found: []

0% tests passed, 1 tests failed out of 1

Label Time Summary:
FRAMEWORK_pytest           = 408.78 sec*proc (1 test)
SUITE_main                 = 408.78 sec*proc (1 test)
SUITE_main_REQUIRES_gpu    = 408.78 sec*proc (1 test)

Total Test time (real) = 412.96 sec
