### PR TITLE
fix for missing msaa rpi sample

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -68,7 +68,10 @@ namespace AtomSampleViewer
         SamplePipelineType m_pipelineType = SamplePipelineType::RHI;
         AZ::ComponentDescriptor* m_componentDescriptor;
 
-        bool operator==(const SampleEntry& other) { return other.m_sampleName == m_sampleName; }
+        bool operator==(const SampleEntry& other)
+        {
+            return other.m_sampleName == m_sampleName && other.m_parentMenuName == m_parentMenuName;
+        }
     };
 
     class SampleComponentManager final


### PR DESCRIPTION
The MSAA RPI sample was not present in the ASV menu because the name overlaps with MSAA RHI sample. Made a small addition to fix this. ASV test for MSAA RPI now runs ok

Signed-off-by: mrieggeramzn <mriegger@amazon.com>