### PR TITLE
Fix padding on RHI sample

### DIFF
--- a/Shaders/RHI/TrianglesConstantBuffer.azsl
+++ b/Shaders/RHI/TrianglesConstantBuffer.azsl
@@ -28,7 +28,8 @@ struct InstanceInfo
     // NOTE: This actually shouldn't be required, but the current validation will give a false positive
     // when the stride isn't the same size as the stride defined on the applicaiton side.
     // This assumes 256 alignment, which is standard for DX12, but is variable in Vulkan
-    float padding0[44]; 
+    float m_padding0[11];
+    float3 m_padding1;
 };
 
 struct InstanceData

--- a/Shaders/RHI/TrianglesConstantBuffer.azsl
+++ b/Shaders/RHI/TrianglesConstantBuffer.azsl
@@ -28,8 +28,7 @@ struct InstanceInfo
     // NOTE: This actually shouldn't be required, but the current validation will give a false positive
     // when the stride isn't the same size as the stride defined on the applicaiton side.
     // This assumes 256 alignment, which is standard for DX12, but is variable in Vulkan
-    float m_padding0[11];
-    float3 m_padding1;
+    float4 m_padding0[11];
 };
 
 struct InstanceData


### PR DESCRIPTION
The padding for this shader was larger than needed. Rewriting the padding so that it actually is 256 bytes. The scene renders fine on both Vulkan/DX12

### RenderDoc Before:
![before](https://user-images.githubusercontent.com/61609885/130541521-56e69634-195d-45e3-ad56-f9388e1c924a.JPG)
### RenderDoc After:
![after](https://user-images.githubusercontent.com/61609885/130541523-74333b79-d715-4f4e-a239-213b88075d06.JPG)

### ShaderPlayground Before
_; cbuffer m_cbuffer
; {
;
;   struct dx.alignment.legacy.m_cbuffer
;   {
;
;       struct dx.alignment.legacy.struct.InstanceInfo
;       {
;
;           column_major float4x4 m_matrix;           ; Offset:    0
;           float4 m_colorMultiplier;                 ; Offset:   64
;           float m_padding0[44];                     ; Offset:   80
;       
;       } m_cbuffer;                                  ; Offset:    0
;
;   
**;   } m_cbuffer;                                      ; Offset:    0 Size:   772**
;
; }_
### ShaderPlayground After:
_; Buffer Definitions:
;
;
; cbuffer m_cb
; {
;
;   struct dx.alignment.legacy.m_cb
;   {
;
;       struct dx.alignment.legacy.struct.InstanceInfo
;       {
;
;           column_major float4x4 m_matrix;           ; Offset:    0
;           float4 m_colorMultiplier;                 ; Offset:   64
;           float4 m_padding0[11];                    ; Offset:   80
;       
;       } m_cb;                                       ; Offset:    0
;
;   
;   } **m_cb;                                           ; Offset:    0 Size:   256**
;
; }