### PR TITLE
WARP gets TEST_REQUIRES gpu to test a session 0 problem

### DIFF
--- a/Standalone/PythonTests/CMakeLists.txt
+++ b/Standalone/PythonTests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
     ly_add_pytest(
         NAME AtomSampleViewer::PythonWARPTests
         PATH ${CMAKE_CURRENT_LIST_DIR}/Automated/test_AtomSampleViewer_warp_suite.py
+        TEST_REQUIRES gpu
         TEST_SUITE main
         TEST_SERIAL
         TIMEOUT 300


### PR DESCRIPTION
WARP gets TEST_REQUIRES gpu to test a session 0 problem since GPU nodes are not session 0

this will be changed back after some test runs overnight

Signed-off-by: Scott Murray <scottmur@amazon.com>