### PR TITLE
Shorten copyright headers by splitting into 2 lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.cpp
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.cpp
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.h
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.h
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.cpp
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.cpp
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.h
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.h
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AreaLightExampleComponent.cpp
+++ b/Gem/Code/Source/AreaLightExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AreaLightExampleComponent.cpp
+++ b/Gem/Code/Source/AreaLightExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AreaLightExampleComponent.h
+++ b/Gem/Code/Source/AreaLightExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AreaLightExampleComponent.h
+++ b/Gem/Code/Source/AreaLightExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AssetLoadTestComponent.cpp
+++ b/Gem/Code/Source/AssetLoadTestComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AssetLoadTestComponent.cpp
+++ b/Gem/Code/Source/AssetLoadTestComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AssetLoadTestComponent.h
+++ b/Gem/Code/Source/AssetLoadTestComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AssetLoadTestComponent.h
+++ b/Gem/Code/Source/AssetLoadTestComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AtomSampleViewerModule.cpp
+++ b/Gem/Code/Source/AtomSampleViewerModule.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AtomSampleViewerModule.cpp
+++ b/Gem/Code/Source/AtomSampleViewerModule.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AtomSampleViewerOptions.h
+++ b/Gem/Code/Source/AtomSampleViewerOptions.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AtomSampleViewerOptions.h
+++ b/Gem/Code/Source/AtomSampleViewerOptions.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AtomSampleViewerRequestBus.h
+++ b/Gem/Code/Source/AtomSampleViewerRequestBus.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AtomSampleViewerRequestBus.h
+++ b/Gem/Code/Source/AtomSampleViewerRequestBus.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.h
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.h
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/AssetStatusTracker.cpp
+++ b/Gem/Code/Source/Automation/AssetStatusTracker.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/AssetStatusTracker.cpp
+++ b/Gem/Code/Source/Automation/AssetStatusTracker.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/AssetStatusTracker.h
+++ b/Gem/Code/Source/Automation/AssetStatusTracker.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/AssetStatusTracker.h
+++ b/Gem/Code/Source/Automation/AssetStatusTracker.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ImageComparisonConfig.cpp
+++ b/Gem/Code/Source/Automation/ImageComparisonConfig.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ImageComparisonConfig.cpp
+++ b/Gem/Code/Source/Automation/ImageComparisonConfig.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ImageComparisonConfig.h
+++ b/Gem/Code/Source/Automation/ImageComparisonConfig.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ImageComparisonConfig.h
+++ b/Gem/Code/Source/Automation/ImageComparisonConfig.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptRepeaterBus.h
+++ b/Gem/Code/Source/Automation/ScriptRepeaterBus.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptRepeaterBus.h
+++ b/Gem/Code/Source/Automation/ScriptRepeaterBus.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptRunnerBus.h
+++ b/Gem/Code/Source/Automation/ScriptRunnerBus.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptRunnerBus.h
+++ b/Gem/Code/Source/Automation/ScriptRunnerBus.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptableImGui.cpp
+++ b/Gem/Code/Source/Automation/ScriptableImGui.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptableImGui.cpp
+++ b/Gem/Code/Source/Automation/ScriptableImGui.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Automation/ScriptableImGui.h
+++ b/Gem/Code/Source/Automation/ScriptableImGui.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Automation/ScriptableImGui.h
+++ b/Gem/Code/Source/Automation/ScriptableImGui.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AuxGeomExampleComponent.cpp
+++ b/Gem/Code/Source/AuxGeomExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AuxGeomExampleComponent.cpp
+++ b/Gem/Code/Source/AuxGeomExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AuxGeomExampleComponent.h
+++ b/Gem/Code/Source/AuxGeomExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AuxGeomExampleComponent.h
+++ b/Gem/Code/Source/AuxGeomExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AuxGeomSharedDrawFunctions.cpp
+++ b/Gem/Code/Source/AuxGeomSharedDrawFunctions.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AuxGeomSharedDrawFunctions.cpp
+++ b/Gem/Code/Source/AuxGeomSharedDrawFunctions.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/AuxGeomSharedDrawFunctions.h
+++ b/Gem/Code/Source/AuxGeomSharedDrawFunctions.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/AuxGeomSharedDrawFunctions.h
+++ b/Gem/Code/Source/AuxGeomSharedDrawFunctions.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
+++ b/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
+++ b/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/BakedShaderVariantExampleComponent.h
+++ b/Gem/Code/Source/BakedShaderVariantExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/BakedShaderVariantExampleComponent.h
+++ b/Gem/Code/Source/BakedShaderVariantExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/BistroBenchmarkComponent.cpp
+++ b/Gem/Code/Source/BistroBenchmarkComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/BistroBenchmarkComponent.cpp
+++ b/Gem/Code/Source/BistroBenchmarkComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/BistroBenchmarkComponent.h
+++ b/Gem/Code/Source/BistroBenchmarkComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/BistroBenchmarkComponent.h
+++ b/Gem/Code/Source/BistroBenchmarkComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/BloomExampleComponent.h
+++ b/Gem/Code/Source/BloomExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/BloomExampleComponent.h
+++ b/Gem/Code/Source/BloomExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/CheckerboardExampleComponent.cpp
+++ b/Gem/Code/Source/CheckerboardExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/CheckerboardExampleComponent.cpp
+++ b/Gem/Code/Source/CheckerboardExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/CheckerboardExampleComponent.h
+++ b/Gem/Code/Source/CheckerboardExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/CheckerboardExampleComponent.h
+++ b/Gem/Code/Source/CheckerboardExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/CommonSampleComponentBase.cpp
+++ b/Gem/Code/Source/CommonSampleComponentBase.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/CommonSampleComponentBase.cpp
+++ b/Gem/Code/Source/CommonSampleComponentBase.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/CommonSampleComponentBase.h
+++ b/Gem/Code/Source/CommonSampleComponentBase.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/CommonSampleComponentBase.h
+++ b/Gem/Code/Source/CommonSampleComponentBase.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/CullingAndLodExampleComponent.cpp
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/CullingAndLodExampleComponent.cpp
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/CullingAndLodExampleComponent.h
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/CullingAndLodExampleComponent.h
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DecalContainer.cpp
+++ b/Gem/Code/Source/DecalContainer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DecalContainer.cpp
+++ b/Gem/Code/Source/DecalContainer.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DecalContainer.h
+++ b/Gem/Code/Source/DecalContainer.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DecalContainer.h
+++ b/Gem/Code/Source/DecalContainer.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DecalExampleComponent.cpp
+++ b/Gem/Code/Source/DecalExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DecalExampleComponent.cpp
+++ b/Gem/Code/Source/DecalExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DecalExampleComponent.h
+++ b/Gem/Code/Source/DecalExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DecalExampleComponent.h
+++ b/Gem/Code/Source/DecalExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DepthOfFieldExampleComponent.cpp
+++ b/Gem/Code/Source/DepthOfFieldExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DepthOfFieldExampleComponent.cpp
+++ b/Gem/Code/Source/DepthOfFieldExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DepthOfFieldExampleComponent.h
+++ b/Gem/Code/Source/DepthOfFieldExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DepthOfFieldExampleComponent.h
+++ b/Gem/Code/Source/DepthOfFieldExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DiffuseGIExampleComponent.cpp
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DiffuseGIExampleComponent.cpp
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DiffuseGIExampleComponent.h
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DiffuseGIExampleComponent.h
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DynamicDrawExampleComponent.cpp
+++ b/Gem/Code/Source/DynamicDrawExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DynamicDrawExampleComponent.cpp
+++ b/Gem/Code/Source/DynamicDrawExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DynamicDrawExampleComponent.h
+++ b/Gem/Code/Source/DynamicDrawExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DynamicDrawExampleComponent.h
+++ b/Gem/Code/Source/DynamicDrawExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DynamicMaterialTestComponent.cpp
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DynamicMaterialTestComponent.cpp
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/DynamicMaterialTestComponent.h
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/DynamicMaterialTestComponent.h
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/EntityLatticeTestComponent.cpp
+++ b/Gem/Code/Source/EntityLatticeTestComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/EntityLatticeTestComponent.cpp
+++ b/Gem/Code/Source/EntityLatticeTestComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/EntityLatticeTestComponent.h
+++ b/Gem/Code/Source/EntityLatticeTestComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/EntityLatticeTestComponent.h
+++ b/Gem/Code/Source/EntityLatticeTestComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/EntityUtilityFunctions.cpp
+++ b/Gem/Code/Source/EntityUtilityFunctions.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/EntityUtilityFunctions.cpp
+++ b/Gem/Code/Source/EntityUtilityFunctions.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/EntityUtilityFunctions.h
+++ b/Gem/Code/Source/EntityUtilityFunctions.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/EntityUtilityFunctions.h
+++ b/Gem/Code/Source/EntityUtilityFunctions.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ExampleComponentBus.h
+++ b/Gem/Code/Source/ExampleComponentBus.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ExampleComponentBus.h
+++ b/Gem/Code/Source/ExampleComponentBus.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ExposureExampleComponent.cpp
+++ b/Gem/Code/Source/ExposureExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ExposureExampleComponent.cpp
+++ b/Gem/Code/Source/ExposureExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ExposureExampleComponent.h
+++ b/Gem/Code/Source/ExposureExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ExposureExampleComponent.h
+++ b/Gem/Code/Source/ExposureExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/LightCullingExampleComponent.cpp
+++ b/Gem/Code/Source/LightCullingExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/LightCullingExampleComponent.cpp
+++ b/Gem/Code/Source/LightCullingExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/LightCullingExampleComponent.h
+++ b/Gem/Code/Source/LightCullingExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/LightCullingExampleComponent.h
+++ b/Gem/Code/Source/LightCullingExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MSAA_RPI_ExampleComponent.cpp
+++ b/Gem/Code/Source/MSAA_RPI_ExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MSAA_RPI_ExampleComponent.cpp
+++ b/Gem/Code/Source/MSAA_RPI_ExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MSAA_RPI_ExampleComponent.h
+++ b/Gem/Code/Source/MSAA_RPI_ExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MSAA_RPI_ExampleComponent.h
+++ b/Gem/Code/Source/MSAA_RPI_ExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MaterialHotReloadTestComponent.h
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MaterialHotReloadTestComponent.h
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MeshExampleComponent.cpp
+++ b/Gem/Code/Source/MeshExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MeshExampleComponent.cpp
+++ b/Gem/Code/Source/MeshExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MeshExampleComponent.h
+++ b/Gem/Code/Source/MeshExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MeshExampleComponent.h
+++ b/Gem/Code/Source/MeshExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.h
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.h
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.cpp
+++ b/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.cpp
+++ b/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.h
+++ b/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.h
+++ b/Gem/Code/Source/MultiViewSingleSceneAuxGeomExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.h
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.h
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/AtomSampleViewerOptions_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/AtomSampleViewerOptions_Android.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/AtomSampleViewerOptions_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/AtomSampleViewerOptions_Android.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/MultiThreadComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/MultiThreadComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/SSRExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/SSRExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/SampleComponentManager_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/SampleComponentManager_Android.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/SampleComponentManager_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/SampleComponentManager_Android.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/ScriptReporter_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/ScriptReporter_Android.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/ScriptReporter_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/ScriptReporter_Android.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/StreamingImageExampleComponent_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/StreamingImageExampleComponent_Android.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/StreamingImageExampleComponent_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/StreamingImageExampleComponent_Android.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Android/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/Utils_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/Utils_Android.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Android/Utils_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/Utils_Android.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Android/additional_android_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Android/additional_android_runtime_library.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Android/additional_android_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Android/additional_android_runtime_library.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Android/atomsampleviewer_android_files.cmake
+++ b/Gem/Code/Source/Platform/Android/atomsampleviewer_android_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Android/atomsampleviewer_android_files.cmake
+++ b/Gem/Code/Source/Platform/Android/atomsampleviewer_android_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Android/platform_android.cmake
+++ b/Gem/Code/Source/Platform/Android/platform_android.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Android/platform_android.cmake
+++ b/Gem/Code/Source/Platform/Android/platform_android.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Linux/AtomSampleViewerOptions_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/AtomSampleViewerOptions_Linux.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/AtomSampleViewerOptions_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/AtomSampleViewerOptions_Linux.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/MultiThreadComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/MultiThreadComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/SSRExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/SSRExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/SampleComponentManager_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/SampleComponentManager_Linux.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/SampleComponentManager_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/SampleComponentManager_Linux.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/ScriptReporter_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/ScriptReporter_Linux.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/ScriptReporter_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/ScriptReporter_Linux.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/StreamingImageExampleComponent_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/StreamingImageExampleComponent_Linux.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/StreamingImageExampleComponent_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/StreamingImageExampleComponent_Linux.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Linux/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Linux/additional_linux_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Linux/additional_linux_runtime_library.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Linux/additional_linux_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Linux/additional_linux_runtime_library.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Linux/atomsampleviewer_linux_files.cmake
+++ b/Gem/Code/Source/Platform/Linux/atomsampleviewer_linux_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Linux/atomsampleviewer_linux_files.cmake
+++ b/Gem/Code/Source/Platform/Linux/atomsampleviewer_linux_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Linux/platform_linux.cmake
+++ b/Gem/Code/Source/Platform/Linux/platform_linux.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Linux/platform_linux.cmake
+++ b/Gem/Code/Source/Platform/Linux/platform_linux.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Mac/AtomSampleViewerOptions_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/AtomSampleViewerOptions_Mac.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/AtomSampleViewerOptions_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/AtomSampleViewerOptions_Mac.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/MultiThreadComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/MultiThreadComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/SSRExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/SSRExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/SampleComponentManager_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/SampleComponentManager_Mac.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/SampleComponentManager_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/SampleComponentManager_Mac.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/ScriptReporter_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/ScriptReporter_Mac.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/ScriptReporter_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/ScriptReporter_Mac.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/StreamingImageExampleComponent_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/StreamingImageExampleComponent_Mac.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/StreamingImageExampleComponent_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/StreamingImageExampleComponent_Mac.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Mac/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/Utils_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/Utils_Mac.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Mac/Utils_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/Utils_Mac.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Mac/additional_mac_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Mac/additional_mac_runtime_library.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Mac/additional_mac_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Mac/additional_mac_runtime_library.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Mac/atomsampleviewer_mac_files.cmake
+++ b/Gem/Code/Source/Platform/Mac/atomsampleviewer_mac_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Mac/atomsampleviewer_mac_files.cmake
+++ b/Gem/Code/Source/Platform/Mac/atomsampleviewer_mac_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Mac/platform_mac.cmake
+++ b/Gem/Code/Source/Platform/Mac/platform_mac.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Mac/platform_mac.cmake
+++ b/Gem/Code/Source/Platform/Mac/platform_mac.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Windows/AtomSampleViewerOptions_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/AtomSampleViewerOptions_Windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/AtomSampleViewerOptions_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/AtomSampleViewerOptions_Windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/MultiThreadComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/MultiThreadComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/SSRExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/SSRExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/SampleComponentManager_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/SampleComponentManager_Windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/SampleComponentManager_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/SampleComponentManager_Windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/ScriptReporter_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/ScriptReporter_Windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/ScriptReporter_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/ScriptReporter_Windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/StreamingImageExampleComponent_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/StreamingImageExampleComponent_Windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/StreamingImageExampleComponent_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/StreamingImageExampleComponent_Windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/Windows/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/Utils_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/Utils_Windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/Windows/Utils_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/Utils_Windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/Windows/additional_windows_runtime_library.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Windows/atomsampleviewer_windows_files.cmake
+++ b/Gem/Code/Source/Platform/Windows/atomsampleviewer_windows_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Windows/atomsampleviewer_windows_files.cmake
+++ b/Gem/Code/Source/Platform/Windows/atomsampleviewer_windows_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/Windows/platform_windows.cmake
+++ b/Gem/Code/Source/Platform/Windows/platform_windows.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/Windows/platform_windows.cmake
+++ b/Gem/Code/Source/Platform/Windows/platform_windows.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/iOS/AtomSampleViewerOptions_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/AtomSampleViewerOptions_iOS.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/AtomSampleViewerOptions_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/AtomSampleViewerOptions_iOS.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/BakedShaderVariantExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/BakedShaderVariantExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/EntityLatticeTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/EntityLatticeTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/MultiThreadComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/MultiThreadComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/MultiThreadComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/SSRExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/SSRExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/SSRExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/SampleComponentManager_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/SampleComponentManager_iOS.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/SampleComponentManager_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/SampleComponentManager_iOS.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/SceneReloadSoakTestComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/SceneReloadSoakTestComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/ScriptReporter_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/ScriptReporter_iOS.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/ScriptReporter_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/ScriptReporter_iOS.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/StreamingImageExampleComponent_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/StreamingImageExampleComponent_iOS.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/StreamingImageExampleComponent_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/StreamingImageExampleComponent_iOS.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/TriangleConstantBufferExampleComponent_Traits_Platform.h
+++ b/Gem/Code/Source/Platform/iOS/TriangleConstantBufferExampleComponent_Traits_Platform.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/Utils_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/Utils_iOS.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Platform/iOS/Utils_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/Utils_iOS.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Platform/iOS/additional_ios_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/iOS/additional_ios_runtime_library.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/iOS/additional_ios_runtime_library.cmake
+++ b/Gem/Code/Source/Platform/iOS/additional_ios_runtime_library.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/iOS/atomsampleviewer_ios_files.cmake
+++ b/Gem/Code/Source/Platform/iOS/atomsampleviewer_ios_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/iOS/atomsampleviewer_ios_files.cmake
+++ b/Gem/Code/Source/Platform/iOS/atomsampleviewer_ios_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Platform/iOS/platform_ios.cmake
+++ b/Gem/Code/Source/Platform/iOS/platform_ios.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Source/Platform/iOS/platform_ios.cmake
+++ b/Gem/Code/Source/Platform/iOS/platform_ios.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/ProceduralSkinnedMesh.cpp
+++ b/Gem/Code/Source/ProceduralSkinnedMesh.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ProceduralSkinnedMesh.cpp
+++ b/Gem/Code/Source/ProceduralSkinnedMesh.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ProceduralSkinnedMesh.h
+++ b/Gem/Code/Source/ProceduralSkinnedMesh.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ProceduralSkinnedMesh.h
+++ b/Gem/Code/Source/ProceduralSkinnedMesh.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ProceduralSkinnedMeshUtils.cpp
+++ b/Gem/Code/Source/ProceduralSkinnedMeshUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ProceduralSkinnedMeshUtils.cpp
+++ b/Gem/Code/Source/ProceduralSkinnedMeshUtils.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ProceduralSkinnedMeshUtils.h
+++ b/Gem/Code/Source/ProceduralSkinnedMeshUtils.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ProceduralSkinnedMeshUtils.h
+++ b/Gem/Code/Source/ProceduralSkinnedMeshUtils.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/BasicRHIComponent.h
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/BasicRHIComponent.h
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/CopyQueueComponent.h
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/CopyQueueComponent.h
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MRTExampleComponent.h
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MRTExampleComponent.h
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.h
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.h
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MultiThreadComponent.h
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MultiThreadComponent.h
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.h
+++ b/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.h
+++ b/Gem/Code/Source/RHI/MultiViewportSwapchainComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.h
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.h
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/StencilExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/StencilExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/SwapchainExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SwapchainExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/SwapchainExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SwapchainExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/SwapchainExampleComponent.h
+++ b/Gem/Code/Source/RHI/SwapchainExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/SwapchainExampleComponent.h
+++ b/Gem/Code/Source/RHI/SwapchainExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TextureExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TextureExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.h
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.h
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/RootConstantsExampleComponent.h
+++ b/Gem/Code/Source/RootConstantsExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/RootConstantsExampleComponent.h
+++ b/Gem/Code/Source/RootConstantsExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SSRExampleComponent.cpp
+++ b/Gem/Code/Source/SSRExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SSRExampleComponent.cpp
+++ b/Gem/Code/Source/SSRExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SSRExampleComponent.h
+++ b/Gem/Code/Source/SSRExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SSRExampleComponent.h
+++ b/Gem/Code/Source/SSRExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SampleComponentConfig.cpp
+++ b/Gem/Code/Source/SampleComponentConfig.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SampleComponentConfig.cpp
+++ b/Gem/Code/Source/SampleComponentConfig.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SampleComponentConfig.h
+++ b/Gem/Code/Source/SampleComponentConfig.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SampleComponentConfig.h
+++ b/Gem/Code/Source/SampleComponentConfig.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SampleComponentManagerBus.h
+++ b/Gem/Code/Source/SampleComponentManagerBus.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SampleComponentManagerBus.h
+++ b/Gem/Code/Source/SampleComponentManagerBus.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SceneReloadSoakTestComponent.cpp
+++ b/Gem/Code/Source/SceneReloadSoakTestComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SceneReloadSoakTestComponent.cpp
+++ b/Gem/Code/Source/SceneReloadSoakTestComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SceneReloadSoakTestComponent.h
+++ b/Gem/Code/Source/SceneReloadSoakTestComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SceneReloadSoakTestComponent.h
+++ b/Gem/Code/Source/SceneReloadSoakTestComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ShadingExampleComponent.cpp
+++ b/Gem/Code/Source/ShadingExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ShadingExampleComponent.cpp
+++ b/Gem/Code/Source/ShadingExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ShadingExampleComponent.h
+++ b/Gem/Code/Source/ShadingExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ShadingExampleComponent.h
+++ b/Gem/Code/Source/ShadingExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ShadowExampleComponent.h
+++ b/Gem/Code/Source/ShadowExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ShadowExampleComponent.h
+++ b/Gem/Code/Source/ShadowExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.h
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.h
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SkinnedMeshContainer.cpp
+++ b/Gem/Code/Source/SkinnedMeshContainer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SkinnedMeshContainer.cpp
+++ b/Gem/Code/Source/SkinnedMeshContainer.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SkinnedMeshContainer.h
+++ b/Gem/Code/Source/SkinnedMeshContainer.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SkinnedMeshContainer.h
+++ b/Gem/Code/Source/SkinnedMeshContainer.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SkinnedMeshExampleComponent.cpp
+++ b/Gem/Code/Source/SkinnedMeshExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SkinnedMeshExampleComponent.cpp
+++ b/Gem/Code/Source/SkinnedMeshExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SkinnedMeshExampleComponent.h
+++ b/Gem/Code/Source/SkinnedMeshExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SkinnedMeshExampleComponent.h
+++ b/Gem/Code/Source/SkinnedMeshExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/SsaoExampleComponent.h
+++ b/Gem/Code/Source/SsaoExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/SsaoExampleComponent.h
+++ b/Gem/Code/Source/SsaoExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/StreamingImageExampleComponent.h
+++ b/Gem/Code/Source/StreamingImageExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/StreamingImageExampleComponent.h
+++ b/Gem/Code/Source/StreamingImageExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/TonemappingExampleComponent.h
+++ b/Gem/Code/Source/TonemappingExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/TonemappingExampleComponent.h
+++ b/Gem/Code/Source/TonemappingExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/TransparencyExampleComponent.cpp
+++ b/Gem/Code/Source/TransparencyExampleComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/TransparencyExampleComponent.cpp
+++ b/Gem/Code/Source/TransparencyExampleComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/TransparencyExampleComponent.h
+++ b/Gem/Code/Source/TransparencyExampleComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/TransparencyExampleComponent.h
+++ b/Gem/Code/Source/TransparencyExampleComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/FileIOErrorHandler.cpp
+++ b/Gem/Code/Source/Utils/FileIOErrorHandler.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/FileIOErrorHandler.cpp
+++ b/Gem/Code/Source/Utils/FileIOErrorHandler.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/FileIOErrorHandler.h
+++ b/Gem/Code/Source/Utils/FileIOErrorHandler.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/FileIOErrorHandler.h
+++ b/Gem/Code/Source/Utils/FileIOErrorHandler.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiAssetBrowser.cpp
+++ b/Gem/Code/Source/Utils/ImGuiAssetBrowser.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiAssetBrowser.cpp
+++ b/Gem/Code/Source/Utils/ImGuiAssetBrowser.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiAssetBrowser.h
+++ b/Gem/Code/Source/Utils/ImGuiAssetBrowser.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiAssetBrowser.h
+++ b/Gem/Code/Source/Utils/ImGuiAssetBrowser.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiHistogramQueue.cpp
+++ b/Gem/Code/Source/Utils/ImGuiHistogramQueue.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiHistogramQueue.cpp
+++ b/Gem/Code/Source/Utils/ImGuiHistogramQueue.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiHistogramQueue.h
+++ b/Gem/Code/Source/Utils/ImGuiHistogramQueue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiHistogramQueue.h
+++ b/Gem/Code/Source/Utils/ImGuiHistogramQueue.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiMaterialDetails.cpp
+++ b/Gem/Code/Source/Utils/ImGuiMaterialDetails.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiMaterialDetails.cpp
+++ b/Gem/Code/Source/Utils/ImGuiMaterialDetails.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiMaterialDetails.h
+++ b/Gem/Code/Source/Utils/ImGuiMaterialDetails.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiMaterialDetails.h
+++ b/Gem/Code/Source/Utils/ImGuiMaterialDetails.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiMessageBox.cpp
+++ b/Gem/Code/Source/Utils/ImGuiMessageBox.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiMessageBox.cpp
+++ b/Gem/Code/Source/Utils/ImGuiMessageBox.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiMessageBox.h
+++ b/Gem/Code/Source/Utils/ImGuiMessageBox.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiMessageBox.h
+++ b/Gem/Code/Source/Utils/ImGuiMessageBox.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiProgressList.cpp
+++ b/Gem/Code/Source/Utils/ImGuiProgressList.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiProgressList.cpp
+++ b/Gem/Code/Source/Utils/ImGuiProgressList.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiProgressList.h
+++ b/Gem/Code/Source/Utils/ImGuiProgressList.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiProgressList.h
+++ b/Gem/Code/Source/Utils/ImGuiProgressList.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiSaveFilePath.cpp
+++ b/Gem/Code/Source/Utils/ImGuiSaveFilePath.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiSaveFilePath.cpp
+++ b/Gem/Code/Source/Utils/ImGuiSaveFilePath.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiSaveFilePath.h
+++ b/Gem/Code/Source/Utils/ImGuiSaveFilePath.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiSaveFilePath.h
+++ b/Gem/Code/Source/Utils/ImGuiSaveFilePath.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp
+++ b/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp
+++ b/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiShaderUtils.h
+++ b/Gem/Code/Source/Utils/ImGuiShaderUtils.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiShaderUtils.h
+++ b/Gem/Code/Source/Utils/ImGuiShaderUtils.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiSidebar.cpp
+++ b/Gem/Code/Source/Utils/ImGuiSidebar.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiSidebar.cpp
+++ b/Gem/Code/Source/Utils/ImGuiSidebar.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/ImGuiSidebar.h
+++ b/Gem/Code/Source/Utils/ImGuiSidebar.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/ImGuiSidebar.h
+++ b/Gem/Code/Source/Utils/ImGuiSidebar.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/Utils.cpp
+++ b/Gem/Code/Source/Utils/Utils.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/Utils.cpp
+++ b/Gem/Code/Source/Utils/Utils.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Utils/Utils.h
+++ b/Gem/Code/Source/Utils/Utils.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Utils/Utils.h
+++ b/Gem/Code/Source/Utils/Utils.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tests/AtomSampleViewerGemTests.cpp
+++ b/Gem/Code/Tests/AtomSampleViewerGemTests.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tests/AtomSampleViewerGemTests.cpp
+++ b/Gem/Code/Tests/AtomSampleViewerGemTests.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/AtomSampleViewerToolsModule.cpp
+++ b/Gem/Code/Tools/AtomSampleViewerToolsModule.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/AtomSampleViewerToolsModule.cpp
+++ b/Gem/Code/Tools/AtomSampleViewerToolsModule.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.cpp
+++ b/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.cpp
+++ b/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.h
+++ b/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.h
+++ b/Gem/Code/Tools/AtomSampleViewerToolsSystemComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.cpp
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.cpp
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.h
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.h
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.cpp
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.cpp
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.h
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.h
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/atomsampleviewer_tests_files.cmake
+++ b/Gem/Code/atomsampleviewer_tests_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewer_tests_files.cmake
+++ b/Gem/Code/atomsampleviewer_tests_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomsampleviewergem_lib_files.cmake
+++ b/Gem/Code/atomsampleviewergem_lib_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewergem_lib_files.cmake
+++ b/Gem/Code/atomsampleviewergem_lib_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomsampleviewergem_private_shared_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_shared_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewergem_private_shared_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_shared_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomsampleviewergem_tests_files.cmake
+++ b/Gem/Code/atomsampleviewergem_tests_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewergem_tests_files.cmake
+++ b/Gem/Code/atomsampleviewergem_tests_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomsampleviewergem_tools_files.cmake
+++ b/Gem/Code/atomsampleviewergem_tools_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewergem_tools_files.cmake
+++ b/Gem/Code/atomsampleviewergem_tools_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/atomsampleviewergem_tools_shared_files.cmake
+++ b/Gem/Code/atomsampleviewergem_tools_shared_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/atomsampleviewergem_tools_shared_files.cmake
+++ b/Gem/Code/atomsampleviewergem_tools_shared_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Materials/DynamicMaterialTest/EmissiveFunctor.lua
+++ b/Materials/DynamicMaterialTest/EmissiveFunctor.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Materials/DynamicMaterialTest/EmissiveFunctor.lua
+++ b/Materials/DynamicMaterialTest/EmissiveFunctor.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Materials/HotReloadTest/TestData/AZSL_HorizontalPattern.txt
+++ b/Materials/HotReloadTest/TestData/AZSL_HorizontalPattern.txt
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project. 
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT*
  */

