### PR TITLE
Removing (unused) boundary width

### DIFF
--- a/Gem/Code/Source/CullingAndLodExampleComponent.cpp
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.cpp
@@ -232,7 +232,6 @@ namespace AtomSampleViewer
                 AZ::Render::DirectionalLightFeatureProcessorInterface::DebugDrawFlags::DebugDrawNone);
             dirLightFP->SetViewFrustumCorrectionEnabled(handle, m_isCascadeCorrectionEnabled);
             dirLightFP->SetShadowFilterMethod(handle, s_shadowFilterMethods[m_shadowFilterMethodIndex]);
-            dirLightFP->SetShadowBoundaryWidth(handle, m_boundaryWidth);
             dirLightFP->SetFilteringSampleCount(handle, static_cast<uint16_t>(m_filteringSampleCount));
             dirLightFP->SetGroundHeight(handle, 0.f);
 
@@ -395,11 +394,6 @@ namespace AtomSampleViewer
             if (ImGui::Combo("Filter Method", &m_shadowFilterMethodIndex, s_shadowFilterMethodLabels, AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
             {
                 m_directionalLightFeatureProcessor->SetShadowFilterMethod(m_directionalLightHandle, s_shadowFilterMethods[m_shadowFilterMethodIndex]);
-            }
-            ImGui::Text("Boundary Width in meter");
-            if (ImGui::SliderFloat("Width", &m_boundaryWidth, 0.f, 0.1f, "%.3f"))
-            {
-                m_directionalLightFeatureProcessor->SetShadowBoundaryWidth(m_directionalLightHandle, m_boundaryWidth);
             }
 
             ImGui::Spacing();

--- a/Gem/Code/Source/CullingAndLodExampleComponent.h
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.h
@@ -126,7 +126,6 @@ namespace AtomSampleViewer
         static const AZ::Render::ShadowFilterMethod s_shadowFilterMethods[];
         static const char* s_shadowFilterMethodLabels[];
         int m_shadowFilterMethodIndex = 0; // filter method is None.
-        float m_boundaryWidth = 0.03f; // 3cm
         int m_predictionSampleCount = 4;
         int m_filteringSampleCount = 16;
 

--- a/Gem/Code/Source/DiffuseGIExampleComponent.cpp
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.cpp
@@ -409,7 +409,6 @@ namespace AtomSampleViewer
             directionalLightFeatureProcessor->SetShadowmapSize(m_directionalLightHandle, AZ::Render::ShadowmapSize::Size2048);
             directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(m_directionalLightHandle, false);
             directionalLightFeatureProcessor->SetShadowFilterMethod(m_directionalLightHandle, AZ::Render::ShadowFilterMethod::EsmPcf);
-            directionalLightFeatureProcessor->SetShadowBoundaryWidth(m_directionalLightHandle, 0.03f);
             directionalLightFeatureProcessor->SetFilteringSampleCount(m_directionalLightHandle, 16);
             directionalLightFeatureProcessor->SetGroundHeight(m_directionalLightHandle, 0.0f);
         }

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
@@ -220,7 +220,6 @@ namespace AtomSampleViewer
         featureProcessor->SetShadowmapSize(handle, Render::ShadowmapSize::Size2048);
         featureProcessor->SetViewFrustumCorrectionEnabled(handle, true);
         featureProcessor->SetShadowFilterMethod(handle, aznumeric_cast<Render::ShadowFilterMethod>(m_shadowFilteringMethod));
-        featureProcessor->SetShadowBoundaryWidth(handle, 0.03f);
         featureProcessor->SetFilteringSampleCount(handle, 32);
         featureProcessor->SetGroundHeight(handle, 0.f);
         featureProcessor->SetShadowFarClipDistance(handle, 100.f);

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -217,7 +217,6 @@ namespace AtomSampleViewer
             m_diskLightFeatureProcessor->SetShadowsEnabled(m_diskLightHandle, true);
             m_diskLightFeatureProcessor->SetShadowmapMaxResolution(m_diskLightHandle, Render::ShadowmapSize::Size512);
             m_diskLightFeatureProcessor->SetConeAngles(m_diskLightHandle, DegToRad(22.5f), DegToRad(27.5f));
-            m_diskLightFeatureProcessor->SetSofteningBoundaryWidthAngle(m_diskLightHandle, DegToRad(0.25f));
         }
 
         // Create DirectionalLight

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
@@ -172,7 +172,6 @@ namespace AtomSampleViewer
         m_directionalLightFeatureProcessor->SetShadowmapFrustumSplitSchemeRatio(handle, 0.5f);
         m_directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(handle, true);
         m_directionalLightFeatureProcessor->SetShadowFilterMethod(handle, AZ::Render::ShadowFilterMethod::Esm);
