### PR TITLE
Updated AtomSampleViewer to use the non-deprecated ly_enable_gems call

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -140,31 +140,10 @@ endif()
 ################################################################################
 # Gem dependencies
 ################################################################################
-# The GameLauncher uses "Clients" gem variants:
-ly_enable_gems(PROJECT_NAME AtomSampleViewer GEM_FILE enabled_gems.cmake
-    TARGETS AtomSampleViewer.GameLauncher
-    VARIANTS Clients)
+
+ly_enable_gems(PROJECT_NAME AtomSampleViewer GEM_FILE enabled_gems.cmake)
 
 # If we build a server, then apply the gems to the server
 if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
-    # if we're making a server, then add the "Server" gem variants to it:
-    ly_enable_gems(PROJECT_NAME AtomSampleViewer GEM_FILE enabled_gems.cmake
-        TARGETS AtomSampleViewer.ServerLauncher
-        VARIANTS Servers)
-
     set_property(GLOBAL APPEND PROPERTY LY_LAUNCHER_SERVER_PROJECTS AtomSampleViewer)
-endif()
-
-if (PAL_TRAIT_BUILD_HOST_TOOLS)
-    # The Editor uses "Tools" gem variants:
-    ly_enable_gems(
-        PROJECT_NAME AtomSampleViewer GEM_FILE enabled_gems.cmake
-        TARGETS Editor
-        VARIANTS Tools)
-
-    # The pipeline tools use "Builders" gem variants:
-    ly_enable_gems(
-        PROJECT_NAME AtomSampleViewer GEM_FILE enabled_gems.cmake
-        TARGETS AssetBuilder AssetProcessor AssetProcessorBatch
-        VARIANTS Builders)
 endif()

--- a/Standalone/CMakeLists.txt
+++ b/Standalone/CMakeLists.txt
@@ -38,9 +38,7 @@ if (NOT LY_MONOLITHIC_GAME)
 
         add_subdirectory(PythonTests)
 
-        ly_enable_gems(GEM_FILE ../Gem/Code/enabled_gems.cmake
-            TARGETS AtomSampleViewerStandalone
-            VARIANTS Clients)
+        ly_set_gem_variant_to_load(TARGETS AtomSampleViewerStandalone VARIANTS Clients)
 
 
         # Adds the AtomSampleViewerStandalone target as a C preprocessor define so that it can be used as a Settings Registry


### PR DESCRIPTION
Fixed the AtomSampleViewerStandalone application to NOT enable the
AtomSampleViewer project gems for all projects in a multi-project
workflow

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>