### PR TITLE
Updated the AtomSampleViewerApplication Lifecycle event signaling

### DIFF
--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -92,12 +92,7 @@ namespace AtomSampleViewer
         AzFramework::Application::StartCommon(systemEntity);
         if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
         {
-            AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "LegacySystemInterfaceCreated", R"({})");
-        }
-
-        if (auto settingsRegistry = AZ::SettingsRegistry::Get(); settingsRegistry != nullptr)
-        {
-            AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "LegacySystemInterfaceCreated", R"({})");
+            AZ::ComponentApplicationLifecycle::SignalEvent(*settingsRegistry, "CriticalAssetsCompiled", R"({})");
         }
 
         ReadTimeoutShutdown();


### PR DESCRIPTION
It now uses the correct `CriticalAssetsCompiled` event instead of
`LegacySystemInterfaceCreated` which is used by the Atom
BootstrapSytemComponent to initialize assets used by the RPISystem

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>