### PR TITLE
[ATOM-16287] Validate Alignment Across All floatNxM Between vulkan & …

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerModule.cpp
+++ b/Gem/Code/Source/AtomSampleViewerModule.cpp
@@ -70,6 +70,7 @@
 #include <RHI/TriangleExampleComponent.h>
 #include <RHI/TrianglesConstantBufferExampleComponent.h>
 #include <RHI/RayTracingExampleComponent.h>
+#include <RHI/MatrixAlignmentTestExampleComponent.h>
 #include <AzFramework/Scene/SceneSystemComponent.h>
 
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h>
@@ -116,7 +117,8 @@ namespace AtomSampleViewer
                 TextureMapExampleComponent::CreateDescriptor(),
                 TriangleExampleComponent::CreateDescriptor(),
                 TrianglesConstantBufferExampleComponent::CreateDescriptor(),
-                RayTracingExampleComponent::CreateDescriptor()
+                RayTracingExampleComponent::CreateDescriptor(),
+                MatrixAlignmentTestExampleComponent::CreateDescriptor()
                 });
 
             // RPI Samples

--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -406,7 +406,7 @@ namespace AtomSampleViewer
         AZ_Error(componentName, shaderInputSamplerIndex->IsValid(), "Failed to find sampler %s.", shaderInputName.GetCStr());
     }
 
-    AZ::Data::Instance<AZ::RPI::Shader> BasicRHIComponent::LoadShader(const char* shaderFilePath, [[maybe_unused]] const char* sampleName)
+    AZ::Data::Instance<AZ::RPI::Shader> BasicRHIComponent::LoadShader(const char* shaderFilePath, [[maybe_unused]] const char* sampleName, const AZ::Name* supervariantName)
     {
         using namespace AZ;
 
@@ -429,40 +429,7 @@ namespace AtomSampleViewer
             return nullptr;
         }
 
-        auto shader = RPI::Shader::FindOrCreate(shaderAsset);
-        if (!shader)
-        {
-            AZ_Error(sampleName, false, "Failed to find or create a shader instance from shader asset '%s'", shaderFilePath);
-            return nullptr;
-        }
-
-        return shader;
-    }
-
-    AZ::Data::Instance<AZ::RPI::Shader> BasicRHIComponent::LoadShader(const char* shaderFilePath, const char* sampleName, const AZ::Name& supervariantName)
-    {
-        using namespace AZ;
-
-        Data::AssetId shaderAssetId;
-        Data::AssetCatalogRequestBus::BroadcastResult(
-            shaderAssetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath,
-            shaderFilePath, azrtti_typeid<RPI::ShaderAsset>(), false);
-        if (!shaderAssetId.IsValid())
-        {
-            AZ_Error(sampleName, false, "Failed to get shader asset id with path %s", shaderFilePath);
-            return nullptr;
-        }
-
-        auto shaderAsset = Data::AssetManager::Instance().GetAsset<RPI::ShaderAsset>(
-            shaderAssetId, AZ::Data::AssetLoadBehavior::PreLoad);
-        shaderAsset.BlockUntilLoadComplete();
-        if (!shaderAsset.IsReady())
-        {
-            AZ_Error(sampleName, false, "Failed to get shader asset with path %s", shaderFilePath);
-            return nullptr;
-        }
-
-        auto shader = RPI::Shader::FindOrCreate(shaderAsset, supervariantName);
+        auto shader = RPI::Shader::FindOrCreate(shaderAsset, (supervariantName != nullptr) ? *supervariantName : AZ::Name{""});
         if (!shader)
         {
             AZ_Error(sampleName, false, "Failed to find or create a shader instance from shader asset '%s'", shaderFilePath);

--- a/Gem/Code/Source/RHI/BasicRHIComponent.h
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.h
@@ -152,8 +152,7 @@ namespace AtomSampleViewer
         AZ::Matrix4x4 CreateViewMatrix(AZ::Vector3 eye, AZ::Vector3 up, AZ::Vector3 lookAt);
 
         // Shader
-        AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const char* shaderFilePath, const char* sampleName);
-        AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const char* shaderFilePath, const char* sampleName, const AZ::Name& supervariantName);
+        AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const char* shaderFilePath, const char* sampleName, const AZ::Name* supervariantName = nullptr);
         AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const AZ::AssetCollectionAsyncLoader& assetLoadMgr, const char* shaderFilePath, const char* sampleName);
         static AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> CreateShaderResourceGroup(AZ::Data::Instance<AZ::RPI::Shader> shader, const char* shaderResourceGroupId, const char* sampleName);
 

--- a/Gem/Code/Source/RHI/BasicRHIComponent.h
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.h
@@ -153,6 +153,7 @@ namespace AtomSampleViewer
 
         // Shader
         AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const char* shaderFilePath, const char* sampleName);