-        m_directionalLightFeatureProcessor->SetShadowBoundaryWidth(handle, 0.03f);
         m_directionalLightFeatureProcessor->SetFilteringSampleCount(handle, 32);
         m_directionalLightFeatureProcessor->SetGroundHeight(handle, 0.f);
 

--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -415,7 +415,6 @@ namespace AtomSampleViewer
         featureProcessor->SetShadowmapFrustumSplitSchemeRatio(handle, m_ratioLogarithmUniform);
         featureProcessor->SetViewFrustumCorrectionEnabled(handle, m_isCascadeCorrectionEnabled);
         featureProcessor->SetShadowFilterMethod(handle, s_shadowFilterMethods[m_shadowFilterMethodIndexDirectional]);
-        featureProcessor->SetShadowBoundaryWidth(handle, m_boundaryWidthDirectional);
         featureProcessor->SetFilteringSampleCount(handle, static_cast<uint16_t>(m_filteringSampleCountDirectional));
         featureProcessor->SetGroundHeight(handle, 0.f);
 
@@ -572,14 +571,6 @@ namespace AtomSampleViewer
                 m_directionalLightFeatureProcessor->SetShadowFilterMethod(
                     m_directionalLightHandle, s_shadowFilterMethods[m_shadowFilterMethodIndexDirectional]);
             }
-            if (m_shadowFilterMethodIndexDirectional != aznumeric_cast<int>(AZ::Render::ShadowFilterMethod::None))
-            {
-                ImGui::Text("Boundary Width in meter");
-                if (ScriptableImGui::SliderFloat("Width##Directional", &m_boundaryWidthDirectional, 0.f, 0.1f, "%.3f"))
-                {
-                    m_directionalLightFeatureProcessor->SetShadowBoundaryWidth(m_directionalLightHandle, m_boundaryWidthDirectional);
-                }
-            }
 
             if (m_shadowFilterMethodIndexDirectional == aznumeric_cast<int>(AZ::Render::ShadowFilterMethod::Pcf) ||
                 m_shadowFilterMethodIndexDirectional == aznumeric_cast<int>(AZ::Render::ShadowFilterMethod::EsmPcf))
@@ -673,7 +664,6 @@ namespace AtomSampleViewer
                 if (!m_positionalLightShadowEnabled[index])
                 {
                     m_shadowFilterMethodIndicesPositional[index] = 0;
-                    m_boundaryWidthsPositional[index] = 0.f;
                     m_filteringSampleCountsPositional[index] = 0;
                 }
                 settingsChanged = true;
@@ -687,15 +677,6 @@ namespace AtomSampleViewer
                     AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
             {
                 settingsChanged = true;
-            }
-
-            if (m_shadowFilterMethodIndicesPositional[index] != aznumeric_cast<int>(ShadowFilterMethod::None))
-            {
-                ImGui::Text("Boundary Width in degrees");
-                if (ScriptableImGui::SliderFloat("Width##Positional", &m_boundaryWidthsPositional[index], 0.f, 1.0f, "%.3f"))
-                {
-                    settingsChanged = true;
-                }
             }
 
             if (m_shadowFilterMethodIndicesPositional[index] == aznumeric_cast<int>(ShadowFilterMethod::Pcf) ||
@@ -793,7 +774,6 @@ namespace AtomSampleViewer
                     m_diskLightFeatureProcessor->SetShadowFilterMethod(
                         lightHandle, s_shadowFilterMethods[m_shadowFilterMethodIndicesPositional[index]]);
 
-                    m_diskLightFeatureProcessor->SetSofteningBoundaryWidthAngle(lightHandle, AZ::DegToRad(m_boundaryWidthsPositional[index]));
                     m_diskLightFeatureProcessor->SetFilteringSampleCount(lightHandle, static_cast<uint16_t>(m_filteringSampleCountsPositional[index]));
                 }
             }
@@ -824,7 +804,6 @@ namespace AtomSampleViewer
                         lightHandle, s_shadowFilterMethods[m_shadowFilterMethodIndicesPositional[index]]);
 
                     m_pointLightFeatureProcessor->SetFilteringSampleCount(lightHandle, static_cast<uint16_t>(m_filteringSampleCountsPositional[index]));
-                    m_pointLightFeatureProcessor->SetSofteningBoundaryWidthAngle(lightHandle, AZ::DegToRad(m_boundaryWidthsPositional[index]));
                 }
             }
         }

--- a/Gem/Code/Source/ShadowExampleComponent.h
+++ b/Gem/Code/Source/ShadowExampleComponent.h
@@ -170,8 +170,6 @@ namespace AtomSampleViewer
         static const char* s_shadowFilterMethodLabels[];
         int m_shadowFilterMethodIndexDirectional = 0; // filter method is None.
         int m_shadowFilterMethodIndicesPositional[PositionalLightCount] = { 0, 0, 0 }; // filter method is None.
