### PR TITLE
Add AZ:: to RHI-namespace classes used in ScriptReporter.

### DIFF
--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -1182,7 +1182,7 @@ namespace AtomSampleViewer
         memcpy(buffer.data() + bufferSize, actualScreenshot.GetBuffer().data(), bufferSize);
         memcpy(buffer.data() + bufferSize * 2, diffBuffer.data(), bufferSize);
 
-        PngFile imageDiff = PngFile::Create(RHI::Size(officialBaseline.GetWidth(), officialBaseline.GetHeight() * 3, 1), RHI::Format::R8G8B8A8_UNORM, buffer);
+        PngFile imageDiff = PngFile::Create(AZ::RHI::Size(officialBaseline.GetWidth(), officialBaseline.GetHeight() * 3, 1), AZ::RHI::Format::R8G8B8A8_UNORM, buffer);
         imageDiff.Save(filePath);
     }
 


### PR DESCRIPTION
This was compiling for me before the changes but saw that the missing AZ namespace caused a compilation error on @HogJonny-AMZN's machine. 

Signed-off-by: hershey5045 <43485729+hershey5045@users.noreply.github.com>