### PR TITLE
Add Scene.h header to fix non-unity build

### DIFF
--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -16,6 +16,7 @@
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/Component/TickBus.h>
 
+#include <AzFramework/Scene/Scene.h>
 #include <AzFramework/Windowing/WindowBus.h>
 #include <AzFramework/Windowing/NativeWindow.h>
 


### PR DESCRIPTION
Compilation regression from https://github.com/o3de/o3de-atom-sampleviewer/pull/327/files