### PR TITLE
Fixed timeout issues in MaterialHotReloadTest

### DIFF
--- a/Gem/Code/Source/Automation/AssetStatusTracker.cpp
+++ b/Gem/Code/Source/Automation/AssetStatusTracker.cpp
@@ -48,7 +48,7 @@ namespace AtomSampleViewer
         AZStd::to_lower(sourceAssetPath.begin(), sourceAssetPath.end());
 
         AZStd::lock_guard<AZStd::mutex> lock(m_mutex);
-        m_allAssetStatusData[sourceAssetPath].m_expecteCount += expectedCount;
+        m_allAssetStatusData[sourceAssetPath].m_expectedCount += expectedCount;
     }
 
     bool AssetStatusTracker::DidExpectedAssetsFinish() const
@@ -59,7 +59,7 @@ namespace AtomSampleViewer
         {
             const AssetStatusEvents& status = assetData.second;
 
-            if (status.m_expecteCount > (status.m_succeeded + status.m_failed))
+            if (status.m_expectedCount > (status.m_succeeded + status.m_failed))
             {
                 return false;
             }
@@ -67,6 +67,24 @@ namespace AtomSampleViewer
 
         return true;
     }
+    
+    AZStd::vector<AZStd::string> AssetStatusTracker::GetIncompleteAssetList() const
+    {
+        AZStd::vector<AZStd::string> incomplete;
+        
+        for (auto& assetData : m_allAssetStatusData)
+        {
+            const AssetStatusEvents& status = assetData.second;
+
+            if (status.m_expectedCount > (status.m_succeeded + status.m_failed))
+            {
+                incomplete.push_back(assetData.first);
+            }
+        }
+
+        return incomplete;
+    }
+
 
     void AssetStatusTracker::AssetCompilationStarted(const AZStd::string& assetPath)
     {

--- a/Gem/Code/Source/Automation/AssetStatusTracker.h
+++ b/Gem/Code/Source/Automation/AssetStatusTracker.h
@@ -33,6 +33,9 @@ namespace AtomSampleViewer
         //! Returns whether all of the expected assets have finished.
         bool DidExpectedAssetsFinish() const;
 
+        //! Return a list of assets that have not completed expected processing.
+        AZStd::vector<AZStd::string> GetIncompleteAssetList() const;
+
         //! Stops tracking asset status updates from the Asset Processor. Clears any asset status information already collected.
         void StopTracking();
 
@@ -44,7 +47,7 @@ namespace AtomSampleViewer
             uint32_t m_started = 0;
             uint32_t m_succeeded = 0;
             uint32_t m_failed = 0;
-            uint32_t m_expecteCount = 0;
+            uint32_t m_expectedCount = 0;
         };
 
         // AssetSystemInfoBus overrides...

--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -331,11 +331,15 @@ namespace AtomSampleViewer
                 m_assetTrackingTimeout -= deltaTime;
                 if (m_assetTrackingTimeout < 0)
                 {
-                    AZ_Error("Automation", false, "Script asset tracking timed out. Continuing...");
+                    auto incomplateAssetList = m_assetStatusTracker.GetIncompleteAssetList();
+                    AZStd::string incompleteAssetListString;
+                    AzFramework::StringFunc::Join(incompleteAssetListString, incomplateAssetList.begin(), incomplateAssetList.end(), "\n    ");
+                    AZ_Error("Automation", false, "Script asset tracking timed out waiting for:\n    %s \n Continuing...", incompleteAssetListString.c_str());
                     m_waitForAssetTracker = false;
                 }
                 else if (m_assetStatusTracker.DidExpectedAssetsFinish())
                 {
+                    AZ_Printf("Automation", "Asset Tracker finished with %f seconds remaining.", m_assetTrackingTimeout);
                     m_waitForAssetTracker = false;
                 }
                 else

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -23,27 +23,25 @@ function SetColorRed()
     AssetTracking_Start()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
     SetImguiValue('ColorA = Red', true)
