### PR TITLE
Fix screenshot sample tests which rely on previous sample name convention

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1360,7 +1360,7 @@ namespace AtomSampleViewer
     {
         for (int32_t i = 0; i < m_availableSamples.size(); i++)
         {
-            if (m_availableSamples[i].m_sampleName == sampleName)
+            if (m_availableSamples[i].m_parentMenuName + '/' + m_availableSamples[i].m_sampleName == sampleName)
             {
                 if (!m_availableSamples[i].m_isSupportedFunc || m_availableSamples[i].m_isSupportedFunc())
                 {


### PR DESCRIPTION
A previous change modified the sample names to have a layer of nesting and this change broke ASV screenshot tests (missed because the names were referenced in lua script and not C++)