### PR TITLE
MSAA sample is missing lighting when viewing the non-MSAA mode

### DIFF
--- a/Gem/Code/Source/MSAA_RPI_ExampleComponent.cpp
+++ b/Gem/Code/Source/MSAA_RPI_ExampleComponent.cpp
@@ -71,8 +71,8 @@ namespace AtomSampleViewer
         AZ::Debug::CameraControllerRequestBus::Event(GetCameraEntityId(), &AZ::Debug::CameraControllerRequestBus::Events::Disable);
         m_defaultIbl.Reset();
 
-        // clear the non-MSAA pipeline and the RPI scene
-        AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(AZ::Name(""));
+        // reset the number of MSAA samples and the RPI scene
+        SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::ResetNumMSAASamples);
         SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::ClearRPIScene);
 
         AZ::Render::Bootstrap::DefaultWindowNotificationBus::Handler::BusDisconnect();
@@ -100,9 +100,8 @@ namespace AtomSampleViewer
         // necessary to re-initialize all of the feature processor shaders and Srgs
         if (isNonMsaaPipeline != m_isNonMsaaPipeline)
         {      
-            // set the NoMsaa flag based on the pipeline type and reset the RPI scene
-            const char* supervariantName = isNonMsaaPipeline ? AZ::RPI::NoMsaaSupervariantName : "";
-            AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(AZ::Name(supervariantName));
+            // set the number of MSAA samples and reset the RPI scene
+            SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::SetNumMSAASamples, m_numSamples);
             SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::ResetRPIScene);
 
             // reset internal sample scene related data

--- a/Gem/Code/Source/Platform/Android/SampleComponentManager_Android.cpp
+++ b/Gem/Code/Source/Platform/Android/SampleComponentManager_Android.cpp
@@ -29,7 +29,7 @@ namespace AtomSampleViewer
         return "LowEndPipelineTemplate";
     }
 
-    int SampleComponentManager::GutNumMSAASamples()
+    int SampleComponentManager::GetDefaultNumMSAASamples()
     {
         return 1;
     }

--- a/Gem/Code/Source/Platform/Linux/SampleComponentManager_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/SampleComponentManager_Linux.cpp
@@ -24,7 +24,7 @@ namespace AtomSampleViewer
         return "MainPipeline";
     }
     
-    int SampleComponentManager::GutNumMSAASamples()
+    int SampleComponentManager::GetDefaultNumMSAASamples()
     {
         return 4;
     }

--- a/Gem/Code/Source/Platform/Mac/SampleComponentManager_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/SampleComponentManager_Mac.cpp
@@ -24,7 +24,7 @@ namespace AtomSampleViewer
         return "MainPipeline";
     }
 
-    int SampleComponentManager::GutNumMSAASamples()
+    int SampleComponentManager::GetDefaultNumMSAASamples()
     {
         return 4;
     }

--- a/Gem/Code/Source/Platform/Windows/SampleComponentManager_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/SampleComponentManager_Windows.cpp
@@ -24,7 +24,7 @@ namespace AtomSampleViewer
         return "MainPipeline";
     }
 
-    int SampleComponentManager::GutNumMSAASamples()
+    int SampleComponentManager::GetDefaultNumMSAASamples()
     {
         return 4;
     }

--- a/Gem/Code/Source/Platform/iOS/SampleComponentManager_iOS.cpp
+++ b/Gem/Code/Source/Platform/iOS/SampleComponentManager_iOS.cpp
@@ -29,7 +29,7 @@ namespace AtomSampleViewer
         return "LowEndPipelineTemplate";
     }
 
-    int SampleComponentManager::GutNumMSAASamples()
+    int SampleComponentManager::GetDefaultNumMSAASamples()
     {
         return 1;
     }

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -136,6 +136,11 @@ namespace AtomSampleViewer
         const char* TransientAttachmentProfilerToolName = "Transient Attachment Profiler";
     }
 
+    bool IsValidNumMSAASamples(int numSamples)
+    {
+        return (numSamples == 1) || (numSamples == 2) || (numSamples == 4) || (numSamples == 8);
+    }
+
     SampleEntry SampleEntry::NewRHISample(const AZStd::string& name, const AZ::Uuid& uuid)
     {
         SampleEntry entry;
@@ -1152,7 +1157,7 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::SetNumMSAASamples(int numMSAASamples)
     {
-        AZ_Assert(numMSAASamples >= 1 && numMSAASamples <= 8, "Invalid MSAA sample setting");
+        AZ_Assert(IsValidNumMSAASamples(numMSAASamples), "Invalid MSAA sample setting");
 
         m_numMSAASamples = numMSAASamples;
     }
@@ -1505,7 +1510,7 @@ namespace AtomSampleViewer
         pipelineDesc.m_mainViewTagName = "MainCamera";
 
         // set pipeline MSAA samples
-        AZ_Assert(m_numMSAASamples >= 1 && m_numMSAASamples <= 8, "Invalid MSAA sample setting");
+        AZ_Assert(IsValidNumMSAASamples(m_numMSAASamples), "Invalid MSAA sample setting");
         pipelineDesc.m_renderSettings.m_multisampleState.m_samples = m_numMSAASamples;
         bool isNonMsaaPipeline = (pipelineDesc.m_renderSettings.m_multisampleState.m_samples == 1);
         const char* supervariantName = isNonMsaaPipeline ? AZ::RPI::NoMsaaSupervariantName : "";

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -301,7 +301,8 @@ namespace AtomSampleViewer
         AZ_Assert(passSystem, "Cannot get the pass system.");
 
         passSystem->AddPassCreator(Name("RayTracingAmbientOcclusionPass"), &AZ::Render::RayTracingAmbientOcclusionPass::Create);
- 
+
+        m_numMSAASamples = GetDefaultNumMSAASamples();
     }
 
     void SampleComponentManager::ActivateInternal()
