### PR TITLE
[ATOM-15058] Remove Automatic Entry Point Detection

### DIFF
--- a/Materials/HotReloadTest/TestData/Shader_BlendingOff.txt
+++ b/Materials/HotReloadTest/TestData/Shader_BlendingOff.txt
@@ -15,5 +15,20 @@
         "BlendOp": "Add"
     },
 
+    "ProgramSettings" : 
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainVS",
+                "type" : "Vertex"
+            },
+            {
+                "name": "MainPS",
+                "type" : "Fragment"
+            }
+        ] 
+    },
+
     "DrawList": "transparent"
 }

--- a/Materials/HotReloadTest/TestData/Shader_BlendingOn.txt
+++ b/Materials/HotReloadTest/TestData/Shader_BlendingOn.txt
@@ -15,5 +15,20 @@
         "BlendOp": "Add"
     },
 
+    "ProgramSettings" : 
+    {
+        "EntryPoints":
+        [
+            {
+                "name": "MainVS",
+                "type" : "Vertex"
+            },
+            {
+                "name": "MainPS",
+                "type" : "Fragment"
+            }
+        ] 
+    },
+
     "DrawList": "transparent"
 }


### PR DESCRIPTION
MaterialHotReloadTest shaders now have explicit
entry point functions.

Signed-off-by: garrieta <garrieta@amazon.com>