### PR TITLE
Fix for w4267 ('var' : conversion from 'size_t' to 'type', possible loss of data)

### DIFF
--- a/Gem/Code/Source/AreaLightExampleComponent.cpp
+++ b/Gem/Code/Source/AreaLightExampleComponent.cpp
@@ -369,7 +369,7 @@ namespace AtomSampleViewer
             TransformVertices(points, m_config.GetRotationQuaternion(), position);
 
             AZ::Vector3 direction = m_config.GetRotationQuaternion().TransformVector(AZ::Vector3::CreateAxisZ());
-            m_polygonLightFeatureProcessor->SetPolygonPoints(handle, points.data(), points.size(), direction);
+            m_polygonLightFeatureProcessor->SetPolygonPoints(handle, points.data(), static_cast<uint32_t>(points.size()), direction);
         }
     }
 
@@ -834,7 +834,7 @@ namespace AtomSampleViewer
                 AZ::RPI::AuxGeomDraw::AuxGeomDynamicDrawArguments args;
                 args.m_colorCount = 1;
                 args.m_colors = &nitsColor;
-                args.m_vertCount = tris.size();
+                args.m_vertCount = static_cast<uint32_t>(tris.size());
                 args.m_verts = tris.data();
                 m_auxGeom->DrawTriangles(args);
                 break;

--- a/Gem/Code/Source/AssetLoadTestComponent.cpp
+++ b/Gem/Code/Source/AssetLoadTestComponent.cpp
@@ -63,7 +63,7 @@ namespace AtomSampleViewer
         };
         m_materialBrowser.SetDefaultPinnedAssets(defaultMaterialAllowlist);
 
-        m_pinnedMaterialCount = m_materialBrowser.GetPinnedAssets().size();
+        m_pinnedMaterialCount = static_cast<uint32_t>(m_materialBrowser.GetPinnedAssets().size());
 
         const AZStd::vector<AZStd::string> defaultModelAllowist =
         {
@@ -307,7 +307,7 @@ namespace AtomSampleViewer
 
             if (materialsChanged)
             {
-                m_pinnedMaterialCount = pinnedMaterials.size();
+                m_pinnedMaterialCount = static_cast<uint32_t>(pinnedMaterials.size());
                 // Keep the current m_cachedMaterials to avoid release-load the same material
                 MaterialAssetSet newCache;
                 // clean up cached material which refcount is 1

--- a/Gem/Code/Source/Utils/ImGuiProgressList.cpp
+++ b/Gem/Code/Source/Utils/ImGuiProgressList.cpp
@@ -85,7 +85,7 @@ namespace AtomSampleViewer
                 };
 
                 ImGui::PushItemWidth(-1.0f);
-                ScriptableImGui::ListBox("", &m_selectedItemIndex, listBoxGetter, &m_itemsList, m_itemsList.size());
+                ScriptableImGui::ListBox("", &m_selectedItemIndex, listBoxGetter, &m_itemsList, static_cast<int>(m_itemsList.size()));
                 ImGui::PopItemWidth();
 
                 if (ScriptableImGui::Button(m_actionButtonLabel.c_str()))


### PR DESCRIPTION
https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4267?view=msvc-160