### PR TITLE
Move benchmark runner from periodic to main suite for GPU requirement.

### DIFF
--- a/Standalone/PythonTests/CMakeLists.txt
+++ b/Standalone/PythonTests/CMakeLists.txt
@@ -56,7 +56,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         NAME AtomSampleViewer::PeriodicPerformanceBenchmarks
         PATH ${CMAKE_CURRENT_LIST_DIR}/Automated/benchmark_runner_periodic_suite.py
         TEST_REQUIRES gpu
-        TEST_SUITE periodic
+        TEST_SUITE main
         TEST_SERIAL
         TIMEOUT 600
         RUNTIME_DEPENDENCIES


### PR DESCRIPTION
Only the main/smoke suites allow for tests requiring GPUs.
