### PR TITLE
Compilation fix - missing include in ASV to stabilization

### DIFF
--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
@@ -15,6 +15,7 @@
 #include <Atom/RHI/RayTracingShaderTable.h>
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
 
 #include <RayTracing/RayTracingFeatureProcessor.h>
 


### PR DESCRIPTION
Signed-off-by: Adi Bar-Lev <82479970+Adi-Amazon@users.noreply.github.com>