+        AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const char* shaderFilePath, const char* sampleName, const AZ::Name& supervariantName);
         AZ::Data::Instance<AZ::RPI::Shader> LoadShader(const AZ::AssetCollectionAsyncLoader& assetLoadMgr, const char* shaderFilePath, const char* sampleName);
         static AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> CreateShaderResourceGroup(AZ::Data::Instance<AZ::RPI::Shader> shader, const char* shaderResourceGroupId, const char* sampleName);
 

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RHI/MatrixAlignmentTestExampleComponent.h>
+#include <Utils/Utils.h>
+
+#include <SampleComponentManager.h>
+
+#include <Atom/RHI/CommandList.h>
+#include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
+#include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AtomSampleViewer
+{
+    void MatrixAlignmentTestExampleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MatrixAlignmentTestExampleComponent, AZ::Component>()
+                ->Version(0)
+                ;
+        }
+    }
+
+    void MatrixAlignmentTestExampleComponent::OnTick([[maybe_unused]] float deltaTime, AZ::ScriptTimePoint time)
+    {
+        AZ_UNUSED(time);
+
+        bool numFloatsChanged = false;
+
+        if (m_imguiSidebar.Begin())
+        {
+            ImGui::Spacing();
+
+            ImGui::Text("Number Of Rows");
+            ScriptableImGui::RadioButton("1##R1", &m_numRows, 1);
+            ImGui::SameLine();       
+            ScriptableImGui::RadioButton("2##R2", &m_numRows, 2);
+            ImGui::SameLine();       
+            ScriptableImGui::RadioButton("3##R3", &m_numRows, 3);
+            ImGui::SameLine();       
+            ScriptableImGui::RadioButton("4##R4", &m_numRows, 4);
+
+            ImGui::Spacing();
+
+            ImGui::Text("Number Of Columns");
+            ScriptableImGui::RadioButton("1##C1", &m_numColumns, 1);
+            ImGui::SameLine();
+            ScriptableImGui::RadioButton("2##C2", &m_numColumns, 2);
+            ImGui::SameLine();
+            ScriptableImGui::RadioButton("3##C3", &m_numColumns, 3);
+            ImGui::SameLine();
+            ScriptableImGui::RadioButton("4##C4", &m_numColumns, 4);
+
+            ImGui::Spacing();
+
+            ImGui::Text("Checked Location Value:");
+            ScriptableImGui::SliderFloat("##CheckedLocationValue", &m_matrixLocationValue, 0.f, 1.f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+            ImGui::Text("Unchecked Location Value: ");
+            ImGui::Text("%.1f", 1.0f - m_matrixLocationValue);
+
+            DrawMatrixValuesTable();
+
+            ImGui::Spacing();
+
+            ImGui::Text("Data After Matrix:");
+            numFloatsChanged |= ScriptableImGui::RadioButton("float", &m_numFloatsAfterMatrix, 1);
+            ImGui::SameLine();       
+            numFloatsChanged |= ScriptableImGui::RadioButton("float2", &m_numFloatsAfterMatrix, 2);
+
+            ImGui::Text("float value:");
+            ScriptableImGui::SliderFloat("##FloatAfterMatrix", &m_floatAfterMatrix, 0.f, 1.f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+
+            m_imguiSidebar.End();
+        }
+
+        if (numFloatsChanged)
+        {
+            m_needPipelineReload = true;
+        }
+    }
+
+    void MatrixAlignmentTestExampleComponent::DrawMatrixValuesTable()
+    {
+        const auto flags = ImGuiTableFlags_Borders;
+        if (ImGui::BeginTable("Matrix Data", m_numColumns + 1, flags))
+        {
+            // Table header setup
+            ImGui::TableSetupColumn("R\\C");
+            for (int col = 0; col < m_numColumns; ++col)
+            {
+                AZStd::string colName = AZStd::string::format("C%d", col);
+                ImGui::TableSetupColumn(colName.c_str());
+            }
+            ImGui::TableHeadersRow();
+            for (int row = 0; row < m_numRows; ++row)
+            {
+                for (int col = 0; col < m_numColumns + 1; ++col)
+                {
+                    ImGui::TableNextColumn();
+                    if (col == 0)
+                    {
+                        ImGui::Text("R%d", row);
+                    }
+                    else
+                    {
+                        AZStd::string cellId = AZStd::string::format("##R%dC%d", row, col-1);
+                        ScriptableImGui::Checkbox(cellId.c_str(), &m_checkedMatrixValues[row][col-1]);
+                    }
+                }
+            }
+            ImGui::EndTable();
+        }
+    }
+
+    void MatrixAlignmentTestExampleComponent::FrameBeginInternal([[maybe_unused]] AZ::RHI::FrameGraphBuilder& frameGraphBuilder)
+    {
+        if (m_needPipelineReload)
+        {
+            ReleaseRhiData();
+            InitializeRenderPipeline();
+        }
+    }
+
+    bool MatrixAlignmentTestExampleComponent::SetSrgMatrixData(int numRows, int numColumns,
+        const AZ::RHI::ShaderInputConstantIndex& dataAfterMatrixConstantId,
+        const AZ::RHI::ShaderInputConstantIndex& matrixConstantId)
+    {
+        if ((m_numRows != numRows) || (m_numColumns != numColumns))
+        {
+            return false;
+        }
+        if (!dataAfterMatrixConstantId.IsValid() || !matrixConstantId.IsValid())
+        {
+            return false;
+        }
+        // Always set the float first, this way if there are alignment issues We'll notice the unexpected
+        // colors
+        bool success = false;
+
+        if (m_numFloatsAfterMatrix == 1)
+        {
+            success = m_shaderResourceGroup->SetConstant(dataAfterMatrixConstantId, m_floatAfterMatrix);
+        }
+        else
+        {
+            AZ::Vector2 float2(m_floatAfterMatrix, m_floatAfterMatrix);
+            success = m_shaderResourceGroup->SetConstant(dataAfterMatrixConstantId, float2);
+        }
+        AZ_Warning("MatrixAlignmentTestExampleComponent", success, "Failed to set SRG Constant m_fAfter%d%d", numRows, numColumns);
+
+        constexpr size_t SizeOfFloat4 = sizeof(float) * 4;
+        constexpr size_t SizeOfFloat = sizeof(float);
+        uint32_t numBytes = (SizeOfFloat4 * numRows) - ((4 - numColumns) * SizeOfFloat); 
+        success = m_shaderResourceGroup->SetConstantRaw(matrixConstantId, m_rawMatrix, numBytes);
+        AZ_Warning("MatrixAlignmentTestExampleComponent", success, "Failed to set SRG Constant m_matrix%d%d", numRows, numColumns);
+
+        return true;
+    }
+
+    void MatrixAlignmentTestExampleComponent::OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder)
+    {
+        using namespace AZ;
+
+        {
+            AZ::Vector4 screenResolution(GetViewportWidth(), GetViewportHeight(), 0, 0);
+            [[maybe_unused]] bool success = m_shaderResourceGroup->SetConstant(m_resolutionConstantIndex, screenResolution);
+            AZ_Warning("MatrixAlignmentTestExampleComponent", success, "Failed to set SRG Constant m_resolution");
+
+            success = m_shaderResourceGroup->SetConstant(m_numRowsConstantIndex, m_numRows);
+            AZ_Warning("MatrixAlignmentTestExampleComponent", success, "Failed to set SRG Constant m_numRows");
+
+            success = m_shaderResourceGroup->SetConstant(m_numColumnsConstantIndex, m_numColumns);
+            AZ_Warning("MatrixAlignmentTestExampleComponent", success, "Failed to set SRG Constant m_numColumns");
+
+            for (int row = 0; row < m_numRows; ++row)
+            {
+                for (int col = 0; col < m_numColumns; ++col)
+                {
+                    m_rawMatrix[row][col] = m_checkedMatrixValues[row][col] ? m_matrixLocationValue : 1.0f - m_matrixLocationValue;
+                }
+            }
+
+            if      (  SetSrgMatrixData(1, 1, m_fAfter11ConstantIndex, m_matrix11ConstantIndex)) {}
+            else if (  SetSrgMatrixData(1, 2, m_fAfter12ConstantIndex, m_matrix12ConstantIndex)) {}
+            else if (  SetSrgMatrixData(1, 3, m_fAfter13ConstantIndex, m_matrix13ConstantIndex)) {}
+            else if (  SetSrgMatrixData(1, 4, m_fAfter14ConstantIndex, m_matrix14ConstantIndex)) {}
+            //else if (SetSrgMatrixData(2, 1, m_fAfter21ConstantIndex, m_matrix21ConstantIndex)) {} //Not supported by AZSLc
+            else if (  SetSrgMatrixData(2, 2, m_fAfter22ConstantIndex, m_matrix22ConstantIndex)) {}
+            else if (  SetSrgMatrixData(2, 3, m_fAfter23ConstantIndex, m_matrix23ConstantIndex)) {}
+            else if (  SetSrgMatrixData(2, 4, m_fAfter24ConstantIndex, m_matrix24ConstantIndex)) {}
+            //else if (SetSrgMatrixData(3, 1, m_fAfter31ConstantIndex, m_matrix31ConstantIndex)) {} //Not supported by AZSLc
+            else if (  SetSrgMatrixData(3, 2, m_fAfter32ConstantIndex, m_matrix32ConstantIndex)) {}
+            else if (  SetSrgMatrixData(3, 3, m_fAfter33ConstantIndex, m_matrix33ConstantIndex)) {}
+            else if (  SetSrgMatrixData(3, 4, m_fAfter34ConstantIndex, m_matrix34ConstantIndex)) {}
+            //else if (SetSrgMatrixData(4, 1, m_fAfter41ConstantIndex, m_matrix41ConstantIndex)) {} //Not supported by AZSLc
+            else if (  SetSrgMatrixData(4, 2, m_fAfter42ConstantIndex, m_matrix42ConstantIndex)) {}
+            else if (  SetSrgMatrixData(4, 3, m_fAfter43ConstantIndex, m_matrix43ConstantIndex)) {}
+            else if (  SetSrgMatrixData(4, 4, m_fAfter44ConstantIndex, m_matrix44ConstantIndex)) {}
+
+            m_shaderResourceGroup->Compile();
+        }
+
+        BasicRHIComponent::OnFramePrepare(frameGraphBuilder);
+    }
+
+    MatrixAlignmentTestExampleComponent::MatrixAlignmentTestExampleComponent()
+    {
+        m_supportRHISamplePipeline = true;
+    }
+
+    void MatrixAlignmentTestExampleComponent::InitializeRenderPipeline()
+    {
+        using namespace AZ;
+
+        RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
+
+        AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
+
+        {
+            m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
+            bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
+            m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+
+            BufferData bufferData;
+
+            SetFullScreenRect(bufferData.m_positions.data(), nullptr, bufferData.m_indices.data());
+
+            // All blue.
+            SetVertexColor(bufferData.m_colors.data(), 0, 0.0, 0.0, 1.0, 1.0);
+            SetVertexColor(bufferData.m_colors.data(), 1, 0.0, 0.0, 1.0, 1.0);
+            SetVertexColor(bufferData.m_colors.data(), 2, 0.0, 0.0, 1.0, 1.0);
+            SetVertexColor(bufferData.m_colors.data(), 3, 0.0, 0.0, 1.0, 1.0);
+
+            m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+
+            RHI::BufferInitRequest request;
+            request.m_buffer = m_inputAssemblyBuffer.get();
+            request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
+            request.m_initialData = &bufferData;
+            m_inputAssemblyBufferPool->InitBuffer(request);
+
+            m_streamBufferViews[0] =
+            {
+                *m_inputAssemblyBuffer,
+                offsetof(BufferData, m_positions),
+                sizeof(BufferData::m_positions),
+                sizeof(VertexPosition)
+            };
+
+            m_streamBufferViews[1] =
+            {
+                *m_inputAssemblyBuffer,
+                offsetof(BufferData, m_colors),
+                sizeof(BufferData::m_colors),
+                sizeof(VertexColor)
+            };
+
+            RHI::InputStreamLayoutBuilder layoutBuilder;
+            layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
+            layoutBuilder.AddBuffer()->Channel("COLOR", RHI::Format::R32G32B32A32_FLOAT);
+            pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
+
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+        }
+
+        {
+            const char* triangeShaderFilePath = "Shaders/RHI/MatrixAlignmentTest.azshader";
+            const char* sampleName = "MatrixAlignmentTest";
+
+            const AZ::Name supervariantName = (m_numFloatsAfterMatrix == 1) ? AZ::Name{""} : AZ::Name{"float2"}; 
+            auto shader = LoadShader(triangeShaderFilePath, sampleName, supervariantName);
+            if (shader == nullptr)
+                return;
+
+            auto shaderVariant = shader->GetRootVariant();
+
+            shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
+
+            RHI::RenderAttachmentLayoutBuilder attachmentsBuilder;
+            attachmentsBuilder.AddSubpass()
+                ->RenderTargetAttachment(m_outputFormat);
+            [[maybe_unused]] AZ::RHI::ResultCode result = attachmentsBuilder.End(pipelineStateDescriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout);
+            AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
+
+            m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
+            if (!m_pipelineState)
+            {
+                AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", triangeShaderFilePath);
+                return;
+            }
+
+            m_shaderResourceGroup = CreateShaderResourceGroup(shader, "AlignmentValidatorSrg", sampleName);
+
+            const Name resolutionConstantId{ "m_resolution" };
+            FindShaderInputIndex(&m_resolutionConstantIndex, m_shaderResourceGroup, resolutionConstantId, sampleName);
+
+            const Name rowSelectionConstantId{ "m_numRows" };
+            FindShaderInputIndex(&m_numRowsConstantIndex, m_shaderResourceGroup, rowSelectionConstantId, sampleName);
+
+            const Name colSelectionConstantId{ "m_numColumns" };
+            FindShaderInputIndex(&m_numColumnsConstantIndex, m_shaderResourceGroup, colSelectionConstantId, sampleName);
+
+            {
+                const Name MatrixName{ "m_matrix11" };
+                FindShaderInputIndex(&m_matrix11ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter11" };
+                FindShaderInputIndex(&m_fAfter11ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix12" };
+                FindShaderInputIndex(&m_matrix12ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter12" };
+                FindShaderInputIndex(&m_fAfter12ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix13" };
+                FindShaderInputIndex(&m_matrix13ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter13" };
+                FindShaderInputIndex(&m_fAfter13ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix14" };
+                FindShaderInputIndex(&m_matrix14ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter14" };
+                FindShaderInputIndex(&m_fAfter14ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            // Not supported by AZSLc
+            //{
+            //    const Name MatrixName{ "m_matrix21" };
+            //    FindShaderInputIndex(&m_matrix21ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+            //    const Name floatAfterMatrixName{ "m_fAfter21" };
+            //    FindShaderInputIndex(&m_fAfter21ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            //}
+
+            {
+                const Name MatrixName{ "m_matrix22" };
+                FindShaderInputIndex(&m_matrix22ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter22" };
+                FindShaderInputIndex(&m_fAfter22ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix23" };
+                FindShaderInputIndex(&m_matrix23ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter23" };
+                FindShaderInputIndex(&m_fAfter23ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix24" };
+                FindShaderInputIndex(&m_matrix24ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter24" };
+                FindShaderInputIndex(&m_fAfter24ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            // Not supported by AZSLc
+            //{
+            //    const Name MatrixName{ "m_matrix31" };
+            //    FindShaderInputIndex(&m_matrix31ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+            //    const Name floatAfterMatrixName{ "m_fAfter31" };
+            //    FindShaderInputIndex(&m_fAfter31ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            //}
+
+            {
+                const Name MatrixName{ "m_matrix32" };
+                FindShaderInputIndex(&m_matrix32ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter32" };
+                FindShaderInputIndex(&m_fAfter32ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix33" };
+                FindShaderInputIndex(&m_matrix33ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter33" };
+                FindShaderInputIndex(&m_fAfter33ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix34" };
+                FindShaderInputIndex(&m_matrix34ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter34" };
+                FindShaderInputIndex(&m_fAfter34ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            // Not supported by AZSLc
+            //{
+            //    const Name MatrixName{ "m_matrix41" };
+            //    FindShaderInputIndex(&m_matrix41ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+            //    const Name floatAfterMatrixName{ "m_fAfter41" };
+            //    FindShaderInputIndex(&m_fAfter41ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            //}
+
+            {
+                const Name MatrixName{ "m_matrix42" };
+                FindShaderInputIndex(&m_matrix42ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter42" };
+                FindShaderInputIndex(&m_fAfter42ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix43" };
+                FindShaderInputIndex(&m_matrix43ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter43" };
+                FindShaderInputIndex(&m_fAfter43ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+            {
+                const Name MatrixName{ "m_matrix44" };
+                FindShaderInputIndex(&m_matrix44ConstantIndex, m_shaderResourceGroup, MatrixName, sampleName);
+                const Name floatAfterMatrixName{ "m_fAfter44" };
+                FindShaderInputIndex(&m_fAfter44ConstantIndex, m_shaderResourceGroup, floatAfterMatrixName, sampleName);
+            }
+
+        }
+
+        // Creates a scope for rendering the triangle.
+        {
+            struct ScopeData
+            {
+            };
+
+            const auto prepareFunction = [this](RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
+            {
+                // Binds the swap chain as a color attachment. Clears it to white.
+                {
+                    RHI::ImageScopeAttachmentDescriptor descriptor;
+                    descriptor.m_attachmentId = m_outputAttachmentId;
+                    descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
+                    frameGraph.UseColorAttachment(descriptor);
+                }
+
+                // We will submit a single draw item.
+                frameGraph.SetEstimatedItemCount(1);
+            };
+
+            RHI::EmptyCompileFunction<ScopeData> compileFunction;
+
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            {
+                RHI::CommandList* commandList = context.GetCommandList();
+
+                // Set persistent viewport and scissor state.
+                commandList->SetViewports(&m_viewport, 1);
+                commandList->SetScissors(&m_scissor, 1);
+
+                const RHI::IndexBufferView indexBufferView =
+                {
+                    *m_inputAssemblyBuffer,
+                    offsetof(BufferData, m_indices),
+                    sizeof(BufferData::m_indices),
+                    RHI::IndexFormat::Uint16
+                };
+
+                RHI::DrawIndexed drawIndexed;
+                drawIndexed.m_indexCount = 6;
+                drawIndexed.m_instanceCount = 2;
+
+                const RHI::ShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+
+                RHI::DrawItem drawItem;
+                drawItem.m_arguments = drawIndexed;
+                drawItem.m_pipelineState = m_pipelineState.get();
+                drawItem.m_indexBufferView = &indexBufferView;
+                drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
+                drawItem.m_shaderResourceGroups = shaderResourceGroups;
+                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
+                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+
+                // Submit the triangle draw item.
+                commandList->Submit(drawItem);
+            };
+
+            m_scopeProducers.emplace_back(
+                aznew RHI::ScopeProducerFunction<
+                ScopeData,
+                decltype(prepareFunction),
+                decltype(compileFunction),
+                decltype(executeFunction)>(
+                    RHI::ScopeId{"Triangle"},
+                    ScopeData{},
+                    prepareFunction,
+                    compileFunction,
+                    executeFunction));
+        }
+
+        m_needPipelineReload = false;
+    }
+
+    void MatrixAlignmentTestExampleComponent::Activate()
+    {
+        using namespace AZ;
+
+        m_numRows = 4;
+        m_numColumns = 4;
+        m_matrixLocationValue = 1.0f;
+        m_checkedMatrixValues[0][0] = true;  m_checkedMatrixValues[0][1] = false; m_checkedMatrixValues[0][2] = true;  m_checkedMatrixValues[0][3] = false;
+        m_checkedMatrixValues[1][0] = false; m_checkedMatrixValues[1][1] = true;  m_checkedMatrixValues[1][2] = false; m_checkedMatrixValues[1][3] = true;
+        m_checkedMatrixValues[2][0] = true;  m_checkedMatrixValues[2][1] = false; m_checkedMatrixValues[2][2] = true;  m_checkedMatrixValues[2][3] = false;
+        m_checkedMatrixValues[3][0] = false; m_checkedMatrixValues[3][1] = true;  m_checkedMatrixValues[3][2] = false; m_checkedMatrixValues[3][3] = true;
+
+        m_numFloatsAfterMatrix = 1;
+        m_floatAfterMatrix = 0.5;
+
+        m_needPipelineReload = true;
+
+        InitializeRenderPipeline();
+
+        m_imguiSidebar.Activate();
+        AZ::RHI::RHISystemNotificationBus::Handler::BusConnect();
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void MatrixAlignmentTestExampleComponent::ReleaseRhiData()
+    {
+        m_inputAssemblyBuffer = nullptr;
+        m_inputAssemblyBufferPool = nullptr;
+        m_pipelineState = nullptr;
+        m_shaderResourceGroup = nullptr;
+        m_scopeProducers.clear();
+    }
+
+    void MatrixAlignmentTestExampleComponent::Deactivate()
+    {
+        m_inputAssemblyBuffer = nullptr;
+        m_inputAssemblyBufferPool = nullptr;
+        m_pipelineState = nullptr;
+        m_shaderResourceGroup = nullptr;
+
+        AZ::TickBus::Handler::BusDisconnect();
+        AZ::RHI::RHISystemNotificationBus::Handler::BusDisconnect();
+        m_imguiSidebar.Deactivate();
+
+        m_windowContext = nullptr;
+        m_scopeProducers.clear();
+    }
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -30,10 +30,8 @@ namespace AtomSampleViewer
         }
     }
 
-    void MatrixAlignmentTestExampleComponent::OnTick([[maybe_unused]] float deltaTime, AZ::ScriptTimePoint time)
+    void MatrixAlignmentTestExampleComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
-        AZ_UNUSED(time);
-
         bool numFloatsChanged = false;
 
         if (m_imguiSidebar.Begin())
@@ -280,7 +278,7 @@ namespace AtomSampleViewer
             const char* sampleName = "MatrixAlignmentTest";
 
             const AZ::Name supervariantName = (m_numFloatsAfterMatrix == 1) ? AZ::Name{""} : AZ::Name{"float2"}; 
-            auto shader = LoadShader(triangeShaderFilePath, sampleName, supervariantName);
+            auto shader = LoadShader(triangeShaderFilePath, sampleName, &supervariantName);
             if (shader == nullptr)
                 return;
 

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzCore/Component/TickBus.h>
+
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+
+#include <Atom/RHI/FrameScheduler.h>
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
+
+#include <RHI/BasicRHIComponent.h>
+
+#include <Utils/ImGuiSidebar.h>
+
+namespace AtomSampleViewer
+{
+    /*
+    * An example that renders the content a chosen RxC matrix followed by float or float2 scalar.
+    * It renders those values as a grid of size (R+1)x(C+1) when Coordinates 0..R-1, 0..C-1 contain the
+    * a Gray value R,G,B where R==G==B==m_matrix<R><C>[r][c]. m_matrix<R><C> is a variable in the SRG Constant Buffer.
+    * The cell coordinate [R][C] contains the color of another SRG constant called m_fAfter<R><C> which can be a "float"
+    * or a "float2".
+    * The rendered grid shows an intuitive image that can be used to catch if a given RHI has data offsets or alignment issues
+    * in the SRG Constant Buffer.
+    */
+    class MatrixAlignmentTestExampleComponent final
+        : public BasicRHIComponent
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(MatrixAlignmentTestExampleComponent, "{194CEF1E-5F35-4179-AB8F-0A4D3831377A}", AZ::Component);
+        AZ_DISABLE_COPY(MatrixAlignmentTestExampleComponent);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        MatrixAlignmentTestExampleComponent();
+        ~MatrixAlignmentTestExampleComponent() override = default;
+
+    private:
+        static constexpr char LogName[] = "MatrixAlignmentTest";
+
+    protected:
+
+        //! Releases render pipeline data. Should be used before calling InitializeRenderPipeline();
+        void ReleaseRhiData();
+
+        void InitializeRenderPipeline();
+
+        // BasicRHIComponent
+        void Activate() override;
+        void Deactivate() override;
+        void FrameBeginInternal(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
+
+        // TickBus::Handler
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+
+        // RHISystemNotificationBus::Handler
+        void OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
+
+        // Helpers
+         
+        //! An ImGui function that renders a table of checkboxes based on the values
+        //! stored in @m_checkedMatrixValues.
+        void DrawMatrixValuesTable();
+
+        //! Sets the correct SRG matrix & float (or float2) with data
+        //! based on the selected number of rows, @numRows, and columns, @numColumns.
+        bool SetSrgMatrixData(int numRows, int numColumns,
+            const AZ::RHI::ShaderInputConstantIndex& dataAfterMatrixConstantId,
+            const AZ::RHI::ShaderInputConstantIndex& matrixConstantId);
+
+
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
+
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
+
+        AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
+
+        AZ::RHI::ShaderInputConstantIndex m_resolutionConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_numRowsConstantIndex;
+        int m_numRows;
+
+        AZ::RHI::ShaderInputConstantIndex m_numColumnsConstantIndex;
+        int m_numColumns;
+
+        bool  m_checkedMatrixValues[4][4];
+        float m_rawMatrix[4][4];
+        float m_floatAfterMatrix; // The value is controlled by an ImGui slider. [0.0f .. 1.0f]
+
+        // Controlled by a Radio Button. Takes value 1 or 2.
+        // Value 1 means to pick the Supervariant where the data after the matrix is of type float.
+        // Value 2 means to pick the Supervariant where the data after the matrix is of type float2.
+        int   m_numFloatsAfterMatrix;
+        bool m_needPipelineReload; // Only true when @m_numFloatsAfterMatrix changes.
+
+        // A value in the range [0.0..1.0]
+        // This variable gets the value of an ImGui Slider.
+        // When the user enables the checkbox at any given matrix location
+        // in the ImGui UI, then
+        // @m_rawMatrix[R][C] = @m_checkedMatrixLocationValue.
+        // When the user un-checks the checkbox then
+        // @m_rawMatrix[R][C] = 1.0 - m_checkedMatrixLocationValue.
+        float m_matrixLocationValue;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix11ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter11ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix12ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter12ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix13ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter13ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix14ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter14ConstantIndex;
+
+        // Not supported by AZSLc
+        //AZ::RHI::ShaderInputConstantIndex m_matrix21ConstantIndex;
+        //AZ::RHI::ShaderInputConstantIndex m_fAfter21ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix22ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter22ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix23ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter23ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix24ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter24ConstantIndex;
+
+        // Not supported by AZSLc
+        //AZ::RHI::ShaderInputConstantIndex m_matrix31ConstantIndex;
+        //AZ::RHI::ShaderInputConstantIndex m_fAfter31ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix32ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter32ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix33ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter33ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix34ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter34ConstantIndex;
+
+        // Not supported by AZSLc
+        //AZ::RHI::ShaderInputConstantIndex m_matrix41ConstantIndex;
+        //AZ::RHI::ShaderInputConstantIndex m_fAfter41ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix42ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter42ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix43ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter43ConstantIndex;
+
+        AZ::RHI::ShaderInputConstantIndex m_matrix44ConstantIndex;
+        AZ::RHI::ShaderInputConstantIndex m_fAfter44ConstantIndex;
+
+
+        // Required data to render two triangles that cover the whole viewport.
+        struct BufferData
+        {
+            AZStd::array<VertexPosition, 4> m_positions;
+            AZStd::array<VertexColor, 4> m_colors;
+            AZStd::array<uint16_t, 6> m_indices;
+        };
+
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::DrawItem m_drawItem;
+
+        // ImGui stuff.
+        ImGuiSidebar m_imguiSidebar;
+    };
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -63,6 +63,7 @@
 #include <RHI/TrianglesConstantBufferExampleComponent.h>
 #include <RHI/BindlessPrototypeExampleComponent.h>
 #include <RHI/RayTracingExampleComponent.h>
+#include <RHI/MatrixAlignmentTestExampleComponent.h>
 
 #include <AreaLightExampleComponent.h>
 #include <AssetLoadTestComponent.h>
@@ -259,6 +260,7 @@ namespace AtomSampleViewer
         SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRHISample( "RHI/TextureMap", azrtti_typeid<TextureMapExampleComponent>() ));
         SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRHISample( "RHI/Triangle", azrtti_typeid<TriangleExampleComponent>() ));
         SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRHISample( "RHI/TrianglesConstantBuffer", azrtti_typeid<TrianglesConstantBufferExampleComponent>() ));
+        SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRHISample( "RHI/MatrixAlignmentTest", azrtti_typeid<MatrixAlignmentTestExampleComponent>() ));
         SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRPISample( "RPI/AssetLoadTest", azrtti_typeid<AssetLoadTestComponent>() ));
         SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRPISample( "RPI/AuxGeom", azrtti_typeid<AuxGeomExampleComponent>() ));
         SampleComponentManager::RegisterSampleComponent(SampleEntry::NewRPISample( "RPI/BakedShaderVariant", azrtti_typeid<BakedShaderVariantExampleComponent>() ));

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -80,6 +80,8 @@ set(FILES
     Source/RHI/TrianglesConstantBufferExampleComponent.cpp
     Source/RHI/RayTracingExampleComponent.cpp
     Source/RHI/RayTracingExampleComponent.h
+    Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+    Source/RHI/MatrixAlignmentTestExampleComponent.h
     Source/AreaLightExampleComponent.cpp
     Source/AreaLightExampleComponent.h
     Source/AssetLoadTestComponent.cpp

--- a/Shaders/RHI/MatrixAlignmentTest.azsl
+++ b/Shaders/RHI/MatrixAlignmentTest.azsl
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+ /*
+    This shader is used to graphically validate data offsets correctness when
+    floatRxC matrices are followed by float or float2 variables
+    in structs/classes/SRGs.
+
+    This shader was created in response to the problem that DXC, when
+    generating Spirv code, was not generating the expected data offsets
+    with the command line argument -fvk-use-dx-layout.
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+// Defined in the supervariant.
+#ifndef NUM_FLOATS_AFTER_MATRIX
+#define NUM_FLOATS_AFTER_MATRIX 1
+#endif
+
+#define GET_COLOR_TEMPLATE(TheMatrix, r, g, b) \
+        int row = 0; \
+        int col = 0 ; \
+        bool isBottomRightCorner = false; \
+        if (GetMatrixLocationFromPixel(pixelCoord, row, col, isBottomRightCorner)) \
+        { \
+            float componentColor = TheMatrix[row][col]; \
+            return float4(componentColor, componentColor, componentColor, 1.0); \
+        } \
+        if (isBottomRightCorner) \
+        { \
+            return float4(r, g, b, 1.0); \
+        } \
+        return defaultColor;
+
+ShaderResourceGroup AlignmentValidatorSrg : SRG_PerDraw
+{
+    // Viewport resolution (in pixels).
+    // .x,.y are width and height respectively.
+    // .z,.w do not matter
+    float4 m_resolution;
+
+    // Based on the value of these two variables We pick which matrix
+    // to use to generate the color grid.
+    // For example:
+    // If m_numRows == 3 && m_numColumns == 2
+    // We draw a 3x2 grid where each cell gets a shade of gray color
+    // as m_matrix32[r][c].
+    // Another example:
+    // If m_numRows == 2 && m_numColumns == 4
+    // We draw a 2x4 grid where each cell gets a shade of gray color
+    // as m_matrix24[r][c].
+    int m_numRows;
+    int m_numColumns;
+
+    float4 __reserved; // Keep this here for alignment.
+
+    // All RxC 
+    
+    // 1xC
+    float1x1 m_matrix11;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter11;
+#else
+    float2 m_fAfter11;
+#endif
+    float4 __reserved11; // Used to force 16 byte boundary
+
+    float1x2 m_matrix12;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter12;
+#else
+    float2 m_fAfter12;
+#endif
+    float4 __reserved12; // Used to force 16 byte boundary 
+    
+    float1x3 m_matrix13;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter13;
+#else
+    float2 m_fAfter13;
+#endif
+    float4 __reserved13; // Used to force 16 byte boundary 
+    
+    float1x4 m_matrix14;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter14;
+#else
+    float2 m_fAfter14;
+#endif
+    float4 __reserved14; // Used to force 16 byte boundary
+    
+    // 2xC
+    // AZSLc: PackAsVectorMatrix: row_major packing for 2x1, 3x1 and 4x1 matrix types is not allowed!
+    // float2x1 m_matrix21;
+    // float m_fAfter21;
+    // float4 __reserved21; // Used to force 16 byte boundary
+    
+    float2x2 m_matrix22;
+    // This case is broken in vulkan. Add float3 padding or use AZSLc 1.7.26+ for automatic float3 padding.
+    float3 __padding22;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter22;
+#else
+    float2 m_fAfter22;
+#endif
+    float4 __reserved22; // Used to force 16 byte boundary 
+    
+    // This case is broken in vulkan. Add float2 padding or use AZSLc 1.7.26+ for automatic float2 padding.
+    float2x3 m_matrix23;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float2 __padding23;
+    float m_fAfter23;
+#else
+    float2 m_fAfter23;
+#endif
+    float4 __reserved23; // Used to force 16 byte boundary 
+    
+    float2x4 m_matrix24;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter24;
+#else
+    float2 m_fAfter24;
+#endif
+    float4 __reserved24; // Used to force 16 byte boundary
+    
+    // 3xC
+    //AZSLc: PackAsVectorMatrix: row_major packing for 2x1, 3x1 and 4x1 matrix types is not allowed!
+    //float3x1 m_matrix31;
+    //float m_fAfter31;
+    //float4 __reserved31; // Used to force 16 byte boundary
+    
+    float3x2 m_matrix32;
+    // This case is broken in vulkan. Add float3 padding or use AZSLc 1.7.26+ for automatic float3 padding.
+    float3 __padding32;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter32;
+#else
+    float2 m_fAfter32;
+#endif
+    float4 __reserved32; // Used to force 16 byte boundary 
+
+    float3x3 m_matrix33;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    // This case is broken in vulkan. Add float2 padding or use AZSLc 1.7.26+ for automatic float2 padding.
+    float2 __padding33;
+    float m_fAfter33;
+#else
+    float2 m_fAfter33;
+#endif
+    float4 __reserved33; // Used to force 16 byte boundary 
+    
+    float3x4 m_matrix34;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter34;
+#else
+    float2 m_fAfter34;
+#endif
+    float4 __reserved34; // Used to force 16 byte boundary 
+    
+    // 4xC
+    //AZSLc: PackAsVectorMatrix: row_major packing for 2x1, 3x1 and 4x1 matrix types is not allowed!
+    //float4x1 m_matrix41;
+    //float m_fAfter41;
+    //float4 __reserved41; // Used to force 16 byte boundary
+    
+    float4x2 m_matrix42;
+    // This case is broken in vulkan. Add float3 padding or use AZSLc 1.7.26+ for automatic float3 padding.
+    float3 __padding42;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter42;
+#else
+    float2 m_fAfter42;
+#endif
+    float4 __reserved42; // Used to force 16 byte boundary 
+    
+    // This case is broken in vulkan. Add float2 padding or use AZSLc 1.7.26+ for automatic float2 padding.
+    float4x3 m_matrix43;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float2 __padding43;
+    float m_fAfter43;
+#else
+    float2 m_fAfter43;    
+#endif
+    float4 __reserved43; // Used to force 16 byte boundary 
+    
+    float4x4 m_matrix44;
+#if NUM_FLOATS_AFTER_MATRIX == 1
+    float m_fAfter44;
+#else
+    float2 m_fAfter44;   
+#endif
+    float4 __reserved44; // Used to force 16 byte boundary
+
+    // Returns true if the normalized pixel coordinate @pixelCoord falls inside a @row, @col cell whose coordinate is safe to use to fetch data from one of the @m_matrix<row><col> variables.
+    // Otherwise returns false.
+    // In addition when returning false, @isBottomRightCorner becomes true if the bottom right corner is being rendered.
+    // In such case the respective float or float2 variable @m_fAfter should be used to pick the color of the
+    // bottom right corner.
+    bool GetMatrixLocationFromPixel(float2 pixelCoord, out int row, out int col, out bool isBottomRightCorner)
+    {
+        const int clampedRowSelection = clamp(m_numRows, 1, 4);
+        const int clampedColSelection = clamp(m_numColumns, 1, 4);
+
+        const float NumRows =  clampedRowSelection + 1;
+        const float NumColumns = clampedColSelection + 1;
+        
+        row = floor(NumRows * pixelCoord.y);
+        col = floor(NumColumns * pixelCoord.x);
+
+        isBottomRightCorner = false;
+        if ((row < clampedRowSelection) && (col < clampedColSelection))
+        {
+            return true;
+        }
+
+        if ((row >= clampedRowSelection) && (col >= clampedColSelection))
+        {
+            isBottomRightCorner = true;
+        }
+
+        return false;
+    }
+
+    float4 GetColor11(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix11, m_fAfter11, m_fAfter11, m_fAfter11);
+#else
+        GET_COLOR_TEMPLATE(m_matrix11, m_fAfter11.x, m_fAfter11.y, 0);
+#endif
+    }
+
+    float4 GetColor12(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix12, m_fAfter12, m_fAfter12, m_fAfter12);
+#else
+        GET_COLOR_TEMPLATE(m_matrix12, m_fAfter12.x, m_fAfter12.y, 0);
+#endif
+    }
+
+    float4 GetColor13(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix13, m_fAfter13, m_fAfter13, m_fAfter13);
+#else
+        GET_COLOR_TEMPLATE(m_matrix13, m_fAfter13.x, m_fAfter13.y, 0);
+#endif
+    }
+
+    float4 GetColor14(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix14, m_fAfter14, m_fAfter14, m_fAfter14);
+#else
+        GET_COLOR_TEMPLATE(m_matrix14, m_fAfter14.x, m_fAfter14.y, 0);
+#endif
+    }
+
+    // Case not supported
+    //float4 GetColor21(float2 pixelCoord, float4 defaultColor)
+    //{
+    //    GET_COLOR_TEMPLATE(m_matrix21, m_fAfter21);
+    //}
+
+    float4 GetColor22(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix22, m_fAfter22, m_fAfter22, m_fAfter22);
+#else
+        GET_COLOR_TEMPLATE(m_matrix22, m_fAfter22.x, m_fAfter22.y, 0);
+#endif
+    }
+
+    float4 GetColor23(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix23, m_fAfter23, m_fAfter23, m_fAfter23);
+#else
+        GET_COLOR_TEMPLATE(m_matrix23, m_fAfter23.x, m_fAfter23.y, 0);
+#endif
+    }
+
+    float4 GetColor24(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix24, m_fAfter24, m_fAfter24, m_fAfter24);
+#else
+        GET_COLOR_TEMPLATE(m_matrix24, m_fAfter24.x, m_fAfter24.y, 0);
+#endif
+    }
+
+    // Case not supported
+    //float4 GetColor31(float2 pixelCoord, float4 defaultColor)
+    //{
+    //    GET_COLOR_TEMPLATE(m_matrix31, m_fAfter31);
+    //}
+
+    float4 GetColor32(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix32, m_fAfter32, m_fAfter32, m_fAfter32);
+#else
+        GET_COLOR_TEMPLATE(m_matrix32, m_fAfter32.x, m_fAfter32.y, 0);
+#endif
+    }
+
+    float4 GetColor33(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix33, m_fAfter33, m_fAfter33, m_fAfter33);
+#else
+        GET_COLOR_TEMPLATE(m_matrix33, m_fAfter33.x, m_fAfter33.y, 0);
+#endif
+    }
+
+    float4 GetColor34(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix34, m_fAfter34, m_fAfter34, m_fAfter34);
+#else
+        GET_COLOR_TEMPLATE(m_matrix34, m_fAfter34.x, m_fAfter34.y, 0);
+#endif
+    }
+      
+    // Case not supported
+    //float4 GetColor41(float2 pixelCoord, float4 defaultColor)
+    //{
+    //    GET_COLOR_TEMPLATE(m_matrix41, m_fAfter41);
+    //}
+
+    float4 GetColor42(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix42, m_fAfter42, m_fAfter42, m_fAfter42);
+#else
+        GET_COLOR_TEMPLATE(m_matrix42, m_fAfter42.x, m_fAfter42.y, 0);
+#endif
+    }
+
+    float4 GetColor43(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix43, m_fAfter43, m_fAfter43, m_fAfter43);
+#else
+        GET_COLOR_TEMPLATE(m_matrix43, m_fAfter43.x, m_fAfter43.y, 0);
+#endif
+    }
+
+    float4 GetColor44(float2 pixelCoord, float4 defaultColor)
+    {
+#if NUM_FLOATS_AFTER_MATRIX == 1
+        GET_COLOR_TEMPLATE(m_matrix44, m_fAfter44, m_fAfter44, m_fAfter44);
+#else
+        GET_COLOR_TEMPLATE(m_matrix44, m_fAfter44.x, m_fAfter44.y, 0);
+#endif
+    }
+}
+
+struct VSInput
+{
+    float3 m_position : POSITION;
+    float4 m_color : COLOR0;
+};
+
+struct VSOutput
+{
+    float4 m_position : SV_Position;
+    float4 m_color : COLOR0;
+};
+
+VSOutput MainVS(VSInput vsInput)
+{
+    VSOutput OUT;
+    OUT.m_position = float4(vsInput.m_position, 1.0);
+    OUT.m_color = vsInput.m_color;
+    return OUT;
+}
+
+struct PSOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+PSOutput MainPS(VSOutput vsOutput)
+{
+    PSOutput OUT;
+
+    // Normalized pixel coordinates (from 0 to 1)
+    float2 pixelCoord = vsOutput.m_position.xy / AlignmentValidatorSrg::m_resolution.xy;
+
+    // The screen will be split in a grid where:
+    // Number of rows is:    m_numRows + 1;
+    // Number of columns is: m_numColumns + 1;
+    // The 0-indexed cells where Row < m_numRows & Col < m_numColumns
+    // will take the color of float4(m_matrix<m_numRows><m_numRows>[row][col], ...)
+    // The last cell will take the color (m_fAfter<m_numRows+1><m_numRows+1>, ...)
+
+    float4 color = vsOutput.m_color.rgba;
+
+    switch(AlignmentValidatorSrg::m_numRows)
+    {
+        case 1:
+        switch(AlignmentValidatorSrg::m_numColumns)
+        {
+            case 1:
+            color = AlignmentValidatorSrg::GetColor11(pixelCoord, color);
+            break;
+            case 2:
+            color = AlignmentValidatorSrg::GetColor12(pixelCoord, color);
+            break;
+            case 3:
+            color = AlignmentValidatorSrg::GetColor13(pixelCoord, color);
+            break;
+            case 4:
+            color = AlignmentValidatorSrg::GetColor14(pixelCoord, color);
+            break;
+            default:
+            break;
+        }
+        break;
+        case 2:
+        switch(AlignmentValidatorSrg::m_numColumns)
+        {
+            case 1:
+            // color = AlignmentValidatorSrg::GetColor21(pixelCoord, color); // Not Supported
+            break;
+            case 2:
+            color = AlignmentValidatorSrg::GetColor22(pixelCoord, color);
+            break;
+            case 3:
+            color = AlignmentValidatorSrg::GetColor23(pixelCoord, color);
+            break;
+            case 4:
+            color = AlignmentValidatorSrg::GetColor24(pixelCoord, color);
+            break;
+            default:
+            break;
+        }
+        break;
+        case 3:
+        switch(AlignmentValidatorSrg::m_numColumns)
+        {
+            case 1:
+            // color = AlignmentValidatorSrg::GetColor31(pixelCoord, color); // Not Supported
+            break;
+            case 2:
+            color = AlignmentValidatorSrg::GetColor32(pixelCoord, color);
+            break;
+            case 3:
+            color = AlignmentValidatorSrg::GetColor33(pixelCoord, color);
+            break;
+            case 4:
+            color = AlignmentValidatorSrg::GetColor34(pixelCoord, color);
+            break;
+            default:
+            break;
+        }
+        break;
+        case 4:
+        switch(AlignmentValidatorSrg::m_numColumns)
+        {
+            case 1:
+            // color = AlignmentValidatorSrg::GetColor41(pixelCoord, color); // Not Supported
+            break;
+            case 2:
+            color = AlignmentValidatorSrg::GetColor42(pixelCoord, color);
+            break;
+            case 3:
+            color = AlignmentValidatorSrg::GetColor43(pixelCoord, color);
+            break;
+            case 4:
+            color = AlignmentValidatorSrg::GetColor44(pixelCoord, color);
+            break;
+            default:
+            break;
+        }
+        break;
+        default:
+        break;
+    }
+
+    OUT.m_color = color;
+
+    return OUT;
+}

--- a/Shaders/RHI/MatrixAlignmentTest.shader
+++ b/Shaders/RHI/MatrixAlignmentTest.shader
@@ -1,0 +1,33 @@
+{
+    "Source" : "MatrixAlignmentTest",
+
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }
+    },
+
+    "DrawList" : "forward",
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    },
+
+    "Supervariants":
+    [
+      {
+        "Name" : "float2",
+        "PlusArguments" : "-DNUM_FLOATS_AFTER_MATRIX=2"
+      }
+    ]
+    
+}


### PR DESCRIPTION
[ATOM-16287] Validate Alignment Across All floatNxM Between vulkan & dx12

Added a new Example named "RHI/MatrixAlignmentTest" that can be used
to spot SRG Constant Buffer alignment issues when a float<R>x<C> is
followed by a "float" or a "float2" variable.

It's been found that, although We try to enforce DX12 alignment rules
across all RHIs, We end up encountering cases where such requested
alignments don't match, and this ASV example can be used to detect
the broken cases.

Signed-off-by: garrieta <garrieta@amazon.com>