### PR TITLE
Updated the FileIOAliases in the AtomSampleViewer Project

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -111,7 +111,7 @@ namespace AtomSampleViewer
             AZ::Render::Bootstrap::DefaultWindowBus::Broadcast(&AZ::Render::Bootstrap::DefaultWindowBus::Events::SetCreateDefaultScene, false);
         }
 
-        AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::LoadCatalog, "@projectproductassets@/assetcatalog.xml");
+        AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::LoadCatalog, "@products@/assetcatalog.xml");
 
         m_atomSampleViewerEntity->Activate();
 

--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -111,7 +111,7 @@ namespace AtomSampleViewer
             AZ::Render::Bootstrap::DefaultWindowBus::Broadcast(&AZ::Render::Bootstrap::DefaultWindowBus::Events::SetCreateDefaultScene, false);
         }
 
-        AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::LoadCatalog, "@assets@/assetcatalog.xml");
+        AZ::Data::AssetCatalogRequestBus::Broadcast(&AZ::Data::AssetCatalogRequestBus::Events::LoadCatalog, "@projectproductassets@/assetcatalog.xml");
 
         m_atomSampleViewerEntity->Activate();
 

--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -92,7 +92,7 @@ namespace AtomSampleViewer
             }
 
             // Turn it back into a full path
-            path = Utils::ResolvePath("@devassets@" + path);
+            path = Utils::ResolvePath("@projectroot@/" + path);
 
             return path;
         }

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -116,7 +116,7 @@ namespace AtomSampleViewer
         AzFramework::StringFunc::Path::Join(resolveBuffer, "log", logDirectory);
         fileIO->SetAlias("@log@", logDirectory.c_str());
 
-        fileIO->CreatePath("@projectproductassets@");
+        fileIO->CreatePath("@products@");
         fileIO->CreatePath("@user@");
         fileIO->CreatePath("@log@");
 

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -116,7 +116,7 @@ namespace AtomSampleViewer
         AzFramework::StringFunc::Path::Join(resolveBuffer, "log", logDirectory);
         fileIO->SetAlias("@log@", logDirectory.c_str());
 
-        fileIO->CreatePath("@root@");
+        fileIO->CreatePath("@projectproductassets@");
         fileIO->CreatePath("@user@");
         fileIO->CreatePath("@log@");
 


### PR DESCRIPTION
The `@assets@` and `@root@` has been updated to `@projectproductassets@` and the `@devassets@` alias has been replaced with `@projectroot@`

relates https://github.com/o3de/o3de/pull/4186

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>