### PR TITLE
Added a new screenshot test for ThinObject transmission

### DIFF
--- a/Gem/Code/Source/ShaderReloadTestComponent.cpp
+++ b/Gem/Code/Source/ShaderReloadTestComponent.cpp
@@ -11,6 +11,7 @@
 #include <AzFramework/IO/LocalFileIO.h>
 
 #include <Atom/RPI.Public/View.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
 
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 
@@ -128,7 +129,7 @@ namespace AtomSampleViewer
 
     bool ShaderReloadTestComponent::ReadInConfig(const AZ::ComponentConfig*)
     {
-        m_scene = RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("RPI"));
+        m_scene = AZ::RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("RPI"));
         return true;
     }
 
@@ -188,7 +189,7 @@ namespace AtomSampleViewer
             {shaderAssetPath, azrtti_typeid<AZ::RPI::ShaderAsset>()},
         };
 
-        m_assetLoadManager.LoadAssetsAsync(assetList, [&](AZStd::string_view assetName, [[maybe_unused]] bool success, size_t pendingAssetCount)
+        m_assetLoadManager.LoadAssetsAsync(assetList, [&]([[maybe_unused]] AZStd::string_view assetName, [[maybe_unused]] bool success, size_t pendingAssetCount)
             {
                 AZ_Error(LogName, success, "Error loading asset %s, a crash will occur when OnAllAssetsReadyActivate() is called!", assetName.data());
                 AZ_TracePrintf(LogName, "Asset %s loaded %s. Wait for %zu more assets before full activation\n", assetName.data(), success ? "successfully" : "UNSUCCESSFULLY", pendingAssetCount);

--- a/Objects/grass_tile_large.fbx
+++ b/Objects/grass_tile_large.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44cfaf47811e14f0ce29e45694188dcc025787170b080347c718df9c535f3573
+size 449660

--- a/Scripts/ExpectedScreenshots/StandardPBR/015_subsurfacescattering_transmission_thin.png
+++ b/Scripts/ExpectedScreenshots/StandardPBR/015_subsurfacescattering_transmission_thin.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b23df9b20d354c9fa4829e2ca7e180c6dc2562bdb8c420c24c4da39966976cbe
+size 610786

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -17,6 +17,7 @@ g_modelWithoutLayerMask = 'objects/bunny.azmodel'
 g_modelWithLayerMask = 'testdata/objects/paintedplane.azmodel'
 g_modelHermanubis = 'materialeditor/viewportmodels/hermanubis.azmodel'
 g_modelTube = 'testdata/objects/tube.azmodel'
+g_modelGrass = 'objects/grass_tile_large.azmodel'
 
 function GenerateMaterialScreenshot(imageComparisonThresholdLevel, materialName, options)
     if options == nil then options = {} end
@@ -123,6 +124,7 @@ GenerateMaterialScreenshot('Level H', '014_ClearCoat_NormalMap_2ndUv', {lighting
 GenerateMaterialScreenshot('Level F', '014_ClearCoat_RoughnessMap', {lighting="Neutral Urban"})
 GenerateMaterialScreenshot('Level F', '015_SubsurfaceScattering', {lighting="Dark Test Lighting", cameraHeading = 45.0, cameraPitch=30.0, cameraDistance=1.5})
 GenerateMaterialScreenshot('Level D', '015_SubsurfaceScattering_Transmission', {lighting="Dark Test Lighting", cameraHeading = 45.0, cameraPitch=-30.0, cameraDistance=1.5})
+GenerateMaterialScreenshot('Level E', '015_SubsurfaceScattering_Transmission_Thin', {model=g_modelGrass, lighting="Goegap (Alt)", cameraHeading = -150.0, cameraPitch=5.0, cameraDistance=1.5})
 GenerateMaterialScreenshot('Level I', '100_UvTiling_AmbientOcclusion')
 GenerateMaterialScreenshot('Level I', '100_UvTiling_BaseColor')
 GenerateMaterialScreenshot('Level I', '100_UvTiling_Emissive')


### PR DESCRIPTION
Includes a new grass model as well from @shawstar  

Requires o3de changes here: https://github.com/o3de/o3de/pull/5360

![015_subsurfacescattering_transmission_thin](https://user-images.githubusercontent.com/55155825/140461829-13cf12fc-a0a6-432d-b071-6ec92449bc19.png)

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>