--- a/Materials/HotReloadTest/TestData/AZSL_VerticalPattern.txt
+++ b/Materials/HotReloadTest/TestData/AZSL_VerticalPattern.txt
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project. 
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT*
  */

--- a/Scripts/AreaLightTest.bv.lua
+++ b/Scripts/AreaLightTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/AreaLightTest.bv.lua
+++ b/Scripts/AreaLightTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/AuxGeom.bv.lua
+++ b/Scripts/AuxGeom.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/AuxGeom.bv.lua
+++ b/Scripts/AuxGeom.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/CheckerboardTest.bv.lua
+++ b/Scripts/CheckerboardTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/CheckerboardTest.bv.lua
+++ b/Scripts/CheckerboardTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/CullingAndLod.bv.lua
+++ b/Scripts/CullingAndLod.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/CullingAndLod.bv.lua
+++ b/Scripts/CullingAndLod.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/Decals.bv.lua
+++ b/Scripts/Decals.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/Decals.bv.lua
+++ b/Scripts/Decals.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/DiffuseGITest.bv.lua
+++ b/Scripts/DiffuseGITest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/DiffuseGITest.bv.lua
+++ b/Scripts/DiffuseGITest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/DynamicDraw.bv.lua
+++ b/Scripts/DynamicDraw.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/DynamicDraw.bv.lua
+++ b/Scripts/DynamicDraw.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/DynamicMaterialTest.bv.lua
+++ b/Scripts/DynamicMaterialTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/DynamicMaterialTest.bv.lua
+++ b/Scripts/DynamicMaterialTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/LightCulling.bv.lua
+++ b/Scripts/LightCulling.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/LightCulling.bv.lua
+++ b/Scripts/LightCulling.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/MSAA_RPI_Test.bv.lua
+++ b/Scripts/MSAA_RPI_Test.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/MSAA_RPI_Test.bv.lua
+++ b/Scripts/MSAA_RPI_Test.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/MultiRenderPipeline.bv.lua
+++ b/Scripts/MultiRenderPipeline.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/MultiRenderPipeline.bv.lua
+++ b/Scripts/MultiRenderPipeline.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/MultiScene.bv.lua
+++ b/Scripts/MultiScene.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/MultiScene.bv.lua
+++ b/Scripts/MultiScene.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/ParallaxTest.bv.lua
+++ b/Scripts/ParallaxTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/ParallaxTest.bv.lua
+++ b/Scripts/ParallaxTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/PassTree.bv.lua
+++ b/Scripts/PassTree.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/PassTree.bv.lua
+++ b/Scripts/PassTree.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/SceneReloadSoakTest.bv.lua
+++ b/Scripts/SceneReloadSoakTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/SceneReloadSoakTest.bv.lua
+++ b/Scripts/SceneReloadSoakTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/ShadowTest.bv.lua
+++ b/Scripts/ShadowTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/ShadowTest.bv.lua
+++ b/Scripts/ShadowTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/ShadowedSponzaTest.bv.lua
+++ b/Scripts/ShadowedSponzaTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/ShadowedSponzaTest.bv.lua
+++ b/Scripts/ShadowedSponzaTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/StreamingImageTest.bv.lua
+++ b/Scripts/StreamingImageTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/StreamingImageTest.bv.lua
+++ b/Scripts/StreamingImageTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/TransparentTest.bv.lua
+++ b/Scripts/TransparentTest.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/TransparentTest.bv.lua
+++ b/Scripts/TransparentTest.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/_AutomatedPeriodicBenchmarkSuite_.bv.lua
+++ b/Scripts/_AutomatedPeriodicBenchmarkSuite_.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 --
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/_AutomatedPeriodicTestSuite_.bv.lua
+++ b/Scripts/_AutomatedPeriodicTestSuite_.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/_AutomatedPeriodicTestSuite_.bv.lua
+++ b/Scripts/_AutomatedPeriodicTestSuite_.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/_AutomatedReviewTestSuite_.bv.lua
+++ b/Scripts/_AutomatedReviewTestSuite_.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/_AutomatedReviewTestSuite_.bv.lua
+++ b/Scripts/_AutomatedReviewTestSuite_.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/_AutomatedReviewWARPTestSuite_.bv.lua
+++ b/Scripts/_AutomatedReviewWARPTestSuite_.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/_AutomatedReviewWARPTestSuite_.bv.lua
+++ b/Scripts/_AutomatedReviewWARPTestSuite_.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/_FullTestSuite_.bv.lua
+++ b/Scripts/_FullTestSuite_.bv.lua
@@ -2,7 +2,7 @@
 --
 -- Copyright (c) Contributors to the Open 3D Engine Project.
 -- For complete copyright and license terms please see the LICENSE at the root of this distribution.
