### PR TITLE
Updating AtomSampleViewerApplication to the TimeSystem change

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -394,7 +394,7 @@ namespace AtomSampleViewer
 
                 if (m_frameTimeIsLocked)
                 {
-                    AZ::Interface<AZ::IConsole>::Get()->PerformCommand("t_frameTimeOverride 0");
+                    AZ::Interface<AZ::IConsole>::Get()->PerformCommand("t_simulationTickDeltaOverride 0");
                     m_frameTimeIsLocked = false;
                 }
 
@@ -903,7 +903,7 @@ namespace AtomSampleViewer
         {
             AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
 
-            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(AZStd::string::format("t_frameTimeOverride %f", seconds).c_str());
+            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(AZStd::string::format("t_simulationTickDeltaOverride %f", seconds).c_str());
             s_instance->m_frameTimeIsLocked = true;
         };
 
@@ -916,7 +916,7 @@ namespace AtomSampleViewer
         {
             AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
 
-            AZ::Interface<AZ::IConsole>::Get()->PerformCommand("t_frameTimeOverride 0");
+            AZ::Interface<AZ::IConsole>::Get()->PerformCommand("t_simulationTickDeltaOverride 0");
             s_instance->m_frameTimeIsLocked = false;
         };
 

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/PlatformIncl.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Debug/Trace.h>
+#include <AzCore/Time/ITime.h>
 
 #include <AzFramework/Asset/AssetSystemBus.h>
 #include <AzFramework/Asset/AssetProcessorMessages.h>
@@ -202,11 +203,11 @@ namespace AtomSampleViewer
         Application::Destroy();
     }
 
-    void AtomSampleViewerApplication::Tick(float deltaOverride)
+    void AtomSampleViewerApplication::Tick()
     {
         TickSystem();
-        Application::Tick(deltaOverride);
-        TickTimeoutShutdown(m_deltaTime); // deltaOverride comes in as -1.f in AtomSampleViewerApplication
+        Application::Tick();
+        TickTimeoutShutdown();
     }
 
     void AtomSampleViewerApplication::ReadTimeoutShutdown()
@@ -220,11 +221,12 @@ namespace AtomSampleViewer
         }
     }
 
-    void AtomSampleViewerApplication::TickTimeoutShutdown(float deltaTimeInSeconds)
+    void AtomSampleViewerApplication::TickTimeoutShutdown()
     {
         if (m_secondsBeforeShutdown > 0.f)
         {
-            m_secondsBeforeShutdown -= deltaTimeInSeconds;
+            const AZ::TimeUs deltaTimeUs = AZ::GetRealTickDeltaTimeUs();
+            m_secondsBeforeShutdown -= AZ::TimeUsToSeconds(deltaTimeUs);
             if (m_secondsBeforeShutdown <= 0.f)
             {
                 AZ_Printf("AtomSampleViewer", "Timeout reached, shutting down");

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.h
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.h
@@ -47,7 +47,7 @@ namespace AtomSampleViewer
         void CompileCriticalAssets();
 
         void StartCommon(AZ::Entity* systemEntity) override;
-        void Tick(float deltaOverride) override;
+        void Tick() override;
 
         //////////////////////////////////////////////////////////////////////////
         // AzFramework::ApplicationRequests::Bus
@@ -57,7 +57,7 @@ namespace AtomSampleViewer
         static const bool s_connectToAssetProcessor;
 
         void ReadTimeoutShutdown();
-        void TickTimeoutShutdown(float deltaTimeInSeconds);
+        void TickTimeoutShutdown();
         float m_secondsBeforeShutdown = 0.0f; // >0.0f If timeout shutdown is enabled, this will count down the time until quit() is called.
 
         //////////////////////////// Logging section /////////////////////////////


### PR DESCRIPTION
This change is required with this PR in o3de.
https://github.com/o3de/o3de/pull/5409
