### PR TITLE
Increase thresholds for a couple screenshot tests

### DIFF
--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -211,7 +211,7 @@ g_testMaterialsFolder = 'materials/types/'
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MinimalPBR/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
-GenerateMaterialScreenshot('Level D', 'MinimalMultilayerExample')
+GenerateMaterialScreenshot('Level G', 'MinimalMultilayerExample')
 
 ----------------------------------------------------------------------
 -- AutoBrick Materials...

--- a/Scripts/PassTree.bv.lua
+++ b/Scripts/PassTree.bv.lua
@@ -27,7 +27,7 @@ end
 OpenSample('RPI/Mesh')
 ResizeViewport(800, 600)
 
-SelectImageComparisonToleranceLevel("Level F")
+SelectImageComparisonToleranceLevel("Level G")
 
 -- choose model, material and lighting
 SetImguiValue('Models/##Available', 'objects/shaderball_simple.azmodel')


### PR DESCRIPTION
Increase thresholds for a couple screenshot tests that were failing on Vulkan with benign differences.

![MinimalMultilayerPbrExample](https://user-images.githubusercontent.com/55155825/155030714-075861c4-77da-4021-b5f3-87a625915167.png)


**Note for the depth-stencil tests,** there is a giant difference in the alpha channel, which is not actually checked as part of these results. So ignore that difference, focus on the minor differences in the rest of the image. Here is another PR to address the alpha comparison issue https://github.com/o3de/o3de/pull/7743

![depthStencilMs](https://user-images.githubusercontent.com/55155825/155030806-87933116-18b8-426e-b42b-fa94a17f0272.png)
![depthStencilResolve](https://user-images.githubusercontent.com/55155825/155030815-9b91bcc4-71ee-4109-81f9-8e5314dfb7ce.png)


Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>