### PR TITLE
Added call to LegacySystemInterfaceCreated after the system entity is…

### DIFF
--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -9,6 +9,7 @@
 #include <AtomSampleViewerApplication.h>
 #include <SampleComponentManagerBus.h>
 
+#include <AzCore/Component/ComponentApplicationLifecycle.h>
 #include <AzCore/PlatformIncl.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Debug/Trace.h>
@@ -91,6 +92,10 @@ namespace AtomSampleViewer
         AzFramework::AssetSystemStatusBus::Handler::BusConnect();
 
         AzFramework::Application::StartCommon(systemEntity);
+        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
+        {
+            AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "LegacySystemInterfaceCreated", R"({})");
+        }
 
         ReadTimeoutShutdown();
 


### PR DESCRIPTION
… created, so that BootstrapSystemComponent.cpp initializes in the AtomSampleViewerApplication with the new startup logic.

Signed-off-by: stankowi <4838196+AMZN-stankowi@users.noreply.github.com>