### PR TITLE
Build Fix: Updated calls to ApplicationRequestBus GetEngineRoot event

### DIFF
--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -85,14 +85,6 @@ namespace AtomSampleViewer
         // Load a default image
         QueueAssetPathForLoad("textures/tonemapping/hdr_test_pattern.exr.streamingimage");
 
-        const char* engineRoot = nullptr;
-        AZStd::string screenshotFolder;
-        AzFramework::ApplicationRequests::Bus::BroadcastResult(engineRoot, &AzFramework::ApplicationRequests::GetEngineRoot);
-        if (engineRoot)
-        {
-            AzFramework::StringFunc::Path::Join(engineRoot, "Screenshots", screenshotFolder, true, false);
-        }
-
         Data::Asset<RPI::AnyAsset> displayMapperAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::AnyAsset>("passes/DisplayMapperConfiguration.azasset", RPI::AssetUtils::TraceLevel::Error);
         const Render::DisplayMapperConfigurationDescriptor* displayMapperConfigurationDescriptor = RPI::GetDataFromAnyAsset<Render::DisplayMapperConfigurationDescriptor>(displayMapperAsset);
         if (displayMapperConfigurationDescriptor == nullptr)

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -106,6 +106,7 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Debug/Profiler.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/std/algorithm.h>
 
@@ -420,25 +421,25 @@ namespace AtomSampleViewer
         }
 
         // Set default screenshot folder to relative path 'Screenshots'
-        AZStd::string screenshotFolder = "Screenshots";
+        AZ::IO::Path screenshotFolder = "Screenshots";
         // Get folder from command line if it exists
         static const char* screenshotFolderFlagName = "screenshotFolder";
         if (commandLine->HasSwitch(screenshotFolderFlagName))
         {
             screenshotFolder = commandLine->GetSwitchValue(screenshotFolderFlagName, 0);
-            AzFramework::StringFunc::Path::Normalize(screenshotFolder);
         }
 
-        if (AzFramework::StringFunc::Path::IsRelative(screenshotFolder.c_str()))
-        {
-            const char* engineRoot = nullptr;
-            AzFramework::ApplicationRequests::Bus::BroadcastResult(engineRoot, &AzFramework::ApplicationRequests::GetEngineRoot);
-            AzFramework::StringFunc::Path::Join(engineRoot, screenshotFolder.c_str(), screenshotFolder, true, false);
-        }
+        // Make the screenshot directory relative to the Writeable Storage Path
+        // The Path::operator/ smartly knows how to concatenate two absolute paths
+        // i.e <absolute path1> / <absolute path2> = <absolute path2>
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ::IO::Path writableStoragePath;
+        settingsRegistry->Get(writableStoragePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_DevWriteStorage);
+        screenshotFolder = writableStoragePath / screenshotFolder;
 
-        m_imguiFrameCaptureSaver.SetDefaultFolder(screenshotFolder);
+        m_imguiFrameCaptureSaver.SetDefaultFolder(screenshotFolder.Native());
         m_imguiFrameCaptureSaver.SetDefaultFileName("screenshot");
-        m_imguiFrameCaptureSaver.SetAvailableExtensions({"png", "ppm", "dds"});
+        m_imguiFrameCaptureSaver.SetAvailableExtensions({ "png", "ppm", "dds" });
         m_imguiFrameCaptureSaver.Activate();
 
         SampleComponentManagerRequestBus::Handler::BusConnect();

--- a/Gem/Code/Source/SponzaBenchmarkComponent.h
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.h
@@ -13,6 +13,7 @@
 #include <AtomCore/Instance/InstanceId.h>
 
 #include <AzCore/Component/TickBus.h>
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/string/string_view.h>
 
@@ -158,7 +159,7 @@ namespace AtomSampleViewer
         AZ::Component* m_cameraControlComponent = nullptr;
 
         AZStd::vector<uint64_t> m_framesToCapture;
-        AZStd::string m_screenshotFolder;
+        AZ::IO::Path m_screenshotFolder;
 
         // Lights
         AZ::Render::DirectionalLightFeatureProcessorInterface* m_directionalLightFeatureProcessor = nullptr;

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -130,15 +130,15 @@ namespace AtomSampleViewer
         // Queue load all the textures under Textures\Streaming folder
         for (uint32_t index = 0; index < TestDDSCount; index++)
         {
-            AZStd::string filePath = TestImageFolder + AZStd::string::format("streaming%d.dds.streamingimage", index);
-            QueueForLoad(filePath);
+            AZ::IO::Path filePath = TestImageFolder / AZStd::string::format("streaming%d.dds.streamingimage", index);
+            QueueForLoad(filePath.Native());
         }
 
         // All Images loaded here have non-power-of-two sizes
         for (uint32_t index = 0; index < TestPNGCount; index++)
         {
-            AZStd::string filePath = TestImageFolder + AZStd::string::format("streaming%d.png.streamingimage", index);
-            QueueForLoad(filePath);
+            AZ::IO::Path filePath = TestImageFolder / AZStd::string::format("streaming%d.png.streamingimage", index);
+            QueueForLoad(filePath.Native());
         }
 
         AZ::TickBus::Handler::BusConnect();
