### PR TITLE
Remove direct include to reflection probe feature processor

### DIFF
--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -23,7 +23,6 @@
 #include <Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h>
 #include <Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h>
 #include <Atom/Feature/ReflectionProbe/ReflectionProbeFeatureProcessorInterface.h>
-#include <Atom/Feature/ReflectionProbe/ReflectionProbeFeatureProcessor.h>
 
 #include <Utils/Utils.h>
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/o3de/o3de/pull/7189