### PR TITLE
Updating msaa rpi xshot

### DIFF
--- a/Scripts/ExpectedScreenshots/msaa_rpi/screenshot_msaa4x_cylinder.png
+++ b/Scripts/ExpectedScreenshots/msaa_rpi/screenshot_msaa4x_cylinder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:438b5d9998d1046b4719002bf9c108e1974a56624677995ccd66e5dd57c414ff
-size 382162
+oid sha256:ef3cb1b55c8af667da369c8064c2093617691dca56c6f1043cfaf5c73befac25
+size 382489


### PR DESCRIPTION
There were some changes unrelated to MSAA that invalidated the xshot (lighting changes). Updating the screenshot.

https://jira.agscollab.com/browse/ATOM-15870
