### PR TITLE
Update shadow screenshots

### DIFF
--- a/Scripts/ExpectedScreenshots/Shadow/directional_esm.png
+++ b/Scripts/ExpectedScreenshots/Shadow/directional_esm.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e59e2628aa440c30fd4cd57d651a7684982f299ab2ed10aeb49c797f6edf4e24
-size 178056
+oid sha256:5a00855d14d006a19806142d240aebb383f2d765f4fe4b4487ffc4d583ca57c4
+size 172519

--- a/Scripts/ExpectedScreenshots/Shadow/directional_esm_pcf.png
+++ b/Scripts/ExpectedScreenshots/Shadow/directional_esm_pcf.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f189d9411333dc0bc00d56a279e0502478df777f023c4aa63f5e208c8704d7b
-size 179700
+oid sha256:fd820713d4a3a5e223147ad7906ec0e2905bb55c9fa2f4e0482a9d35141ff6af
+size 173188

--- a/Scripts/ExpectedScreenshots/ShadowedSponza/directional_filter.png
+++ b/Scripts/ExpectedScreenshots/ShadowedSponza/directional_filter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c4727ce981f94f07f513e24925699dcf8b099c80f6926c6f7484b30cdaf47fdc
-size 130413
+oid sha256:7431de98450bc58a69425266f7f949a14b3c5468fe8fadb3556c3d61ac9a3fd8
+size 129439

--- a/Scripts/ExpectedScreenshots/ShadowedSponza/initial.png
+++ b/Scripts/ExpectedScreenshots/ShadowedSponza/initial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:674f6bd8229d6dc2892ff71a76239168648a1bdc9ee5768b4174aeb7211d1779
-size 141734
+oid sha256:d56b3aaad036fb387d64fb154d44c0031c4685134568c94218bd9bcb1ba00dfb
+size 140910

--- a/Scripts/ExpectedScreenshots/ShadowedSponza/spot_nofilter.png
+++ b/Scripts/ExpectedScreenshots/ShadowedSponza/spot_nofilter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:78b7a109db6a4e42d863a83563c61d076278affd735a2efcfb3e18b3b245a6fa
-size 139876
+oid sha256:08cb4c1eff8c36d05397516a8b204714893301fbe64babd1de4689f0f1406a22
+size 140519


### PR DESCRIPTION
Updating the screenshots for shadowtest and shadowsponza. There were a number of shots that appeared obsolete.