-        float m_boundaryWidthDirectional = 0.03f; // 3cm
-        float m_boundaryWidthsPositional[PositionalLightCount] = { 0.25f, 0.25f, 0.25f }; // 0.25 degrees
         int m_filteringSampleCountDirectional = 32;
         int m_filteringSampleCountsPositional[PositionalLightCount] = { 32, 32, 32 };
 

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
@@ -248,7 +248,6 @@ namespace AtomSampleViewer
             featureProcessor->SetShadowmapSize(handle, s_shadowmapSizes[s_shadowmapSizeIndexDefault]);
             featureProcessor->SetViewFrustumCorrectionEnabled(handle, m_isCascadeCorrectionEnabled);
             featureProcessor->SetShadowFilterMethod(handle, s_shadowFilterMethods[m_shadowFilterMethodIndexDirectional]);
-            featureProcessor->SetShadowBoundaryWidth(handle, m_boundaryWidthDirectional);
             featureProcessor->SetFilteringSampleCount(handle, static_cast<uint16_t>(m_filteringSampleCountDirectional));
             featureProcessor->SetGroundHeight(handle, 0.f);
 
@@ -478,17 +477,6 @@ namespace AtomSampleViewer
                     s_shadowFilterMethods[m_shadowFilterMethodIndexDirectional]);
             }
 
-            if (m_shadowFilterMethodIndexDirectional != aznumeric_cast<int>(ShadowFilterMethod::None))
-            {
-                ImGui::Text("Boundary Width in meter");
-                if (ScriptableImGui::SliderFloat("Width##Directional", &m_boundaryWidthDirectional, 0.f, 0.1f, "%.3f"))
-                {
-                    m_directionalLightFeatureProcessor->SetShadowBoundaryWidth(
-                        m_directionalLightHandle,
-                        m_boundaryWidthDirectional);
-                }
-            }
-
             if (m_shadowFilterMethodIndexDirectional == aznumeric_cast<int>(ShadowFilterMethod::Pcf) ||
                 m_shadowFilterMethodIndexDirectional == aznumeric_cast<int>(ShadowFilterMethod::EsmPcf))
             {
@@ -568,18 +556,6 @@ namespace AtomSampleViewer
                 for (int index = 0; index < m_diskLightCount; ++index)
                 {
                     m_diskLightFeatureProcessor->SetShadowFilterMethod(m_diskLights[index].m_handle, aznumeric_cast<ShadowFilterMethod>(m_shadowFilterMethodIndexDisk));
-                }
-            }
-
-            if (m_shadowFilterMethodIndexDisk != aznumeric_cast<int>(ShadowFilterMethod::None))
-            {
-                ImGui::Text("Boundary Width in degrees");
-                if (ScriptableImGui::SliderFloat("Width##Spot", &m_boundaryWidthDisk, 0.f, 1.f, "%.3f"))
-                {
-                    for (int index = 0; index < m_diskLightCount; ++index)
-                    {
-                        m_diskLightFeatureProcessor->SetSofteningBoundaryWidthAngle(m_diskLights[index].m_handle, DegToRad(m_boundaryWidthDisk));
-                    }
                 }
             }
 

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.h
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.h
@@ -138,8 +138,6 @@ namespace AtomSampleViewer
         static const char* s_shadowFilterMethodLabels[];
         int m_shadowFilterMethodIndexDirectional = 0; // filter method is None.
         int m_shadowFilterMethodIndexDisk = 0; // filter method is None
-        float m_boundaryWidthDirectional = 0.03f; // 3cm
-        float m_boundaryWidthDisk = 0.25f; // 0.25 degrees
         int m_filteringSampleCountDirectional = 16;
         int m_filteringSampleCountDisk = 16;
 

--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -158,7 +158,6 @@ namespace AtomSampleViewer
         m_directionalLightFeatureProcessor->SetShadowmapSize(handle, AZ::Render::ShadowmapSizeNamespace::ShadowmapSize::Size2048);
         m_directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(handle, true);
         m_directionalLightFeatureProcessor->SetShadowFilterMethod(handle, AZ::Render::ShadowFilterMethod::EsmPcf);
-        m_directionalLightFeatureProcessor->SetShadowBoundaryWidth(handle, 0.03);
         m_directionalLightFeatureProcessor->SetFilteringSampleCount(handle, 16);
         m_directionalLightFeatureProcessor->SetGroundHeight(handle, 0.f);
         m_directionalLightHandle = handle;


### PR DESCRIPTION
Boundary width is obsolete. It was no longer used since we replaced the Silicon Studios gaussian blur with kawase blur.
Ran ASV tests

Signed-off-by: mrieggeramzn <mriegger@amazon.com>