--- 
+--
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --
 --

--- a/Scripts/_FullTestSuite_.bv.lua
+++ b/Scripts/_FullTestSuite_.bv.lua
@@ -1,6 +1,7 @@
 ----------------------------------------------------------------------------------------------------
 --
--- Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
 -- 
 -- SPDX-License-Identifier: Apache-2.0 OR MIT
 --

--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -1,6 +1,7 @@
 #!/usr/bin/env groovy
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/ComprehensiveTestMaterial/Stacks.azsl
+++ b/Shaders/ComprehensiveTestMaterial/Stacks.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/ComprehensiveTestMaterial/Stacks.azsl
+++ b/Shaders/ComprehensiveTestMaterial/Stacks.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/DebugVertexNormals.azsl
+++ b/Shaders/DebugVertexNormals.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/DebugVertexNormals.azsl
+++ b/Shaders/DebugVertexNormals.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/DynamicDraw/DynamicDrawExample.azsl
+++ b/Shaders/DynamicDraw/DynamicDrawExample.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/DynamicDraw/DynamicDrawExample.azsl
+++ b/Shaders/DynamicDraw/DynamicDrawExample.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/PostProcessing/ColorInvertCS.azsl
+++ b/Shaders/PostProcessing/ColorInvertCS.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/PostProcessing/ColorInvertCS.azsl
+++ b/Shaders/PostProcessing/ColorInvertCS.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/PostProcessing/ColorblindnessSimulation.azsl
+++ b/Shaders/PostProcessing/ColorblindnessSimulation.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/PostProcessing/ColorblindnessSimulation.azsl
+++ b/Shaders/PostProcessing/ColorblindnessSimulation.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/PostProcessing/MSAAResolveDepth.azsl
+++ b/Shaders/PostProcessing/MSAAResolveDepth.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/PostProcessing/MSAAResolveDepth.azsl
+++ b/Shaders/PostProcessing/MSAAResolveDepth.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/PostProcessing/Monochrome.azsl
+++ b/Shaders/PostProcessing/Monochrome.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/PostProcessing/Monochrome.azsl
+++ b/Shaders/PostProcessing/Monochrome.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/AsyncComputeLuminanceMap.azsl
+++ b/Shaders/RHI/AsyncComputeLuminanceMap.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/AsyncComputeLuminanceMap.azsl
+++ b/Shaders/RHI/AsyncComputeLuminanceMap.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/AsyncComputeLuminanceReduce.azsl
+++ b/Shaders/RHI/AsyncComputeLuminanceReduce.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/AsyncComputeLuminanceReduce.azsl
+++ b/Shaders/RHI/AsyncComputeLuminanceReduce.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/AsyncComputeShadow.azsl
+++ b/Shaders/RHI/AsyncComputeShadow.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/AsyncComputeShadow.azsl
+++ b/Shaders/RHI/AsyncComputeShadow.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/AsyncComputeTonemapping.azsl
+++ b/Shaders/RHI/AsyncComputeTonemapping.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/AsyncComputeTonemapping.azsl
+++ b/Shaders/RHI/AsyncComputeTonemapping.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/BindlessPrototype.azsl
+++ b/Shaders/RHI/BindlessPrototype.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/BindlessPrototype.azsl
+++ b/Shaders/RHI/BindlessPrototype.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/BindlessPrototypeSrg.azsli
+++ b/Shaders/RHI/BindlessPrototypeSrg.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/BindlessPrototypeSrg.azsli
+++ b/Shaders/RHI/BindlessPrototypeSrg.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/ColorMesh.azsl
+++ b/Shaders/RHI/ColorMesh.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/ColorMesh.azsl
+++ b/Shaders/RHI/ColorMesh.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/Compute.azsli
+++ b/Shaders/RHI/Compute.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/Compute.azsli
+++ b/Shaders/RHI/Compute.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/ComputeDispatch.azsl
+++ b/Shaders/RHI/ComputeDispatch.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/ComputeDispatch.azsl
+++ b/Shaders/RHI/ComputeDispatch.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/ComputeDraw.azsl
+++ b/Shaders/RHI/ComputeDraw.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/ComputeDraw.azsl
+++ b/Shaders/RHI/ComputeDraw.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/CopyQueue.azsl
+++ b/Shaders/RHI/CopyQueue.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/CopyQueue.azsl
+++ b/Shaders/RHI/CopyQueue.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/DualSourceBlending.azsl
+++ b/Shaders/RHI/DualSourceBlending.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/DualSourceBlending.azsl
+++ b/Shaders/RHI/DualSourceBlending.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/IndirectDispatch.azsl
+++ b/Shaders/RHI/IndirectDispatch.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/IndirectDispatch.azsl
+++ b/Shaders/RHI/IndirectDispatch.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/IndirectDraw.azsl
+++ b/Shaders/RHI/IndirectDraw.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/IndirectDraw.azsl
+++ b/Shaders/RHI/IndirectDraw.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/IndirectRendering.azsli
+++ b/Shaders/RHI/IndirectRendering.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/IndirectRendering.azsli
+++ b/Shaders/RHI/IndirectRendering.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/InputAssemblyCompute.azsl
+++ b/Shaders/RHI/InputAssemblyCompute.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/InputAssemblyCompute.azsl
+++ b/Shaders/RHI/InputAssemblyCompute.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/InputAssemblyDraw.azsl
+++ b/Shaders/RHI/InputAssemblyDraw.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/InputAssemblyDraw.azsl
+++ b/Shaders/RHI/InputAssemblyDraw.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/MRTScreen.azsl
+++ b/Shaders/RHI/MRTScreen.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/MRTScreen.azsl
+++ b/Shaders/RHI/MRTScreen.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/MRTTarget.azsl
+++ b/Shaders/RHI/MRTTarget.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/MRTTarget.azsl
+++ b/Shaders/RHI/MRTTarget.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/MSAAResolve.azsl
+++ b/Shaders/RHI/MSAAResolve.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/MSAAResolve.azsl
+++ b/Shaders/RHI/MSAAResolve.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/MultipleViewsDepth.azsl
+++ b/Shaders/RHI/MultipleViewsDepth.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/MultipleViewsDepth.azsl
+++ b/Shaders/RHI/MultipleViewsDepth.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/MultipleViewsShadow.azsl
+++ b/Shaders/RHI/MultipleViewsShadow.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/MultipleViewsShadow.azsl
+++ b/Shaders/RHI/MultipleViewsShadow.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/Multithread.azsl
+++ b/Shaders/RHI/Multithread.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/Multithread.azsl
+++ b/Shaders/RHI/Multithread.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/RayTracingClosestHitGradient.azsl
+++ b/Shaders/RHI/RayTracingClosestHitGradient.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/RayTracingClosestHitGradient.azsl
+++ b/Shaders/RHI/RayTracingClosestHitGradient.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/RayTracingClosestHitSolid.azsl
+++ b/Shaders/RHI/RayTracingClosestHitSolid.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/RayTracingClosestHitSolid.azsl
+++ b/Shaders/RHI/RayTracingClosestHitSolid.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/RayTracingCommon.azsli
+++ b/Shaders/RHI/RayTracingCommon.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/RayTracingCommon.azsli
+++ b/Shaders/RHI/RayTracingCommon.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/RayTracingDispatch.azsl
+++ b/Shaders/RHI/RayTracingDispatch.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/RayTracingDispatch.azsl
+++ b/Shaders/RHI/RayTracingDispatch.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/RayTracingDraw.azsl
+++ b/Shaders/RHI/RayTracingDraw.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/RayTracingDraw.azsl
+++ b/Shaders/RHI/RayTracingDraw.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/RayTracingMiss.azsl
+++ b/Shaders/RHI/RayTracingMiss.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/RayTracingMiss.azsl
+++ b/Shaders/RHI/RayTracingMiss.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/SHDemo.azsl
+++ b/Shaders/RHI/SHDemo.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/SHDemo.azsl
+++ b/Shaders/RHI/SHDemo.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/SHRender.azsl
+++ b/Shaders/RHI/SHRender.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/SHRender.azsl
+++ b/Shaders/RHI/SHRender.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/Stencil.azsl
+++ b/Shaders/RHI/Stencil.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/Stencil.azsl
+++ b/Shaders/RHI/Stencil.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/SubpassInputComposition.azsl
+++ b/Shaders/RHI/SubpassInputComposition.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/SubpassInputComposition.azsl
+++ b/Shaders/RHI/SubpassInputComposition.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/SubpassInputGBuffer.azsl
+++ b/Shaders/RHI/SubpassInputGBuffer.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/SubpassInputGBuffer.azsl
+++ b/Shaders/RHI/SubpassInputGBuffer.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/SubpassInputModelSrg.azsli
+++ b/Shaders/RHI/SubpassInputModelSrg.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/SubpassInputModelSrg.azsli
+++ b/Shaders/RHI/SubpassInputModelSrg.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/SubpassInputSceneSrg.azsli
+++ b/Shaders/RHI/SubpassInputSceneSrg.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/SubpassInputSceneSrg.azsli
+++ b/Shaders/RHI/SubpassInputSceneSrg.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/Texture.azsl
+++ b/Shaders/RHI/Texture.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/Texture.azsl
+++ b/Shaders/RHI/Texture.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/Texture3d.azsl
+++ b/Shaders/RHI/Texture3d.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/Texture3d.azsl
+++ b/Shaders/RHI/Texture3d.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureArray.azsl
+++ b/Shaders/RHI/TextureArray.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureArray.azsl
+++ b/Shaders/RHI/TextureArray.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMap1D.azsl
+++ b/Shaders/RHI/TextureMap1D.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMap1D.azsl
+++ b/Shaders/RHI/TextureMap1D.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMap1DArray.azsl
+++ b/Shaders/RHI/TextureMap1DArray.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMap1DArray.azsl
+++ b/Shaders/RHI/TextureMap1DArray.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMap2DArray.azsl
+++ b/Shaders/RHI/TextureMap2DArray.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMap2DArray.azsl
+++ b/Shaders/RHI/TextureMap2DArray.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMap3D.azsl
+++ b/Shaders/RHI/TextureMap3D.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMap3D.azsl
+++ b/Shaders/RHI/TextureMap3D.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMapCubemap.azsl
+++ b/Shaders/RHI/TextureMapCubemap.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMapCubemap.azsl
+++ b/Shaders/RHI/TextureMapCubemap.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMapCubemapArray.azsl
+++ b/Shaders/RHI/TextureMapCubemapArray.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMapCubemapArray.azsl
+++ b/Shaders/RHI/TextureMapCubemapArray.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TextureMapTarget.azsl
+++ b/Shaders/RHI/TextureMapTarget.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TextureMapTarget.azsl
+++ b/Shaders/RHI/TextureMapTarget.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TexturedSurface.azsl
+++ b/Shaders/RHI/TexturedSurface.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TexturedSurface.azsl
+++ b/Shaders/RHI/TexturedSurface.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/Triangle.azsl
+++ b/Shaders/RHI/Triangle.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/Triangle.azsl
+++ b/Shaders/RHI/Triangle.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RHI/TrianglesConstantBuffer.azsl
+++ b/Shaders/RHI/TrianglesConstantBuffer.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RHI/TrianglesConstantBuffer.azsl
+++ b/Shaders/RHI/TrianglesConstantBuffer.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RayTracing/RTAOClosestHit.azsl
+++ b/Shaders/RayTracing/RTAOClosestHit.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RayTracing/RTAOClosestHit.azsl
+++ b/Shaders/RayTracing/RTAOClosestHit.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RayTracing/RTAODefines.azsli
+++ b/Shaders/RayTracing/RTAODefines.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RayTracing/RTAODefines.azsli
+++ b/Shaders/RayTracing/RTAODefines.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RayTracing/RTAOGeneration.azsl
+++ b/Shaders/RayTracing/RTAOGeneration.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RayTracing/RTAOGeneration.azsl
+++ b/Shaders/RayTracing/RTAOGeneration.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RayTracing/RTAOMiss.azsl
+++ b/Shaders/RayTracing/RTAOMiss.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RayTracing/RTAOMiss.azsl
+++ b/Shaders/RayTracing/RTAOMiss.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/RootConstantsExample/ColorMesh.azsl
+++ b/Shaders/RootConstantsExample/ColorMesh.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/RootConstantsExample/ColorMesh.azsl
+++ b/Shaders/RootConstantsExample/ColorMesh.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/ShaderResourceGroups/SceneSrg.azsli
+++ b/Shaders/ShaderResourceGroups/SceneSrg.azsli
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/ShaderResourceGroups/SceneSrg.azsli
+++ b/Shaders/ShaderResourceGroups/SceneSrg.azsli
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/StaticMesh.azsl
+++ b/Shaders/StaticMesh.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/StaticMesh.azsl
+++ b/Shaders/StaticMesh.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/StreamingImageExample/Image3d.azsl
+++ b/Shaders/StreamingImageExample/Image3d.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/StreamingImageExample/Image3d.azsl
+++ b/Shaders/StreamingImageExample/Image3d.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/StreamingImageExample/ImageMips.azsl
+++ b/Shaders/StreamingImageExample/ImageMips.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/StreamingImageExample/ImageMips.azsl
+++ b/Shaders/StreamingImageExample/ImageMips.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/TonemappingExample/RenderImage.azsl
+++ b/Shaders/TonemappingExample/RenderImage.azsl
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Shaders/TonemappingExample/RenderImage.azsl
+++ b/Shaders/TonemappingExample/RenderImage.azsl
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/CMakeLists.txt
+++ b/Standalone/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/CMakeLists.txt
+++ b/Standalone/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Android/atomsampleviewer_traits_android.cmake
+++ b/Standalone/Platform/Android/atomsampleviewer_traits_android.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Android/atomsampleviewer_traits_android.cmake
+++ b/Standalone/Platform/Android/atomsampleviewer_traits_android.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Android/main_android.cpp
+++ b/Standalone/Platform/Android/main_android.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Android/main_android.cpp
+++ b/Standalone/Platform/Android/main_android.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Android/platform_android_files.cmake
+++ b/Standalone/Platform/Android/platform_android_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Android/platform_android_files.cmake
+++ b/Standalone/Platform/Android/platform_android_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.h
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.h
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Common/AtomSampleViewerApplication_common.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication_common.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Common/AtomSampleViewerApplication_common.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication_common.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Linux/atomsampleviewer_traits_linux.cmake
+++ b/Standalone/Platform/Linux/atomsampleviewer_traits_linux.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Linux/atomsampleviewer_traits_linux.cmake
+++ b/Standalone/Platform/Linux/atomsampleviewer_traits_linux.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Linux/main_linux.cpp
+++ b/Standalone/Platform/Linux/main_linux.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Linux/main_linux.cpp
+++ b/Standalone/Platform/Linux/main_linux.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Linux/platform_linux_files.cmake
+++ b/Standalone/Platform/Linux/platform_linux_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Linux/platform_linux_files.cmake
+++ b/Standalone/Platform/Linux/platform_linux_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Mac/AtomSampleViewerApplication_mac.cpp
+++ b/Standalone/Platform/Mac/AtomSampleViewerApplication_mac.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Mac/AtomSampleViewerApplication_mac.cpp
+++ b/Standalone/Platform/Mac/AtomSampleViewerApplication_mac.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Mac/MacO3DEApplication.h
+++ b/Standalone/Platform/Mac/MacO3DEApplication.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Mac/MacO3DEApplication.h
+++ b/Standalone/Platform/Mac/MacO3DEApplication.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Mac/MacO3DEApplication.mm
+++ b/Standalone/Platform/Mac/MacO3DEApplication.mm
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Mac/MacO3DEApplication.mm
+++ b/Standalone/Platform/Mac/MacO3DEApplication.mm
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Mac/MacO3DEApplicationDelegate.mm
+++ b/Standalone/Platform/Mac/MacO3DEApplicationDelegate.mm
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Mac/MacO3DEApplicationDelegate.mm
+++ b/Standalone/Platform/Mac/MacO3DEApplicationDelegate.mm
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Mac/atomsampleviewer_traits_mac.cmake
+++ b/Standalone/Platform/Mac/atomsampleviewer_traits_mac.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Mac/atomsampleviewer_traits_mac.cmake
+++ b/Standalone/Platform/Mac/atomsampleviewer_traits_mac.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Mac/main_mac.mm
+++ b/Standalone/Platform/Mac/main_mac.mm
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Mac/main_mac.mm
+++ b/Standalone/Platform/Mac/main_mac.mm
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Mac/platform_mac_files.cmake
+++ b/Standalone/Platform/Mac/platform_mac_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Mac/platform_mac_files.cmake
+++ b/Standalone/Platform/Mac/platform_mac_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Windows/AtomSampleViewerApplication_windows.cpp
+++ b/Standalone/Platform/Windows/AtomSampleViewerApplication_windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Windows/AtomSampleViewerApplication_windows.cpp
+++ b/Standalone/Platform/Windows/AtomSampleViewerApplication_windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Windows/atomsampleviewer_traits_windows.cmake
+++ b/Standalone/Platform/Windows/atomsampleviewer_traits_windows.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Windows/atomsampleviewer_traits_windows.cmake
+++ b/Standalone/Platform/Windows/atomsampleviewer_traits_windows.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/Windows/main_windows.cpp
+++ b/Standalone/Platform/Windows/main_windows.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/Windows/main_windows.cpp
+++ b/Standalone/Platform/Windows/main_windows.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/Windows/platform_windows_files.cmake
+++ b/Standalone/Platform/Windows/platform_windows_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/Windows/platform_windows_files.cmake
+++ b/Standalone/Platform/Windows/platform_windows_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/iOS/AtomSampleViewerApplication_ios.cpp
+++ b/Standalone/Platform/iOS/AtomSampleViewerApplication_ios.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/iOS/AtomSampleViewerApplication_ios.cpp
+++ b/Standalone/Platform/iOS/AtomSampleViewerApplication_ios.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/iOS/IosO3DEApplication.mm
+++ b/Standalone/Platform/iOS/IosO3DEApplication.mm
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/iOS/IosO3DEApplication.mm
+++ b/Standalone/Platform/iOS/IosO3DEApplication.mm
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/iOS/IosO3DEApplicationDelegate.mm
+++ b/Standalone/Platform/iOS/IosO3DEApplicationDelegate.mm
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/iOS/IosO3DEApplicationDelegate.mm
+++ b/Standalone/Platform/iOS/IosO3DEApplicationDelegate.mm
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/iOS/atomsampleviewer_traits_ios.cmake
+++ b/Standalone/Platform/iOS/atomsampleviewer_traits_ios.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/iOS/atomsampleviewer_traits_ios.cmake
+++ b/Standalone/Platform/iOS/atomsampleviewer_traits_ios.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/Platform/iOS/main_ios.mm
+++ b/Standalone/Platform/iOS/main_ios.mm
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Standalone/Platform/iOS/main_ios.mm
+++ b/Standalone/Platform/iOS/main_ios.mm
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Standalone/Platform/iOS/platform_ios_files.cmake
+++ b/Standalone/Platform/iOS/platform_ios_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/Platform/iOS/platform_ios_files.cmake
+++ b/Standalone/Platform/iOS/platform_ios_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/PythonTests/Automated/__init__.py
+++ b/Standalone/PythonTests/Automated/__init__.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Standalone/PythonTests/Automated/benchmark_data_aggregator.py
+++ b/Standalone/PythonTests/Automated/benchmark_data_aggregator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_periodic_suite.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_warp_suite.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 """

--- a/Standalone/PythonTests/CMakeLists.txt
+++ b/Standalone/PythonTests/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/PythonTests/conftest.py
+++ b/Standalone/PythonTests/conftest.py
@@ -1,5 +1,6 @@
 """
-Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
 
 SPDX-License-Identifier: Apache-2.0 OR MIT
 

--- a/Standalone/atomsample_viewer_files.cmake
+++ b/Standalone/atomsample_viewer_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/atomsample_viewer_files.cmake
+++ b/Standalone/atomsample_viewer_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/atomsample_viewer_ios_files.cmake
+++ b/Standalone/atomsample_viewer_ios_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/atomsample_viewer_ios_files.cmake
+++ b/Standalone/atomsample_viewer_ios_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/atomsample_viewer_mac_files.cmake
+++ b/Standalone/atomsample_viewer_mac_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/atomsample_viewer_mac_files.cmake
+++ b/Standalone/atomsample_viewer_mac_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Standalone/native_activity_glue_files.cmake
+++ b/Standalone/native_activity_glue_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Standalone/native_activity_glue_files.cmake
+++ b/Standalone/native_activity_glue_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/atomsampleviewer_asset_files.cmake
+++ b/atomsampleviewer_asset_files.cmake
@@ -1,5 +1,6 @@
 # 
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/atomsampleviewer_asset_files.cmake
+++ b/atomsampleviewer_asset_files.cmake
@@ -1,7 +1,7 @@
 # 
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 # 

--- a/generate_asset_cmake.bat
+++ b/generate_asset_cmake.bat
@@ -1,7 +1,7 @@
 @ECHO off
 REM Copyright (c) Contributors to the Open 3D Engine Project.
 REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
