### PR TITLE
AR Fixes for project specific artifact collection

### DIFF
--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -496,9 +496,9 @@ def UploadAPLogs(Map options, String branchName, String platformName, String job
                 pythonPath = "${options.PYTHON_DIR}/python.cmd"
             }
             def command = "${pythonPath} -u ${s3UploadScriptPath} --base_dir ${apLogsPath} " +
-                            "--file_regex \".*\" --bucket ${env.AP_LOGS_S3_BUCKET} " +
-                            "--search_subdirectories True --key_prefix ${PROJECT_REPOSITORY_NAME}/${branchName}/${env.BUILD_NUMBER}/${platformName}/${jobName} " +
-                            '--extra_args {\\"ACL\\":\\"bucket-owner-full-control\\"}'
+                          "--file_regex \".*\" --bucket ${env.AP_LOGS_S3_BUCKET} " +
+                          "--search_subdirectories True --key_prefix ${PROJECT_REPOSITORY_NAME}/${branchName}/${env.BUILD_NUMBER}/${platformName}/${jobName} " +
+                          '--extra_args {\\"ACL\\":\\"bucket-owner-full-control\\"}'
             palSh(command, "Uploading AP logs for job ${jobName} for branch ${branchName}", false)
         }
     }

--- a/Scripts/build/Jenkins/Jenkinsfile
+++ b/Scripts/build/Jenkins/Jenkinsfile
@@ -460,7 +460,7 @@ def ExportTestResults(Map options, String platform, String type, String workspac
     catchError(message: "Error exporting tests results (this won't fail the build)", buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         def o3deroot = "${workspace}/${ENGINE_REPOSITORY_NAME}"
         dir("${o3deroot}/${params.OUTPUT_DIRECTORY}") {
-            junit testResults: "Testing/**/*.xml"
+            junit testResults: "Testing/**/*.xml", skipPublishingChecks: true
             palRmDir("Testing")
             // Recreate test runner xml directories that need to be pre generated
             palMkdir("Testing/Pytest")
@@ -472,12 +472,12 @@ def ExportTestResults(Map options, String platform, String type, String workspac
 def ExportTestScreenshots(Map options, String branchName, String platformName, String jobName, String workspace, Map params) {
     catchError(message: "Error exporting test screenshots (this won't fail the build)", buildResult: 'SUCCESS', stageResult: 'FAILURE') {
         dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
-            def screenshotsFolder = "AutomatedTesting/user/PythonTests/Automated/Screenshots"
+            def screenshotsFolder = "${workspace}/${PROJECT_REPOSITORY_NAME}/user/Scripts/Screenshots"
             def s3Uploader = "scripts/build/tools/upload_to_s3.py"
             def command = "${options.PYTHON_DIR}/python.cmd -u ${s3Uploader} --base_dir ${screenshotsFolder} " +
-                          '--file_regex \\"(.*zip\$)\\" ' +
+                          '--file_regex \\"(.*\$)\\" ' +
                           "--bucket ${env.TEST_SCREENSHOT_BUCKET} " +
-                          "--search_subdirectories True --key_prefix ${branchName}_${env.BUILD_NUMBER} " +
+                          "--search_subdirectories True --key_prefix ${PROJECT_REPOSITORY_NAME}/${branchName}/${env.BUILD_NUMBER}/${jobName} " +
                           '--extra_args {\\"ACL\\":\\"bucket-owner-full-control\\"}'
             palSh(command, "Uploading test screenshots for ${jobName}")
         }
@@ -485,10 +485,9 @@ def ExportTestScreenshots(Map options, String branchName, String platformName, S
 }
 
 def UploadAPLogs(Map options, String branchName, String platformName, String jobName, String workspace, Map params) {
-    dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
-        projects = params.CMAKE_LY_PROJECTS.split(",")
-        projects.each{ project ->
-            def apLogsPath = "${project}/user/log"
+    catchError(message: "Error exporting logs (this won't fail the build)", buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+        dir("${workspace}/${ENGINE_REPOSITORY_NAME}") {
+            def apLogsPath = "${workspace}/${PROJECT_REPOSITORY_NAME}/user/log"
             def s3UploadScriptPath = "scripts/build/tools/upload_to_s3.py"
             if(env.IS_UNIX) {
                 pythonPath = "${options.PYTHON_DIR}/python.sh"
@@ -497,13 +496,13 @@ def UploadAPLogs(Map options, String branchName, String platformName, String job
                 pythonPath = "${options.PYTHON_DIR}/python.cmd"
             }
             def command = "${pythonPath} -u ${s3UploadScriptPath} --base_dir ${apLogsPath} " +
-                          "--file_regex \".*\" --bucket ${env.AP_LOGS_S3_BUCKET} " +
-                          "--search_subdirectories True --key_prefix ${env.JENKINS_JOB_NAME}/${branchName}/${env.BUILD_NUMBER}/${platformName}/${jobName} " +
-                          '--extra_args {\\"ACL\\":\\"bucket-owner-full-control\\"}'
+                            "--file_regex \".*\" --bucket ${env.AP_LOGS_S3_BUCKET} " +
+                            "--search_subdirectories True --key_prefix ${PROJECT_REPOSITORY_NAME}/${branchName}/${env.BUILD_NUMBER}/${platformName}/${jobName} " +
+                            '--extra_args {\\"ACL\\":\\"bucket-owner-full-control\\"}'
             palSh(command, "Uploading AP logs for job ${jobName} for branch ${branchName}", false)
-            }
         }
     }
+}
 
 def PostBuildCommonSteps(String workspace, boolean mount = true) {
     echo 'Starting post-build common steps...'


### PR DESCRIPTION
Set screenshot and log collection for ASV to specific folders, which don't map to o3de's folders

Also adds a non-blocking catch for the log collection