@@ -1149,6 +1150,18 @@ namespace AtomSampleViewer
         }
     }
 
+    void SampleComponentManager::SetNumMSAASamples(int numMSAASamples)
+    {
+        AZ_Assert(numMSAASamples >= 1 && numMSAASamples <= 8, "Invalid MSAA sample setting");
+
+        m_numMSAASamples = numMSAASamples;
+    }
+
+    void SampleComponentManager::ResetNumMSAASamples()
+    {
+        m_numMSAASamples = GetDefaultNumMSAASamples();
+    }
+
     void SampleComponentManager::ResetRPIScene()
     {
         ReleaseRPIScene();
@@ -1490,7 +1503,10 @@ namespace AtomSampleViewer
         pipelineDesc.m_name = "RPISamplePipeline";
         pipelineDesc.m_rootPassTemplate = GetRootPassTemplateName();
         pipelineDesc.m_mainViewTagName = "MainCamera";
-        pipelineDesc.m_renderSettings.m_multisampleState.m_samples = GutNumMSAASamples();
+
+        // set pipeline MSAA samples
+        AZ_Assert(m_numMSAASamples >= 1 && m_numMSAASamples <= 8, "Invalid MSAA sample setting");
+        pipelineDesc.m_renderSettings.m_multisampleState.m_samples = m_numMSAASamples;
         bool isNonMsaaPipeline = (pipelineDesc.m_renderSettings.m_multisampleState.m_samples == 1);
         const char* supervariantName = isNonMsaaPipeline ? AZ::RPI::NoMsaaSupervariantName : "";
         AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(AZ::Name(supervariantName));

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -145,6 +145,8 @@ namespace AtomSampleViewer
         void RequestFrameCapture(const AZStd::string& filePath, bool hideImGui) override;
         bool IsFrameCapturePending() override;
         void RunMainTestSuite(const AZStd::string& suiteFilePath, bool exitOnTestEnd, int randomSeed) override;
+        void SetNumMSAASamples(int numMSAASamples) override;
+        void ResetNumMSAASamples() override;
         void ResetRPIScene() override;
         void ClearRPIScene() override;
 
@@ -165,8 +167,8 @@ namespace AtomSampleViewer
         static bool IsMultiViewportSwapchainSampleSupported();
         void AdjustImGuiFontScale();
         const char* GetRootPassTemplateName();
-        int GutNumMSAASamples();
-        
+        int GetDefaultNumMSAASamples();
+
         // ---------- variables -----------------
 
         bool m_wasActivated = false;
@@ -251,5 +253,8 @@ namespace AtomSampleViewer
         AZ::RPI::ScenePtr m_rpiScene;
         float m_simulateTime = 0;
         float m_deltaTime = 0.016f;
+
+        // number of MSAA samples, initialized in Activate() and can vary by platform
+        int m_numMSAASamples = 0;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/SampleComponentManagerBus.h
+++ b/Gem/Code/Source/SampleComponentManagerBus.h
@@ -39,6 +39,13 @@ namespace AtomSampleViewer
         //! @param randomSeed the seed for the random generator, frequently used inside lua tests to shuffle the order of the test execution
         virtual void RunMainTestSuite(const AZStd::string& suiteFilePath, bool exitOnTestEnd, int randomSeed) = 0;
 
+        //! Set the number of MSAA samples
+        //! @param numMSAASamples the number of MSAA samples
+        virtual void SetNumMSAASamples(int numMSAASamples) = 0;
+
+        //! Set the number of MSAA samples to the platform default
+        virtual void ResetNumMSAASamples() = 0;
+
         //! Reset the RPI scene while keeping the current sample running
         virtual void ResetRPIScene() = 0;
 


### PR DESCRIPTION
Added SampleComponentManagerBus events for setting the number of MSAA samples.
Broadcasted these events in the MSAA_RPI_ExampleComponent to properly handle changing the pipeline to a different number of samples.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>