### PR TITLE
Fixing usages of AZ_ARRAY_SIZE in vs 2022.

### DIFF
--- a/Gem/Code/Source/CullingAndLodExampleComponent.cpp
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.cpp
@@ -341,7 +341,7 @@ namespace AtomSampleViewer
             ImGui::Separator();
 
             ImGui::Text("Shadowmap Size");
-            if (ImGui::Combo( "Size", &m_directionalLightShadowmapSizeIndex, s_directionalLightShadowmapSizeLabels, AZ_ARRAY_SIZE(s_directionalLightShadowmapSizeLabels)))
+            if (ImGui::Combo( "Size", &m_directionalLightShadowmapSizeIndex, s_directionalLightShadowmapSizeLabels, aznumeric_cast<int>(AZStd::size(s_directionalLightShadowmapSizeLabels))))
             {
                 m_directionalLightFeatureProcessor->SetShadowmapSize(m_directionalLightHandle, s_shadowmapSizes[m_directionalLightShadowmapSizeIndex]);
             }
@@ -391,7 +391,7 @@ namespace AtomSampleViewer
             ImGui::Spacing();
 
             ImGui::Text("Filtering");
-            if (ImGui::Combo("Filter Method", &m_shadowFilterMethodIndex, s_shadowFilterMethodLabels, AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
+            if (ImGui::Combo("Filter Method", &m_shadowFilterMethodIndex, s_shadowFilterMethodLabels, aznumeric_cast<int>(AZStd::size(s_shadowFilterMethodLabels))))
             {
                 m_directionalLightFeatureProcessor->SetShadowFilterMethod(m_directionalLightHandle, s_shadowFilterMethods[m_shadowFilterMethodIndex]);
             }

--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -507,8 +507,8 @@ namespace AtomSampleViewer
 
             ImGui::Text("Shadowmap Size");
             if (ScriptableImGui::Combo(
-                    "Size##Directional", &m_directionalLightImageSizeIndex, s_shadowmapImageSizeLabels,
-                    AZ_ARRAY_SIZE(s_shadowmapImageSizeLabels)))
+                "Size##Directional", &m_directionalLightImageSizeIndex, s_shadowmapImageSizeLabels,
+                aznumeric_cast<int>(AZStd::size(s_shadowmapImageSizeLabels))))
             {
                 m_directionalLightFeatureProcessor->SetShadowmapSize(
                     m_directionalLightHandle, s_shadowmapImageSizes[m_directionalLightImageSizeIndex]);
@@ -564,8 +564,8 @@ namespace AtomSampleViewer
 
             ImGui::Text("Filtering");
             if (ScriptableImGui::Combo(
-                    "Filter Method##Directional", &m_shadowFilterMethodIndexDirectional, s_shadowFilterMethodLabels,
-                    AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
+                "Filter Method##Directional", &m_shadowFilterMethodIndexDirectional, s_shadowFilterMethodLabels,
+                aznumeric_cast<int>(AZStd::size(s_shadowFilterMethodLabels))))
             {
                 m_directionalLightFeatureProcessor->SetShadowFilterMethod(
                     m_directionalLightHandle, s_shadowFilterMethods[m_shadowFilterMethodIndexDirectional]);
@@ -656,7 +656,7 @@ namespace AtomSampleViewer
             ImGui::Text("Shadowmap Size");
             shadowmapSizeChanged = shadowmapSizeChanged ||
                 ScriptableImGui::Combo("Size##Positional", &m_positionalLightImageSizeIndices[index], s_shadowmapImageSizeLabels,
-                                       AZ_ARRAY_SIZE(s_shadowmapImageSizeLabels));
+                    aznumeric_cast<int>(AZStd::size(s_shadowmapImageSizeLabels)));
             if (shadowmapSizeChanged)
             {
                 // Reset shadow parameters when shadow is disabled.
@@ -672,8 +672,8 @@ namespace AtomSampleViewer
 
             ImGui::Text("Filtering");
             if (ScriptableImGui::Combo(
-                    "Filter Method##Positional", &m_shadowFilterMethodIndicesPositional[index], s_shadowFilterMethodLabels,
-                    AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
+                "Filter Method##Positional", &m_shadowFilterMethodIndicesPositional[index], s_shadowFilterMethodLabels,
+                aznumeric_cast<int>(AZStd::size(s_shadowFilterMethodLabels))))
             {
                 settingsChanged = true;
             }

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
@@ -407,7 +407,7 @@ namespace AtomSampleViewer
                 "Size",
                 &m_directionalLightShadowmapSizeIndex,
                 s_directionalLightShadowmapSizeLabels,
-                AZ_ARRAY_SIZE(s_directionalLightShadowmapSizeLabels)))
+                aznumeric_cast<int>(AZStd::size(s_directionalLightShadowmapSizeLabels))))
             {
                 m_directionalLightFeatureProcessor->SetShadowmapSize(
                     m_directionalLightHandle,
@@ -469,7 +469,7 @@ namespace AtomSampleViewer
                 "Filter Method##Directional",
                 &m_shadowFilterMethodIndexDirectional,
                 s_shadowFilterMethodLabels,
-                AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
+                aznumeric_cast<int>(AZStd::size(s_shadowFilterMethodLabels))))
             {
                 m_directionalLightFeatureProcessor->SetShadowFilterMethod(
                     m_directionalLightHandle,
@@ -550,7 +550,7 @@ namespace AtomSampleViewer
                 "Filter Method##Spot",
                 &m_shadowFilterMethodIndexDisk,
                 s_shadowFilterMethodLabels,
-                AZ_ARRAY_SIZE(s_shadowFilterMethodLabels)))
+                aznumeric_cast<int>(AZStd::size(s_shadowFilterMethodLabels))))
             {
                 for (int index = 0; index < m_diskLightCount; ++index)
                 {

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -162,7 +162,7 @@ namespace AtomSampleViewer
             "Input Colorspace",
             &m_inputColorSpaceIndex,
             s_colorSpaceLabels,
-            AZ_ARRAY_SIZE(s_colorSpaceLabels)))
+            aznumeric_cast<int>(AZStd::size(s_colorSpaceLabels))))
         {
             m_inputColorSpace = GetColorSpaceIdForIndex(static_cast<uint8_t>(m_inputColorSpaceIndex));
             m_drawImage.m_srg->SetConstant<int>(m_colorSpaceIndex, static_cast<int>(m_inputColorSpace));


### PR DESCRIPTION
 The compiler can't use sizeof() on static arrays whose size is determined in the cpp.