### PR TITLE
Improve shadow quality in sponza

### DIFF
--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -156,6 +156,7 @@ namespace AtomSampleViewer
         m_directionalLightFeatureProcessor->SetShadowmapSize(handle, AZ::Render::ShadowmapSizeNamespace::ShadowmapSize::Size2048);
         m_directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(handle, true);
         m_directionalLightFeatureProcessor->SetShadowFilterMethod(handle, AZ::Render::ShadowFilterMethod::EsmPcf);
+        m_directionalLightFeatureProcessor->SetShadowFarClipDistance(handle, 100.0);
         m_directionalLightFeatureProcessor->SetFilteringSampleCount(handle, 16);
         m_directionalLightFeatureProcessor->SetGroundHeight(handle, 0.f);
         m_directionalLightHandle = handle;

--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -156,7 +156,7 @@ namespace AtomSampleViewer
         m_directionalLightFeatureProcessor->SetShadowmapSize(handle, AZ::Render::ShadowmapSizeNamespace::ShadowmapSize::Size2048);
         m_directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(handle, true);
         m_directionalLightFeatureProcessor->SetShadowFilterMethod(handle, AZ::Render::ShadowFilterMethod::EsmPcf);
-        m_directionalLightFeatureProcessor->SetShadowFarClipDistance(handle, 100.0);
+        m_directionalLightFeatureProcessor->SetShadowFarClipDistance(handle, 100.0f);
         m_directionalLightFeatureProcessor->SetFilteringSampleCount(handle, 16);
         m_directionalLightFeatureProcessor->SetGroundHeight(handle, 0.f);
         m_directionalLightHandle = handle;


### PR DESCRIPTION
CSM shadows could be made a bit nicer by tweaking the far distance. This counteracts the reduction in quality when the camera far plane was set to 1000 (from 100) in a recent change.

Before
![after](https://user-images.githubusercontent.com/61609885/149264340-2db62113-93df-4cd7-aa36-2832a99c0f5f.PNG)


After
![BEFORE](https://user-images.githubusercontent.com/61609885/149264344-f69e0cb3-a061-4d99-9cd3-8b8ec9544b19.PNG)



Signed-off-by: mrieggeramzn <mriegger@amazon.com>