### PR TITLE
Change the HighInstanceTest default to using only simple cubes 

### DIFF
--- a/Gem/Code/Source/AuxGeomExampleComponent.cpp
+++ b/Gem/Code/Source/AuxGeomExampleComponent.cpp
@@ -71,6 +71,7 @@ namespace AtomSampleViewer
     
     void AuxGeomExampleComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
     {
+        AZ_PROFILE_SCOPE(AzRender, "AuxGeomExampleComponent: OnTick");
         if (m_imguiSidebar.Begin())
         {
             ImGui::Text("Draw Options");

--- a/Gem/Code/Source/HighInstanceExampleComponent.cpp
+++ b/Gem/Code/Source/HighInstanceExampleComponent.cpp
@@ -103,7 +103,7 @@ namespace AtomSampleViewer
 
         m_pinnedMaterialCount = static_cast<uint32_t>(m_materialBrowser.GetPinnedAssets().size());
 
-        const AZStd::vector<AZStd::string> modelAllowlist =
+        m_expandedModelList =
         {
             "materialeditor/viewportmodels/cone.azmodel",
             "materialeditor/viewportmodels/cube.azmodel",
@@ -115,7 +115,11 @@ namespace AtomSampleViewer
             "objects/cube.azmodel",
             "objects/cylinder.azmodel",
         };
-        m_modelBrowser.SetDefaultPinnedAssets(modelAllowlist);
+        m_simpleModelList =
+        {
+            "objects/cube.azmodel"
+        };
+        m_modelBrowser.SetDefaultPinnedAssets(m_simpleModelList);
     }
 
     void HighInstanceTestComponent::Activate()
@@ -324,6 +328,7 @@ namespace AtomSampleViewer
             }
         }
 
+        bool currentUseSimpleModels = m_useSimpleModels;
         if (m_imguiSidebar.Begin())
         {
             ImGui::Checkbox("Update Transforms Every Frame", &m_updateTransformEnabled);
@@ -334,7 +339,24 @@ namespace AtomSampleViewer
 
             RenderImGuiLatticeControls();
 
+            ImGui::Spacing();
+            ImGui::Separator();
+            ImGui::Spacing();
+
+            ImGui::Checkbox("Use simple models", &m_useSimpleModels);
+
             m_imguiSidebar.End();
+        }
+
+        if (currentUseSimpleModels != m_useSimpleModels)
+        {
+            m_modelBrowser.SetPinnedAssets(m_useSimpleModels?m_simpleModelList:m_expandedModelList);
+            for (ModelInstanceData& instanceData : m_modelInstanceData)
+            {
+                instanceData.m_modelAssetId = GetRandomModelId();
+            }
+            DestroyHandles();
+            FinalizeLatticeInstances();
         }
     }
 

--- a/Gem/Code/Source/HighInstanceExampleComponent.h
+++ b/Gem/Code/Source/HighInstanceExampleComponent.h
@@ -92,9 +92,12 @@ namespace AtomSampleViewer
         uint32_t m_pinnedMaterialCount = 0;
         uint32_t m_preActivateVSyncInterval = 0;
         
+        AZStd::vector<AZStd::string> m_expandedModelList; // has models that are more expensive on the gpu
+        AZStd::vector<AZStd::string> m_simpleModelList; // Aims to keep the test cpu bottlenecked by using trivial geometry such as a cube
         size_t m_lastPinnedModelCount = 0;
 
         float m_originalFarClipDistance;
         bool m_updateTransformEnabled = false;
+        bool m_useSimpleModels = true;
     };
 } // namespace AtomSampleViewer


### PR DESCRIPTION
The test is gpu limited with other models. 
Retain imgui option to switch back to the more complex models

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>