### PR TITLE
Features/Shadow sample does not have a global IBL

### DIFF
--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -102,6 +102,10 @@ namespace AtomSampleViewer
         };
 
         PreloadAssets(assetList);
+
+        // initialize and then reset IBL, which will disable it by binding the default cubemaps
+        m_defaultIbl.Init(AZ::RPI::RPISystemInterface::Get()->GetDefaultScene().get());
+        m_defaultIbl.Reset();
     }
 
     void ShadowExampleComponent::OnAllAssetsReadyActivate()

--- a/Gem/Code/Source/ShadowExampleComponent.h
+++ b/Gem/Code/Source/ShadowExampleComponent.h
@@ -21,6 +21,7 @@
 
 #include <Utils/ImGuiSidebar.h>
 #include <Utils/ImGuiMaterialDetails.h>
+#include <Utils/Utils.h>
 
 namespace AtomSampleViewer
 {
@@ -184,5 +185,7 @@ namespace AtomSampleViewer
         // original camera configuration
         float m_originalFarClipDistance = 0.f;
         float m_originalCameraFovRadians = 0.f;
+
+        Utils::DefaultIBL m_defaultIbl;
     };
 } // namespace AtomSampleViewer


### PR DESCRIPTION
Added IBL to the Shadow sample, and called Reset on it during activation to bind the default cubemaps.

Signed-off-by: dmcdiar <dmcdiar@amazon.com>