### PR TITLE
Increase timeout of benchmark runner suite.

### DIFF
--- a/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
@@ -48,7 +48,7 @@ class TestPerformanceBenchmarksPeriodicSuite:
         process_utils.safe_check_call(cmd, stderr=subprocess.STDOUT, encoding='UTF-8', shell=True)
         try:
             expected_lines = ["Script: Capturing complete."]
-            atomsampleviewer_log_monitor.monitor_log_for_lines(expected_lines, timeout=300)
+            atomsampleviewer_log_monitor.monitor_log_for_lines(expected_lines, timeout=180)
 
             aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')
             aggregator.upload_metrics(rhi)

--- a/Standalone/PythonTests/CMakeLists.txt
+++ b/Standalone/PythonTests/CMakeLists.txt
@@ -58,7 +58,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         TEST_REQUIRES gpu
         TEST_SUITE main
         TEST_SERIAL
-        TIMEOUT 600
+        TIMEOUT 1200
         RUNTIME_DEPENDENCIES
             AssetProcessor
             AssetProcessorBatch


### PR DESCRIPTION
Current timeout only allows for dx12 suite to run but not vulkan.