### PR TITLE
Remove static qualifier which prevented clean ASV shutdown

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerModule.cpp
+++ b/Gem/Code/Source/AtomSampleViewerModule.cpp
@@ -30,7 +30,7 @@ namespace AtomSampleViewer
                 SampleComponentManager::CreateDescriptor(),
                 });
 
-            AZStd::span<const SampleEntry> samples = SampleComponentManager::GetSamples();
+            AZStd::vector<SampleEntry> samples = SampleComponentManager::GetSamples();
             for (const SampleEntry& sample : samples)
             {
                 m_descriptors.emplace_back(sample.m_componentDescriptor);

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -228,9 +228,9 @@ namespace AtomSampleViewer
         dependent.push_back(AZ_CRC("AzFrameworkConfigurationSystemComponentService", 0xcc49c96e)); // Ensures a scene is created for the GameEntityContext
     }
 
-    const AZStd::span<const SampleEntry> SampleComponentManager::GetSamples()
+    AZStd::vector<SampleEntry> SampleComponentManager::GetSamples()
     {
-        static SampleEntry sampleEntries[] = {
+        return {
             NewRHISample<AlphaToCoverageExampleComponent>("AlphaToCoverage"),
             NewRHISample<AsyncComputeExampleComponent>("AsyncCompute"),
             NewRHISample<BindlessPrototypeExampleComponent>("BindlessPrototype", []() {return Utils::GetRHIDevice()->GetFeatures().m_unboundedArrays; }),
@@ -291,8 +291,6 @@ namespace AtomSampleViewer
             NewFeaturesSample<TonemappingExampleComponent>("Tonemapping"),
             NewFeaturesSample<TransparencyExampleComponent>("Transparency"),
         };
-
-        return {sampleEntries, AZ_ARRAY_SIZE(sampleEntries)};
     }
 
     void SampleComponentManager::RegisterSampleComponent(const SampleEntry& sample)
@@ -326,7 +324,7 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::Init()
     {
-        AZStd::span<const SampleEntry> samples = GetSamples();
+        AZStd::vector<SampleEntry> samples = GetSamples();
         for (const SampleEntry& sample : samples)
         {
             RegisterSampleComponent(sample);

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -92,7 +92,7 @@ namespace AtomSampleViewer
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
-        static const AZStd::span<const SampleEntry> GetSamples();
+        static AZStd::vector<SampleEntry> GetSamples();
 
         SampleComponentManager();
         ~SampleComponentManager() override;


### PR DESCRIPTION
Sample entries may allocate for sample names and paths that exceed SSO size which could cause a crash on exit non-deterministically.