### PR TITLE
Added a new screenshot test in ParallaxTest.bv.lua for a specific cam…

### DIFF
--- a/Scripts/ExpectedScreenshots/ParallaxTest/screenshot_11_problematicAngle.png
+++ b/Scripts/ExpectedScreenshots/ParallaxTest/screenshot_11_problematicAngle.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83100b46d389a3325521263bd0ef5ec66220d3c5920f40f6a7f70aab11edc939
+size 460090

--- a/Scripts/ParallaxTest.bv.lua
+++ b/Scripts/ParallaxTest.bv.lua
@@ -144,5 +144,14 @@ IdleFrames(1)
 ArcBallCameraController_SetPitch(DegToRad(0))
 IdleFrames(1)
 
+-- Testing a specific camera and light angle that caused almost all geometry to render as black
+OpenSample('Features/Parallax') -- Reset the sample
+SetImguiValue('Lighting/Auto Rotation', false)
+SetImguiValue('Lighting/Direction', 1.18682396)
+ArcBallCameraController_SetHeading(1.95481825)
+ArcBallCameraController_SetPitch(-0.169443831)
+ArcBallCameraController_SetDistance(6.000000)
+IdleFrames(1)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_11_problematicAngle.png')
 
 OpenSample(nil)


### PR DESCRIPTION
…era and light angle that renders most of the geometry as black. The issue is not specific to parallax, as the cube is rendered black as well. Will open an Issue to for someone to investigate.

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

![ProblematicAngle](https://user-images.githubusercontent.com/55155825/158243812-7e817eac-ee7f-4a34-90fa-ef24b7d2a38a.png)

