### PR TITLE
Updating alpha settings for 2 decal materials

### DIFF
--- a/Materials/Decal/am_mud_decal.material
+++ b/Materials/Decal/am_mud_decal.material
@@ -1,27 +1,25 @@
 {
     "description": "",
-    "materialType": "Materials\\Types\\StandardPBR.materialtype",
     "parentMaterial": "",
-    "materialTypeVersion": 3,
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 4,
     "properties": {
         "baseColor": {
-            "textureMap": "Materials/Decal/am_mud_decal.tif"
+            "textureMap": "am_mud_decal.tif"
         },
         "general": {
-            "applySpecularAA": false
+            "doubleSided": true
         },
         "metallic": {
             "useTexture": false
         },
         "normal": {
-            "textureMap": "Materials/Decal/am_mud_decal_nrm.tif"
-        },  
+            "textureMap": "am_mud_decal_nrm.tif"
+        },
         "opacity": {
-            "alphaSource": "Split",
-            "doubleSided": true,
-            "factor": 0.6899999976158142,
-            "mode": "Cutout",
-            "textureMap": "Materials/Decal/am_mud_decal.tif"
+            "factor": 1.0,
+            "mode": "Blended",
+            "textureMap": "am_mud_decal.tif"
         },
         "roughness": {
             "useTexture": false

--- a/Materials/Decal/scorch_01_decal.material
+++ b/Materials/Decal/scorch_01_decal.material
@@ -1,24 +1,25 @@
 {
     "description": "",
-    "materialType": "Materials/Types/StandardPBR.materialtype",
     "parentMaterial": "",
-    "materialTypeVersion": 3,
+    "materialType": "Materials/Types/StandardPBR.materialtype",
+    "materialTypeVersion": 4,
     "properties": {
         "baseColor": {
-            "textureMap": "Materials/Decal/scorch_01_decal.tif"
+            "textureMap": "scorch_01_decal.tif"
+        },
+        "general": {
+            "doubleSided": true
         },
         "metallic": {
             "useTexture": false
         },
         "normal": {
-            "textureMap": "Materials/Decal/scorch_01_decal_nrm.tif"
-        }, 
+            "textureMap": "scorch_01_decal_nrm.tif"
+        },
         "opacity": {
-            "alphaSource": "Split",
-            "doubleSided": true,
-            "factor": 0.6899999976158142,
-            "mode": "Cutout",
-            "textureMap": "Materials/Decal/scorch_01_decal.tif"
+            "factor": 1.0,
+            "mode": "Blended",
+            "textureMap": "scorch_01_decal.tif"
         },
         "roughness": {
             "useTexture": false


### PR DESCRIPTION
Updating decal material alpha settings so that they are the proper version and show alpha in the material-editor properly

ASV decal test runs fine

ATOM-15909

Signed-off-by: mrieggeramzn <mriegger@amazon.com>