### PR TITLE
ASV SSAO Fix

### DIFF
--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -14,6 +14,7 @@
 
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>
+#include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
 
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
@@ -52,6 +53,10 @@ namespace AtomSampleViewer
 
     void SsaoExampleComponent::Activate()
     {
+        // We have a non-msaa pipeline, adjust the shader system supervariant settings accordingly
+        AZ::Name noMsaaSupervariant = AZ::Name(AZ::RPI::NoMsaaSupervariantName);
+        AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(noMsaaSupervariant);
+
         RHI::Ptr<RHI::Device> device = RHI::RHISystemInterface::Get()->GetDevice();
         m_rayTracingEnabled = device->GetFeatures().m_rayTracing;
 
@@ -75,6 +80,10 @@ namespace AtomSampleViewer
         DeactivateSsaoPipeline();
         AZ::Render::Bootstrap::DefaultWindowNotificationBus::Handler::BusDisconnect();
         AZ::TickBus::Handler::BusDisconnect();
+
+        // Reset the number of MSAA samples and the RPI scene
+        SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::ResetNumMSAASamples);
+        SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::ClearRPIScene);
     }
 
     // --- World Model ---

--- a/Passes/SsaoPipeline.pass
+++ b/Passes/SsaoPipeline.pass
@@ -36,13 +36,8 @@
                     "TemplateName": "RayTracingAccelerationStructurePassTemplate"
                 },
                 {
-                    "Name": "CascadedShadowmapsPass",
-                    "TemplateName": "CascadedShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "shadow",
-                        "PipelineViewTag": "DirectionalLightView"
-                    },
+                    "Name": "DepthPrePass",
+                    "TemplateName": "DepthMSAAParentTemplate",
                     "Connections": [
                         {
                             "LocalSlot": "SkinnedMeshes",
@@ -50,183 +45,116 @@
                                 "Pass": "SkinningPass",
                                 "Attachment": "SkinnedMeshOutputStream"
                             }
-                        }
-                    ]
-                },
-                {
-                    "Name": "ProjectedShadowmapsPass",
-                    "TemplateName": "ProjectedShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "shadow",
-                        "PipelineViewTag": "ProjectedShadowView"
-                    },
-                    "Connections": [
+                        },
                         {
-                            "LocalSlot": "SkinnedMeshes",
+                            "LocalSlot": "SwapChainOutput",
                             "AttachmentRef": {
-                                "Pass": "SkinningPass",
-                                "Attachment": "SkinnedMeshOutputStream"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "EsmShadowmapsPassDirectional",
-                    "TemplateName": "EsmShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "EsmShadowmapsPassData",
-                        "LightType": "directional"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "DepthShadowmaps",
-                            "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
-                                "Attachment": "Shadowmap"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "EsmShadowmapsPassProjected",
-                    "TemplateName": "EsmShadowmapsTemplate",
-                    "PassData": {
-                        "$type": "EsmShadowmapsPassData",
-                        "LightType": "projected"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "DepthShadowmaps",
-                            "AttachmentRef": {
-                                "Pass": "ProjectedShadowmapsPass",
-                                "Attachment": "Shadowmap"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "DepthPass",
-                    "TemplateName": "DepthPassTemplate",
-                    "PassData": {
-                        "$type": "RasterPassData",
-                        "DrawListTag": "depth",
-                        "PipelineViewTag": "MainCamera"
-                    },
-                    "Connections": [
-                        {
-                            "LocalSlot": "SkinnedMeshes",
-                            "AttachmentRef": {
-                                "Pass": "SkinningPass",
-                                "Attachment": "SkinnedMeshOutputStream"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "LightCullingTilePreparePass",
-                    "TemplateName": "LightCullingTilePrepareMSAATemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "Depth",
-                            "AttachmentRef": {
-                                "Pass": "DepthPass",
-                                "Attachment": "Output"
+                                "Pass": "Parent",
+                                "Attachment": "SwapChainOutput"
                             }
                         }
                     ]
                 },
                 {
                     "Name": "LightCullingPass",
-                    "TemplateName": "LightCullingTemplate",
+                    "TemplateName": "LightCullingParentTemplate",
                     "Connections": [
                         {
-                            "LocalSlot": "TileLightData",
+                            "LocalSlot": "SkinnedMeshes",
                             "AttachmentRef": {
-                                "Pass": "LightCullingTilePreparePass",
-                                "Attachment": "TileLightData"
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
+                            }
+                        },
+                        {
+                            "LocalSlot": "DepthMSAA",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
+                            }
+                        },
+                        {
+                            "LocalSlot": "SwapChainOutput",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "SwapChainOutput"
                             }
                         }
                     ]
                 },
                 {
-                    "Name": "LightCullingRemapPass",
-                    "TemplateName": "LightCullingRemapTemplate",
+                    "Name": "ShadowPass",
+                    "TemplateName": "ShadowParentTemplate",
                     "Connections": [
                         {
-                            "LocalSlot": "TileLightData",
+                            "LocalSlot": "SkinnedMeshes",
                             "AttachmentRef": {
-                                "Pass": "LightCullingTilePreparePass",
-                                "Attachment": "TileLightData"
+                                "Pass": "SkinningPass",
+                                "Attachment": "SkinnedMeshOutputStream"
                             }
                         },
                         {
-                            "LocalSlot": "LightCount",
+                            "LocalSlot": "SwapChainOutput",
                             "AttachmentRef": {
-                                "Pass": "LightCullingPass",
-                                "Attachment": "LightCount"
-                            }
-                        },
-                        {
-                            "LocalSlot": "LightList",
-                            "AttachmentRef": {
-                                "Pass": "LightCullingPass",
-                                "Attachment": "LightList"
+                                "Pass": "Parent",
+                                "Attachment": "SwapChainOutput"
                             }
                         }
                     ]
                 },
                 {
-                    "Name": "ForwardPass",
-                    "TemplateName": "ForwardPassTemplate",
+                    "Name": "ForwardMSAAPass",
+                    "TemplateName": "ForwardMSAAPassTemplate",
                     "Connections": [
+                        // Inputs...
                         {
                             "LocalSlot": "DirectionalLightShadowmap",
                             "AttachmentRef": {
-                                "Pass": "CascadedShadowmapsPass",
-                                "Attachment": "Shadowmap"
+                                "Pass": "ShadowPass",
+                                "Attachment": "DirectionalShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ExponentialShadowmapDirectional",
                             "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassDirectional",
-                                "Attachment": "EsmShadowmaps"
+                                "Pass": "ShadowPass",
+                                "Attachment": "DirectionalESM"
                             }
                         },
                         {
                             "LocalSlot": "ProjectedShadowmap",
                             "AttachmentRef": {
-                                "Pass": "ProjectedShadowmapsPass",
-                                "Attachment": "Shadowmap"
+                                "Pass": "ShadowPass",
+                                "Attachment": "ProjectedShadowmap"
                             }
                         },
                         {
                             "LocalSlot": "ExponentialShadowmapProjected",
                             "AttachmentRef": {
-                                "Pass": "EsmShadowmapsPassProjected",
-                                "Attachment": "EsmShadowmaps"
-                            }
-                        },
-                        {
-                            "LocalSlot": "DepthStencilInputOutput",
-                            "AttachmentRef": {
-                                "Pass": "DepthPass",
-                                "Attachment": "Output"
+                                "Pass": "ShadowPass",
+                                "Attachment": "ProjectedESM"
                             }
                         },
                         {
                             "LocalSlot": "TileLightData",
                             "AttachmentRef": {
-                                "Pass": "LightCullingTilePreparePass",
+                                "Pass": "LightCullingPass",
                                 "Attachment": "TileLightData"
                             }
                         },
                         {
                             "LocalSlot": "LightListRemapped",
                             "AttachmentRef": {
-                                "Pass": "LightCullingRemapPass",
+                                "Pass": "LightCullingPass",
                                 "Attachment": "LightListRemapped"
+                            }
+                        },
+                        // Input/Outputs...
+                        {
+                            "LocalSlot": "DepthStencilInputOutput",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthMSAA"
                             }
                         }
                     ],
@@ -246,41 +174,15 @@
                         {
                             "LocalSlot": "InputDepth",
                             "AttachmentRef": {
-                                "Pass": "ForwardPass",
+                                "Pass": "ForwardMSAAPass",
                                 "Attachment": "DepthStencilInputOutput"
                             }
                         },
                         {
                             "LocalSlot": "WorldNormal",
                             "AttachmentRef": {
-                                "Pass": "ForwardPass",
+                                "Pass": "ForwardMSAAPass",
                                 "Attachment": "NormalOutput"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "DepthToLinearDepthPass",
-                    "TemplateName": "DepthToLinearTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "Input",
-                            "AttachmentRef": {
-                                "Pass": "DepthPass",
-                                "Attachment": "Output"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "Name": "Ssao",
-                    "TemplateName": "SsaoParentTemplate",
-                    "Connections": [
-                        {
-                            "LocalSlot": "LinearDepth",
-                            "AttachmentRef": {
-                                "Pass": "DepthToLinearDepthPass",
-                                "Attachment": "Output"
                             }
                         }
                     ]
@@ -328,32 +230,24 @@
                     }
                 },
                 {
-                    "Name": "ModulateWithSsao",
-                    "TemplateName": "ModulateTextureTemplate",
-                    "Enabled": true,
+                    "Name": "Ssao",
+                    "TemplateName": "SsaoParentTemplate",
                     "Connections": [
                         {
-                            "LocalSlot": "Input",
+                            "LocalSlot": "LinearDepth",
                             "AttachmentRef": {
-                                "Pass": "Ssao",
-                                "Attachment": "Output"
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
                             }
                         },
                         {
-                            "LocalSlot": "InputOutput",
+                            "LocalSlot": "Modulate",
                             "AttachmentRef": {
                                 "Pass": "DebugWhiteTexture",
                                 "Attachment": "Output"
                             }
                         }
-                    ],
-                    "PassData": {
-                        "$type": "ComputePassData",
-                        "ShaderAsset": {
-                            "FilePath": "Shaders/PostProcessing/ModulateTexture.shader"
-                        },
-                        "Make Fullscreen Pass": true
-                    }
+                    ]
                 },
                 {
                     "Name": "SelectorPass",
@@ -370,8 +264,8 @@
                         {
                             "LocalSlot": "Input2",
                             "AttachmentRef": {
-                                "Pass": "ModulateWithSsao",
-                                "Attachment": "InputOutput"
+                                "Pass": "Ssao",
+                                "Attachment": "Output"
                             }
                         }
                     ]
@@ -422,7 +316,7 @@
                         "$type": "ImGuiPassData",
                         "IsDefaultImGui": true
                     }
-                },		
+                },
                 {
                     "Name": "2DPass",
                     "TemplateName": "UIPassTemplate",
@@ -438,8 +332,8 @@
                         {
                             "LocalSlot": "DepthInputOutput",
                             "AttachmentRef": {
-                                "Pass": "DepthPass",
-                                "Attachment": "Output"
+                                "Pass": "DepthPrePass",
+                                "Attachment": "Depth"
                             }
                         }
                     ],


### PR DESCRIPTION
Fixed SSAO pipeline to use updated SSAO pass as well as other updated passes.
Also fixed an issue with non-msaa shaders that would spam an error in the SSAO ASV sample.

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>