-REM 
+REM
 REM SPDX-License-Identifier: Apache-2.0 OR MIT
 
 setlocal enabledelayedexpansion

--- a/generate_asset_cmake.bat
+++ b/generate_asset_cmake.bat
@@ -1,5 +1,6 @@
 @ECHO off
-REM Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
 REM 
 REM SPDX-License-Identifier: Apache-2.0 OR MIT
 
@@ -16,7 +17,8 @@ set OUTPUT_FILE=atomsampleviewer_asset_files.cmake
 
 :: Write copyright header to top of file
 echo # > %OUTPUT_FILE%
-echo # Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution. >> %OUTPUT_FILE%
+echo # Copyright (c) Contributors to the Open 3D Engine Project. >> %OUTPUT_FILE%
+echo # For complete copyright and license terms please see the LICENSE at the root of this distribution. >> %OUTPUT_FILE%
 echo # >> %OUTPUT_FILE%
 echo # SPDX-License-Identifier: Apache-2.0 OR MIT >> %OUTPUT_FILE%
 echo # >> %OUTPUT_FILE%


### PR DESCRIPTION
The original copyright headers for O3DE went over 140 characters, which is causing clang-format to automatically wrap it from:

```
/*
 * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
 * 
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 to:
 
 ```
 /*
 * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
 * this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 So to reduce this unnecessary reformatting, and to make the copyright statement shorter in general (for all source code files), we are updating it to (C-style example):
 
 ```
 /*
 * Copyright (c) Contributors to the Open 3D Engine Project. 
 * For complete copyright and license terms please see the LICENSE at the root of this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 Note: The copyright submission validator will still pass the original single-line version, as it is still a valid statement.
 