### PR TITLE
ATOM-16177 [RHI][Android] Light Culling sample crashes for device lost

### DIFF
--- a/Gem/Code/Source/LightCullingExampleComponent.cpp
+++ b/Gem/Code/Source/LightCullingExampleComponent.cpp
@@ -96,7 +96,7 @@ namespace AtomSampleViewer
         m_sampleName = "LightCullingExampleComponent";
 
         // Add some initial lights to illuminate the scene
-        m_settings[(int)LightType::Point].m_numActive = 150;
+        m_settings[(int)LightType::Point].m_numActive = 10;
         m_settings[(int)LightType::Disk].m_intensity = 40.0f;
         m_settings[(int)LightType::Capsule].m_intensity = 10.0f;
     }


### PR DESCRIPTION
The initial value is too big for android and it will reach android limit. As we have a slide bar for the light number, it won't affect the ability for testing other platforms.

Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>