### PR TITLE
Fixed LockFrameTime script function.

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -903,7 +903,9 @@ namespace AtomSampleViewer
         {
             AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
 
-            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(AZStd::string::format("t_simulationTickDeltaOverride %f", seconds).c_str());
+            int milliseconds = static_cast<int>(seconds * 1000);
+
+            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(AZStd::string::format("t_simulationTickDeltaOverride %d", milliseconds).c_str());
             s_instance->m_frameTimeIsLocked = true;
         };
 


### PR DESCRIPTION
There were changes to the timing system recently, replacing old Cry timing code with the new AzTimer stuff. Along with these changes, t_frameTimeOverride (seconds) was repalced with a new t_simulationTickDeltaOverride (milliseconds), but LockFrameTime was not updated to convert the units accordingly.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>