@@ -270,7 +270,7 @@ namespace AtomSampleViewer
     {
         if (!m_imageHotReload.m_assetId.IsValid())
         {
-            AZStd::string filePath = TestImageFolder + ReloadTestImageName + ".streamingimage";
+            AZ::IO::Path filePath = TestImageFolder / (ReloadTestImageName.Native() + ".streamingimage");
             AZ::Data::AssetCatalogRequestBus::BroadcastResult(
                 m_imageHotReload.m_assetId, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, filePath.c_str(),
                 azrtti_typeid <AZ::RPI::StreamingImageAsset>(), false);
@@ -533,24 +533,17 @@ namespace AtomSampleViewer
         AZStd::string sourceImageFiles[] = {
             {"streaming1.png"}, {"streaming2.png" }
         };
-        
-        auto projectPath = AZ::Utils::GetProjectPath();
-        AZStd::string srcPath, destPath;
-        AzFramework::StringFunc::Path::Join(projectPath.c_str(), (TestImageFolder + sourceImageFiles[m_curSourceImage]).c_str(), srcPath);
-        AzFramework::StringFunc::Path::Join(projectPath.c_str(), (TestImageFolder + ReloadTestImageName).c_str(), destPath);
 
-        CopyFile(destPath, srcPath);
+        AZ::IO::FixedMaxPath projectPath = AZ::Utils::GetProjectPath();
+        AZ::IO::FixedMaxPath srcPath = projectPath / TestImageFolder / sourceImageFiles[m_curSourceImage];
+        AZ::IO::FixedMaxPath destPath = projectPath / TestImageFolder / ReloadTestImageName;
+
+        CopyFile(destPath.String(), srcPath.String());
     }
 
     void StreamingImageExampleComponent::DeleteHotReloadImage()
     {
-        const char* engineRoot = nullptr;
-        AzFramework::ApplicationRequests::Bus::BroadcastResult(engineRoot, &AzFramework::ApplicationRequests::GetEngineRoot);
-
-        AZStd::string testFilePath = "AtomSampleViewer/" + TestImageFolder + ReloadTestImageName;
-        AZStd::string testFileFullPath;
-        AzFramework::StringFunc::Path::Join(engineRoot, testFilePath.c_str(), testFileFullPath);
-
+        const auto testFileFullPath = AZ::IO::FixedMaxPath(AZ::Utils::GetProjectPath()) / TestImageFolder / ReloadTestImageName;
         if (AZ::IO::SystemFile::Exists(testFileFullPath.c_str()))
         {
             AZ::IO::SystemFile::Delete(testFileFullPath.c_str());

--- a/Gem/Code/Source/StreamingImageExampleComponent.h
+++ b/Gem/Code/Source/StreamingImageExampleComponent.h
@@ -20,6 +20,7 @@
 
 #include <AzFramework/Asset/AssetCatalogBus.h>
 
+#include <AzCore/IO/Path/Path.h>
 #include <AzCore/Component/TickBus.h>
 
 #include <Utils/ImGuiSidebar.h>
@@ -128,8 +129,8 @@ namespace AtomSampleViewer
 
         const static uint32_t TestDDSCount = 36; // For image streaming and profile
         const static uint32_t TestPNGCount = 4; // For non-power-of-two textures
-        const AZStd::string TestImageFolder = "textures/streaming/";
-        const AZStd::string ReloadTestImageName = "reloadtest.png";
+        const AZ::IO::Path TestImageFolder = "Textures/Streaming";
+        const AZ::IO::Path ReloadTestImageName = "reloadtest.png";
         // Constants of display area for showing all streaming images.
         // As reference, the window's left bottom is (-1, -1). The window size is (2, 2)
         const float AreaWidth = 1.5f;

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/Component/Entity.h>
 #include <AzCore/IO/Path/Path.h>
+#include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzFramework/Components/TransformComponent.h>
 #include <AzFramework/Entity/EntityContextBus.h>
 
@@ -91,13 +92,10 @@ namespace AtomSampleViewer
         // Load a default image
         QueueAssetPathForLoad("textures/tonemapping/hdr_test_pattern.exr.streamingimage");
 
-        const char* engineRoot = nullptr;
-        AZStd::string screenshotFolder;
-        AzFramework::ApplicationRequests::Bus::BroadcastResult(engineRoot, &AzFramework::ApplicationRequests::GetEngineRoot);
-        if (engineRoot)
-        {
-            AzFramework::StringFunc::Path::Join(engineRoot, "Screenshots", screenshotFolder, true, false);
-        }
+        auto settingsRegistry = AZ::SettingsRegistry::Get();
+        AZ::IO::Path writableStoragePath;
+        settingsRegistry->Get(writableStoragePath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_DevWriteStorage);
+        AZ::IO::Path screenshotFolder = writableStoragePath / "Screenshots";
 
         Data::Asset<RPI::AnyAsset> displayMapperAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::AnyAsset>("passes/DisplayMapperConfiguration.azasset", RPI::AssetUtils::TraceLevel::Error);
         const Render::DisplayMapperConfigurationDescriptor* displayMapperConfigurationDescriptor = RPI::GetDataFromAnyAsset<Render::DisplayMapperConfigurationDescriptor>(displayMapperAsset);
@@ -109,7 +107,7 @@ namespace AtomSampleViewer
         m_displayMapperConfiguration = *displayMapperConfigurationDescriptor;
         UpdateCapturePassHierarchy();
 
-        m_imguiFrameCaptureSaver.SetDefaultFolder(screenshotFolder);
+        m_imguiFrameCaptureSaver.SetDefaultFolder(screenshotFolder.Native());
         m_imguiFrameCaptureSaver.SetDefaultFileName("tonemap_capture");
         m_imguiFrameCaptureSaver.SetAvailableExtensions({ "dds" });
         m_imguiFrameCaptureSaver.Activate();


### PR DESCRIPTION
All the locations have been updated to either use GetProjectPath when retrieving a file path relative to the project root or query the FilePathKey_DevWriteStorage setting to find a writable directory for Screenshots

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>