### PR TITLE
Fixed a material functor compile error that mysteriously appeared.

### DIFF
--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.h
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderCollectionFunctor.h
@@ -23,7 +23,8 @@ namespace AtomSampleViewer
         AZ_RTTI(StacksShaderCollectionFunctor, "{4E51A7D5-7DF1-4402-8975-F6C9DFDEDC1E}", AZ::RPI::MaterialFunctor);
 
         static void Reflect(AZ::ReflectContext* context);
-
+        
+        using AZ::RPI::MaterialFunctor::Process;
         void Process(RuntimeContext& context) override;
 
     private:

--- a/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.h
+++ b/Gem/Code/Lib/MaterialFunctors/StacksShaderInputFunctor.h
@@ -24,7 +24,8 @@ namespace AtomSampleViewer
         AZ_RTTI(StacksShaderInputFunctor, "{7F607170-1BC2-4510-A252-8A665FC02052}", AZ::RPI::MaterialFunctor);
 
         static void Reflect(AZ::ReflectContext* context);
-
+        
+        using AZ::RPI::MaterialFunctor::Process;
         void Process(RuntimeContext& context) override;
 
     private:

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.h
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderCollectionFunctorSourceData.h
@@ -25,7 +25,8 @@ namespace AtomSampleViewer
         AZ_RTTI(StacksShaderCollectionFunctorSourceData, "{2B4678D5-5C1B-4BEE-99E5-9EC9FB871D37}", AZ::RPI::MaterialFunctorSourceData);
 
         static void Reflect(AZ::ReflectContext* context);
-
+        
+        using AZ::RPI::MaterialFunctorSourceData::CreateFunctor;
         FunctorResult CreateFunctor(const RuntimeContext& context) const override;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.h
+++ b/Gem/Code/Tools/MaterialFunctors/StacksShaderInputFunctorSourceData.h
@@ -24,6 +24,7 @@ namespace AtomSampleViewer
         static void Reflect(AZ::ReflectContext* context);
 
     private:
+        using AZ::RPI::MaterialFunctorSourceData::CreateFunctor;
         FunctorResult CreateFunctor(const RuntimeContext& context) const override;
     };
 


### PR DESCRIPTION
1>C:\GitHub\o3de\AtomSampleViewer\Gem\Code\Lib\MaterialFunctors/StacksShaderCollectionFunctor.h(37,5): error C4266:     };
1>C:\GitHub\o3de\AtomSampleViewer\Gem\Code\Lib\MaterialFunctors/StacksShaderCollectionFunctor.h(37,5): error C4266:     ^
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(249): message : see declaration of 'AZ::RPI::MaterialFunctor::Process'
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(249): message :             virtual void Process([[maybe_unused]] EditorContext& context) {}
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(69): message : see declaration of 'AZ::RPI::MaterialFunctor'
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(69): message :         class MaterialFunctor
1>C:\GitHub\o3de\AtomSampleViewer\Gem\Code\Lib\MaterialFunctors/StacksShaderInputFunctor.h(38,5): error C4266: 'void AZ::RPI::MaterialFunctor::Process(AZ::RPI::MaterialFunctor::EditorContext &)': no override available for virtual member function from base 'AZ::RPI::MaterialFunctor'; function is hidden
1>C:\GitHub\o3de\AtomSampleViewer\Gem\Code\Lib\MaterialFunctors/StacksShaderInputFunctor.h(38,5): error C4266:     };
1>C:\GitHub\o3de\AtomSampleViewer\Gem\Code\Lib\MaterialFunctors/StacksShaderInputFunctor.h(38,5): error C4266:     ^
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(249): message : see declaration of 'AZ::RPI::MaterialFunctor::Process'
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(249): message :             virtual void Process([[maybe_unused]] EditorContext& context) {}
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(69): message : see declaration of 'AZ::RPI::MaterialFunctor'
1>C:\GitHub\o3de\Gems\Atom\RPI\Code\Include\Atom/RPI.Reflect/Material/MaterialFunctor.h(69): message :         class MaterialFunctor

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>