### PR TITLE
Updated screenshots with new sponza.fbx

### DIFF
--- a/Scripts/ExpectedScreenshots/ShadowedSponza/directional_nofilter.png
+++ b/Scripts/ExpectedScreenshots/ShadowedSponza/directional_nofilter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b39ab344f23e50ba70984d38007a8f99f3ea81d8b1fcf438f082e95a19f611c8
-size 113493
+oid sha256:db7bd43477e5fef3ea86a6dc9853a35ecc86c22c885705b593fa3f9d976ad4d5
+size 123378

--- a/Scripts/ExpectedScreenshots/ShadowedSponza/spot_filter.png
+++ b/Scripts/ExpectedScreenshots/ShadowedSponza/spot_filter.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4d225d6d5f6e4c71d185f683f89186eb391588fad4aa9196ff71c540eb0de052
-size 146846
+oid sha256:5ee99410c2fa503ea8cd13148f7905b63a7e719797a3b011ea0f95c64466d627
+size 146768


### PR DESCRIPTION
Sponza.fbx changed on Dec 8 (29da71e64ea08bd0cd9a9fc5b0c5f8c39cb8694a). Updating the differing screenshots for the shadow sponza test
ATOM-17106
![diff 2](https://user-images.githubusercontent.com/61609885/148806731-59255332-3322-49b3-bfc8-8089def2f554.PNG)
![diff 1](https://user-images.githubusercontent.com/61609885/148806734-59ca2883-2197-4299-84dd-056092a81835.PNG)

Signed-off-by: mrieggeramzn <mriegger@amazon.com>