### PR TITLE
Change EmissiveMaterial to reflect Surface interface change

### DIFF
--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -77,10 +77,10 @@ ForwardPassOutput MainPS(VSOutput IN)
     surface.CalculateRoughnessA();
 
     // Albedo, SpecularF0
-    const float3 baseColor = float3(0.05f, 0.05f, 0.05f);
-    const float metallic = 0.0f;
-    const float specularF0Factor = 0.5f;
-    surface.SetAlbedoAndSpecularF0(baseColor, specularF0Factor, metallic);
+    surface.baseColor = float3(0.05f, 0.05f, 0.05f);
+    surface.metallic = 0.0f;
+    float specularF0Factor = 0.5f;
+    surface.SetAlbedoAndSpecularF0(specularF0Factor);
 
     // Clear Coat
     surface.clearCoat.InitializeToZero();


### PR DESCRIPTION
This change is required for the Emissive Material to compile after https://github.com/o3de/o3de/pull/7437 is merged.