### PR TITLE
ATOM-17158 ASV: AssetLoadTest sample loads with several "<Missing>" t…

### DIFF
--- a/Gem/Code/Source/AssetLoadTestComponent.cpp
+++ b/Gem/Code/Source/AssetLoadTestComponent.cpp
@@ -58,9 +58,7 @@ namespace AtomSampleViewer
         {
             "materials/defaultpbr.azmaterial",
             "materials/presets/pbr/metal_aluminum_polished.azmaterial",
-            "shaders/staticmesh_colorr.azmaterial",
-            "shaders/staticmesh_colorg.azmaterial",
-            "shaders/staticmesh_colorb.azmaterial"
+            "materials/basic_gray.azmaterial"
         };
         m_materialBrowser.SetDefaultPinnedAssets(defaultMaterialAllowlist);
 


### PR DESCRIPTION
…extures in the Material Allow list by default

Note, the fix requires clean user folder which saves previous menu settings

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>