### PR TITLE
Adds changes from o3de Jenkinsfile to o3de-atom-sampleviewer Jenkinsfile (attempt 2)

### DIFF
--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -341,9 +341,9 @@ def PreBuildCommonSteps(Map pipelineConfig, String repositoryName, String projec
         if(!fileExists('3rdParty')) {
             palMkdir('3rdParty')
         }
+        CheckoutRepo(disableSubmodules)
     }
     dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
-        CheckoutRepo(disableSubmodules)
         // Get python
         if(env.IS_UNIX) {
             sh label: 'Getting python',


### PR DESCRIPTION
- Re-opening the closed PR from https://github.com/o3de/o3de-atom-sampleviewer/pull/225 as I wasn't able to get a pass in the branch due to this weird error (I added the `REDACTED` to remove any potentially sensitive info):
```
14:23:25  + python/get_python.sh
14:23:25  /REDACTED/script.sh: 1: /REDACTED/script.sh: python/get_python.sh: not found
```