### PR TITLE
Fixed RPI/Mesh sample to not crash when turning on ground plane

### DIFF
--- a/Gem/Code/Source/MeshExampleComponent.cpp
+++ b/Gem/Code/Source/MeshExampleComponent.cpp
@@ -381,15 +381,18 @@ namespace AtomSampleViewer
         {
             AZ::Transform groundPlaneTransform = AZ::Transform::CreateIdentity();
 
-            AZ::Vector3 modelCenter;
-            float modelRadius;
-            m_modelAsset->GetAabb().GetAsSphere(modelCenter, modelRadius);
+            if (m_modelAsset)
+            {
+                AZ::Vector3 modelCenter;
+                float modelRadius;
+                m_modelAsset->GetAabb().GetAsSphere(modelCenter, modelRadius);
 
-            static const float GroundPlaneRelativeScale = 4.0f;
-            static const float GroundPlaneOffset = 0.01f;
+                static const float GroundPlaneRelativeScale = 4.0f;
+                static const float GroundPlaneOffset = 0.01f;
 
-            groundPlaneTransform.SetUniformScale(GroundPlaneRelativeScale * modelRadius);
-            groundPlaneTransform.SetTranslation(AZ::Vector3(0.0f, 0.0f, m_modelAsset->GetAabb().GetMin().GetZ() - GroundPlaneOffset));
+                groundPlaneTransform.SetUniformScale(GroundPlaneRelativeScale * modelRadius);
+                groundPlaneTransform.SetTranslation(AZ::Vector3(0.0f, 0.0f, m_modelAsset->GetAabb().GetMin().GetZ() - GroundPlaneOffset));
+            }
 
             GetMeshFeatureProcessor()->SetTransform(m_groundPlandMeshHandle, groundPlaneTransform);
         }

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -83,6 +83,11 @@ end
 OpenSample('RPI/Mesh')
 ResizeViewport(999, 999)
 
+-- This is just quick regression test for a crash that happened when turning on the ground plane with no model
+SetImguiValue('Show Ground Plane', true)
+IdleFrames(1) 
+SetImguiValue('Show Ground Plane', false)
+
 ----------------------------------------------------------------------
 -- StandardPBR Materials...
 


### PR DESCRIPTION
Fixed RPI/Mesh sample to not crash when turning on ground plane while no model is selected.

Addresses https://github.com/o3de/o3de/issues/3936

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>