### PR TITLE
Updated AtomSampleViewer uses of array_view with span.

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerModule.cpp
+++ b/Gem/Code/Source/AtomSampleViewerModule.cpp
@@ -30,7 +30,7 @@ namespace AtomSampleViewer
                 SampleComponentManager::CreateDescriptor(),
                 });
 
-            AZStd::array_view<SampleEntry> samples = SampleComponentManager::GetSamples();
+            AZStd::span<const SampleEntry> samples = SampleComponentManager::GetSamples();
             for (const SampleEntry& sample : samples)
             {
                 m_descriptors.emplace_back(sample.m_componentDescriptor);

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -239,7 +239,7 @@ namespace AtomSampleViewer
                 sizeof(uint32_t)
             };
 
-            RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::array_view<RHI::StreamBufferView>(m_streamBufferViews.data(), 2));
+            RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::StreamBufferView>(m_streamBufferViews.data(), 2));
         }
     }
 

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
@@ -370,7 +370,7 @@ namespace AtomSampleViewer
                 {
                     m_streamBufferView[0] = {inputAssemblyBufferView->GetBuffer(), 0, sizeof(BufferData), sizeof(BufferData::value_type)};
 
-                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::array_view<RHI::StreamBufferView>(&m_streamBufferView[0], 1));
+                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::StreamBufferView>(&m_streamBufferView[0], 1));
                 }
             }
 
@@ -380,7 +380,7 @@ namespace AtomSampleViewer
                 {
                     m_streamBufferView[1] = {inputAssemblyBufferView->GetBuffer(), 0, sizeof(BufferData), sizeof(BufferData::value_type)};
 
-                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::array_view<RHI::StreamBufferView>(&m_streamBufferView[1], 1));
+                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::StreamBufferView>(&m_streamBufferView[1], 1));
                 }
             }
         };

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -192,7 +192,7 @@ namespace AtomSampleViewer
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             m_quadInputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(m_quadInputStreamLayout, AZStd::array_view<RHI::StreamBufferView>(&m_quadStreamBufferView, 1));
+            RHI::ValidateStreamBufferViews(m_quadInputStreamLayout, AZStd::span<const RHI::StreamBufferView>(&m_quadStreamBufferView, 1));
         }
     }
 

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -186,7 +186,7 @@ namespace AtomSampleViewer
             ModelType_Suzanne,
         };
 
-        auto setModelType = [](AZStd::array_view<ModelType> types, AZStd::vector<ModelData>& modelDataList)
+        auto setModelType = [](AZStd::span<const ModelType> types, AZStd::vector<ModelData>& modelDataList)
         {
             modelDataList.resize(types.size());
             for (uint32_t i = 0; i < modelDataList.size(); ++i)
@@ -195,7 +195,7 @@ namespace AtomSampleViewer
             }
         };
 
-        setModelType(AZStd::array_view<ModelType>(&opaqueModels[0], AZ_ARRAY_SIZE(opaqueModels)), m_opaqueModelsData);
+        setModelType(AZStd::span<const ModelType>(&opaqueModels[0], AZ_ARRAY_SIZE(opaqueModels)), m_opaqueModelsData);
     }
 
     void SubpassExampleComponent::LoadShaders()

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -228,7 +228,7 @@ namespace AtomSampleViewer
         dependent.push_back(AZ_CRC("AzFrameworkConfigurationSystemComponentService", 0xcc49c96e)); // Ensures a scene is created for the GameEntityContext
     }
 
-    const AZStd::array_view<SampleEntry> SampleComponentManager::GetSamples()
+    const AZStd::span<const SampleEntry> SampleComponentManager::GetSamples()
     {
         static SampleEntry sampleEntries[] = {
             NewRHISample<AlphaToCoverageExampleComponent>("AlphaToCoverage"),
@@ -326,7 +326,7 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::Init()
     {
-        AZStd::array_view<SampleEntry> samples = GetSamples();
+        AZStd::span<const SampleEntry> samples = GetSamples();
         for (const SampleEntry& sample : samples)
         {
             RegisterSampleComponent(sample);

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -12,7 +12,7 @@
 
 #include <Automation/ScriptableImGui.h> // This file needs to be included before "<Atom/Utils/ImGuiPassTree.h>" to enable scriptable imgui for ImguiPassTree
 
-#include <AtomCore/std/containers/array_view.h>
+#include <AzCore/std/containers/span.h>
 
 #include <Atom/Feature/ImGui/SystemBus.h>
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
@@ -92,7 +92,7 @@ namespace AtomSampleViewer
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
-        static const AZStd::array_view<SampleEntry> GetSamples();
+        static const AZStd::span<const SampleEntry> GetSamples();
 
         SampleComponentManager();
         ~SampleComponentManager() override;


### PR DESCRIPTION
Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>