### PR TITLE
Update light culling ASV screenshots

### DIFF
--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_capsulelights.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_capsulelights.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:aa08b685dc29d9aab54af503fdb6e7e2c5bf191e359640922f41bf8f17421cfa
-size 113558
+oid sha256:fa6735efa7d0f83c6879319c5b67b2aeb6785a44a649b1df3ab6b6a8fa00e733
+size 100035

--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_decals.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_decals.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb601baba7d5b42712b422c3e09231d3515b075f098041bab72755bae87498d9
-size 125781
+oid sha256:2a17c06b6851cac1e573d838c9822fc94c3b09df58837ef0dba39f771108c7ca
+size 113469

--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_disklights.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_disklights.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5753abfaa592ef10eef3b79cfdb0e0f4731111259903f6be5c43c9002eec1bb5
-size 126202
+oid sha256:b8f1170f4808f888c8f2ae925e4dc93f418ffd4625c13c3daf32743405461fb5
+size 114276

--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_lookingdown.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_lookingdown.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c25608c644becd02750d5cc4970358bd8ca0c53336432d0f2cb9bbe10910b7d0
-size 71667
+oid sha256:4c52d6a17bbf79685200021d3a6697b93cdf22ea649ad377bcc407ad5f2ea866
+size 66704

--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_pointlights.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_pointlights.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:deba253febb80b210a7fd441349aca796cd4a26a206f5a2725627689e9517548
-size 123573
+oid sha256:d1dd05709ebe237458c07f932bb41be7ec787ed6327987f777a3725f31f4b676
+size 114586

--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_quadlights.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_quadlights.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2666a8a57fd8f03c45c0c560c1fbbf382bed4f7d581759f1fcd70248e736d778
-size 125777
+oid sha256:0e28264090313ba084a319436891498ab6833af5a1a6ef20429d95f9e5ac13cb
+size 126692


### PR DESCRIPTION
LightCulling screenshots need updating because I changed the coloring of the heatmap
ATOM-14993
Signed-off-by: mrieggeramzn <mriegger@amazon.com>