### PR TITLE
[development] Removed references to AZ::RHI::CpuTimingStatistics

### DIFF
--- a/Gem/Code/Source/DynamicMaterialTestComponent.cpp
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.cpp
@@ -19,6 +19,7 @@
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Debug/EventTrace.h>
+#include <AzCore/Debug/Timer.h>
 #include <AzCore/Math/Random.h>
 
 #include <RHI/BasicRHIComponent.h>

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1023,11 +1023,7 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::ShowCpuProfilerWindow()
     {
-        const AZ::RHI::CpuTimingStatistics* stats = AZ::RHI::RHISystemInterface::Get()->GetCpuTimingStatistics();
-        if (stats)
-        {
-            m_imguiCpuProfiler.Draw(m_showCpuProfiler, *stats);
-        }
+        m_imguiCpuProfiler.Draw(m_showCpuProfiler);
     }
 
     void SampleComponentManager::ShowGpuProfilerWindow()


### PR DESCRIPTION
Changed related to https://github.com/o3de/o3de/pull/4549

Signed-off-by: AMZN-ScottR <24445312+AMZN-ScottR@users.noreply.github.com>