### PR TITLE
Adding updated screenshots

### DIFF
--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_decals.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_decals.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a17c06b6851cac1e573d838c9822fc94c3b09df58837ef0dba39f771108c7ca
-size 113469
+oid sha256:1b3ce4d194e2555cef2df122ad719550e919a309967574c195d50c2ab1996d1a
+size 106750

--- a/Scripts/ExpectedScreenshots/LightCulling/screenshot_lookingdown.png
+++ b/Scripts/ExpectedScreenshots/LightCulling/screenshot_lookingdown.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c52d6a17bbf79685200021d3a6697b93cdf22ea649ad377bcc407ad5f2ea866
-size 66704
+oid sha256:68cdbc164dcf6884e0a4dbf0db4b6e74617cba9d8a40acd03dbb1a1452937a1f
+size 66690


### PR DESCRIPTION
Light culling sample needs a pair of updated screenshots. This is because some optimizations for the decals made the number of cells that they cover smaller.

Signed-off-by: mrieggeramzn <mriegger@amazon.com>