### PR TITLE
Fix rendering artifacts (holes) in the ASV screenshot tests using Vulkan

### DIFF
--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -43,7 +43,7 @@ struct VSInput
 
 struct VSOutput
 {
-    float4 m_position : SV_Position;
+    precise float4 m_position : SV_Position;
     float3 m_normal: NORMAL;
     float3 m_tangent : TANGENT; 
     float3 m_bitangent : BITANGENT; 


### PR DESCRIPTION
Signed-off-by: moudgils <47460854+moudgils@users.noreply.github.com>