-    AssetTracking_IdleUntilExpectedAssetsFinish(5)
+    AssetTracking_IdleUntilExpectedAssetsFinish(10)
     IdleSeconds(0.25) -- Idle for a bit to give time for the asset to reload
 end
 
 function SetBlendingOn()
     AssetTracking_Start()
     SetImguiValue('Blending On', true)
-    AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
-    AssetTracking_IdleUntilExpectedAssetsFinish(60)
+    AssetTracking_IdleUntilExpectedAssetsFinish(10)
     IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
 end
 
 function SetBlendingOff()
     AssetTracking_Start()
     SetImguiValue('Blending Off', true)
-    AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
-    AssetTracking_IdleUntilExpectedAssetsFinish(60)
+    AssetTracking_IdleUntilExpectedAssetsFinish(10)
     IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
 end
 
@@ -55,31 +53,29 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/02_Red.png')
 AssetTracking_Start()
 SetImguiValue('ColorA = Blue', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
-AssetTracking_IdleUntilExpectedAssetsFinish(5)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(0.25) -- Idle for a bit to give time for the asset to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/03_Blue.png')
 
 AssetTracking_Start()
 SetImguiValue('Default Colors', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
-AssetTracking_IdleUntilExpectedAssetsFinish(5)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(0.25) -- Idle for a bit to give time for the asset to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/04_DefaultAgain.png')
 
 AssetTracking_Start()
 SetImguiValue('Wavy Lines', true)
-AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
-AssetTracking_IdleUntilExpectedAssetsFinish(5)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/05_WavyLines.png')
 
 AssetTracking_Start()
 SetImguiValue('Vertical Pattern', true)
-AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
-AssetTracking_IdleUntilExpectedAssetsFinish(60)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png')
 
@@ -90,7 +86,7 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/07_BlendingOn.png')
 AssetTracking_Start()
 SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
-AssetTracking_IdleUntilExpectedAssetsFinish(60)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png')
 
@@ -98,7 +94,7 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png')
 AssetTracking_Start()
 SetImguiValue('ShaderVariantList/Only Straight Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
-AssetTracking_IdleUntilExpectedAssetsFinish(60)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.png')
 
@@ -106,7 +102,7 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.pn
 AssetTracking_Start()
 SetImguiValue('ShaderVariantList/Only Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
-AssetTracking_IdleUntilExpectedAssetsFinish(60)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/10_Variants_OnlyWavyLines.png')
 
@@ -128,7 +124,7 @@ SetBlendingOff()
 AssetTracking_Start()
 SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
-AssetTracking_IdleUntilExpectedAssetsFinish(60)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png')
 -- Now that the material is using a fully-baked variant, modify the .azsl file to force *everything* to rebuild. In the failure case, the runtime
@@ -138,10 +134,9 @@ AssetTracking_Start()
 SetImguiValue('Horizontal Pattern', true)
 -- Note that here we explicitly do NOT wait for HotReloadTest.shadervariantlist even though the ShaderVariantAssets will be rebuild here too; 
 -- part of this test is to ensure the updated shader code is used as soon as the root variant is available.
-AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
-AssetTracking_IdleUntilExpectedAssetsFinish(60)
+AssetTracking_IdleUntilExpectedAssetsFinish(10)
 -- We want this idle to be short enough that the ShaderVariantAssets don't have time to finish building before we take the screenshot, as part
 -- of the validation that the root variant gets applied asap. But it also needs to be long enough to account for some delay between the
 -- AssetTracking utility and the asset system triggering the reload. We should avoid increasing this if possible (but maybe we'll have no 


### PR DESCRIPTION
Since we removed the job dependency between .material and .materialtype, any changes to .materialtype, .shader, or .azsl files will not trigger a rebuild of the .material file. So I removed some AssetTracking_ExpectAsset("HotReloadTest.material") calls that are no longer appropriate.
Changed the timeout from 60s to 10s in case timeouts do occur in the future, we won't have to wait quite as long.
Improved the error reporting to list the specific files that timed out.

Testing: Ran the test script 10 times with no failures, dx12 and vulkan.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>