### PR TITLE
The .shader file must now include the .azsl extension when referencing a .azsl file

### DIFF
--- a/Shaders/DebugVertexNormals.shader
+++ b/Shaders/DebugVertexNormals.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DebugVertexNormals",
+    "Source" : "DebugVertexNormals.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/DynamicDraw/DynamicDrawExample.shader
+++ b/Shaders/DynamicDraw/DynamicDrawExample.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "DynamicDrawExample",
+    "Source" : "DynamicDrawExample.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { 

--- a/Shaders/PostProcessing/ColorInvertCS.shader
+++ b/Shaders/PostProcessing/ColorInvertCS.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "ColorInvertCS",
+    "Source": "ColorInvertCS.azsl",
 
     "ProgramSettings":
     {

--- a/Shaders/PostProcessing/ColorblindnessSimulation.shader
+++ b/Shaders/PostProcessing/ColorblindnessSimulation.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "ColorblindnessSimulation",
+    "Source" : "ColorblindnessSimulation.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Shaders/PostProcessing/MSAAResolveDepth.shader
+++ b/Shaders/PostProcessing/MSAAResolveDepth.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "MSAAResolveDepth",
+    "Source" : "MSAAResolveDepth.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "Always" }

--- a/Shaders/PostProcessing/Monochrome.shader
+++ b/Shaders/PostProcessing/Monochrome.shader
@@ -1,5 +1,5 @@
 { 
-    "Source" : "Monochrome",
+    "Source" : "Monochrome.azsl",
 
     "DepthStencilState" : {
         "Depth" : { "Enable" : false }

--- a/Shaders/RHI/AsyncComputeLuminanceMap.shader
+++ b/Shaders/RHI/AsyncComputeLuminanceMap.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "AsyncComputeLuminanceMap",
+    "Source": "AsyncComputeLuminanceMap.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/AsyncComputeLuminanceReduce.shader
+++ b/Shaders/RHI/AsyncComputeLuminanceReduce.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "AsyncComputeLuminanceReduce",
+    "Source": "AsyncComputeLuminanceReduce.azsl",
        
     "ProgramSettings":
     {

--- a/Shaders/RHI/AsyncComputeShadow.shader
+++ b/Shaders/RHI/AsyncComputeShadow.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "AsyncComputeShadow",
+    "Source" : "AsyncComputeShadow.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }

--- a/Shaders/RHI/AsyncComputeTonemapping.shader
+++ b/Shaders/RHI/AsyncComputeTonemapping.shader
@@ -1,5 +1,5 @@
 {   
-    "Source": "AsyncComputeTonemapping",
+    "Source": "AsyncComputeTonemapping.azsl",
   
     "ProgramSettings":
     {

--- a/Shaders/RHI/BindlessPrototype.shader
+++ b/Shaders/RHI/BindlessPrototype.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "BindlessPrototype",
+    "Source" : "BindlessPrototype.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/ColorMesh.shader
+++ b/Shaders/RHI/ColorMesh.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ColorMesh",
+    "Source" : "ColorMesh.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/ComputeDispatch.shader
+++ b/Shaders/RHI/ComputeDispatch.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "ComputeDispatch",
+    "Source": "ComputeDispatch.azsl",
 
     "ProgramSettings":
     {

--- a/Shaders/RHI/ComputeDraw.shader
+++ b/Shaders/RHI/ComputeDraw.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "ComputeDraw",
+    "Source": "ComputeDraw.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/CopyQueue.shader
+++ b/Shaders/RHI/CopyQueue.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "CopyQueue",
+    "Source": "CopyQueue.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/DualSourceBlending.shader
+++ b/Shaders/RHI/DualSourceBlending.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "DualSourceBlending",
+    "Source": "DualSourceBlending.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/IndirectDispatch.shader
+++ b/Shaders/RHI/IndirectDispatch.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "IndirectDispatch",
+    "Source": "IndirectDispatch.azsl",
 
     "ProgramSettings":
     {

--- a/Shaders/RHI/IndirectDraw.shader
+++ b/Shaders/RHI/IndirectDraw.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "IndirectDraw",
+    "Source" : "IndirectDraw.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }

--- a/Shaders/RHI/InputAssemblyCompute.shader
+++ b/Shaders/RHI/InputAssemblyCompute.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "InputAssemblyCompute",
+    "Source": "InputAssemblyCompute.azsl",
 
     "ProgramSettings":
     {

--- a/Shaders/RHI/InputAssemblyDraw.shader
+++ b/Shaders/RHI/InputAssemblyDraw.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "InputAssemblyDraw",
+    "Source": "InputAssemblyDraw.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/MRTScreen.shader
+++ b/Shaders/RHI/MRTScreen.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "MRTScreen",
+    "Source": "MRTScreen.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/MRTTarget.shader
+++ b/Shaders/RHI/MRTTarget.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "MRTTarget",
+    "Source": "MRTTarget.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/MSAAResolve.shader
+++ b/Shaders/RHI/MSAAResolve.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "MSAAResolve",
+    "Source": "MSAAResolve.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/MatrixAlignmentTest.shader
+++ b/Shaders/RHI/MatrixAlignmentTest.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "MatrixAlignmentTest",
+    "Source" : "MatrixAlignmentTest.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/MultipleViewsDepth.shader
+++ b/Shaders/RHI/MultipleViewsDepth.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "MultipleViewsDepth",
+    "Source" : "MultipleViewsDepth.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }

--- a/Shaders/RHI/MultipleViewsShadow.shader
+++ b/Shaders/RHI/MultipleViewsShadow.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "MultipleViewsShadow",
+    "Source" : "MultipleViewsShadow.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "LessEqual" }

--- a/Shaders/RHI/Multithread.shader
+++ b/Shaders/RHI/Multithread.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Multithread",
+    "Source" : "Multithread.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/RayTracingClosestHitGradient.shader
+++ b/Shaders/RHI/RayTracingClosestHitGradient.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RayTracingClosestHitGradient",
+    "Source" : "RayTracingClosestHitGradient.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RHI/RayTracingClosestHitSolid.shader
+++ b/Shaders/RHI/RayTracingClosestHitSolid.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RayTracingClosestHitSolid",
+    "Source" : "RayTracingClosestHitSolid.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RHI/RayTracingDispatch.shader
+++ b/Shaders/RHI/RayTracingDispatch.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RayTracingDispatch",
+    "Source" : "RayTracingDispatch.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RHI/RayTracingDraw.shader
+++ b/Shaders/RHI/RayTracingDraw.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "RayTracingDraw",
+    "Source": "RayTracingDraw.azsl",
 
     "DepthStencilState": 
     {

--- a/Shaders/RHI/RayTracingMiss.shader
+++ b/Shaders/RHI/RayTracingMiss.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RayTracingMiss",
+    "Source" : "RayTracingMiss.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RHI/SHDemo.shader
+++ b/Shaders/RHI/SHDemo.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "SHDemo",
+    "Source": "SHDemo.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/SHRender.shader
+++ b/Shaders/RHI/SHRender.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "SHRender",
+    "Source": "SHRender.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/Stencil.shader
+++ b/Shaders/RHI/Stencil.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Stencil",
+    "Source" : "Stencil.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "Less" }

--- a/Shaders/RHI/SubpassInputComposition.shader
+++ b/Shaders/RHI/SubpassInputComposition.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "SubpassInputComposition",
+    "Source" : "SubpassInputComposition.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/SubpassInputGBuffer.shader
+++ b/Shaders/RHI/SubpassInputGBuffer.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "SubpassInputGBuffer",
+    "Source" : "SubpassInputGBuffer.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/Texture.shader
+++ b/Shaders/RHI/Texture.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "Texture",
+    "Source": "Texture.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/Texture3d.shader
+++ b/Shaders/RHI/Texture3d.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Texture3d",
+    "Source" : "Texture3d.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/TextureArray.shader
+++ b/Shaders/RHI/TextureArray.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "TextureArray",
+    "Source" : "TextureArray.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/TextureMap1D.shader
+++ b/Shaders/RHI/TextureMap1D.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMap1D",
+    "Source": "TextureMap1D.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TextureMap1DArray.shader
+++ b/Shaders/RHI/TextureMap1DArray.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMap1DArray",
+    "Source": "TextureMap1DArray.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TextureMap2DArray.shader
+++ b/Shaders/RHI/TextureMap2DArray.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMap2DArray",
+    "Source": "TextureMap2DArray.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TextureMap3D.shader
+++ b/Shaders/RHI/TextureMap3D.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMap3D",
+    "Source": "TextureMap3D.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TextureMapCubemap.shader
+++ b/Shaders/RHI/TextureMapCubemap.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMapCubemap",
+    "Source": "TextureMapCubemap.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TextureMapCubemapArray.shader
+++ b/Shaders/RHI/TextureMapCubemapArray.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMapCubemapArray",
+    "Source": "TextureMapCubemapArray.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TextureMapTarget.shader
+++ b/Shaders/RHI/TextureMapTarget.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TextureMapTarget",
+    "Source": "TextureMapTarget.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/TexturedSurface.shader
+++ b/Shaders/RHI/TexturedSurface.shader
@@ -1,5 +1,5 @@
 {
-    "Source": "TexturedSurface",
+    "Source": "TexturedSurface.azsl",
 
     "DepthStencilState": {
         "Depth": {

--- a/Shaders/RHI/Triangle.shader
+++ b/Shaders/RHI/Triangle.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Triangle",
+    "Source" : "Triangle.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RHI/TrianglesConstantBuffer.shader
+++ b/Shaders/RHI/TrianglesConstantBuffer.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "TrianglesConstantBuffer",
+    "Source" : "TrianglesConstantBuffer.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/RayTracing/RTAOClosestHit.shader
+++ b/Shaders/RayTracing/RTAOClosestHit.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RTAOClosestHit",
+    "Source" : "RTAOClosestHit.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RayTracing/RTAOGeneration.shader
+++ b/Shaders/RayTracing/RTAOGeneration.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RTAOGeneration",
+    "Source" : "RTAOGeneration.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RayTracing/RTAOMiss.shader
+++ b/Shaders/RayTracing/RTAOMiss.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RTAOMiss",
+    "Source" : "RTAOMiss.azsl",
     "DrawList" : "RayTracing",
 
     "CompilerHints":

--- a/Shaders/RootConstantsExample/ColorMesh.shader
+++ b/Shaders/RootConstantsExample/ColorMesh.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ColorMesh",
+    "Source" : "ColorMesh.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : true, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/StreamingImageExample/Image3d.shader
+++ b/Shaders/StreamingImageExample/Image3d.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "Image3d",
+    "Source" : "Image3d.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/StreamingImageExample/ImageMips.shader
+++ b/Shaders/StreamingImageExample/ImageMips.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "ImageMips",
+    "Source" : "ImageMips.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }

--- a/Shaders/TonemappingExample/RenderImage.shader
+++ b/Shaders/TonemappingExample/RenderImage.shader
@@ -1,5 +1,5 @@
 {
-    "Source" : "RenderImage",
+    "Source" : "RenderImage.azsl",
 
     "DepthStencilState" : { 
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }


### PR DESCRIPTION
The .shader file must now include the .azsl extension when referencing a .azsl file. It will no longer be automatically appended.

Updated all .shader files accordingly.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>