### PR TITLE
Fix buffer overrun and update bone transform code

### DIFF
--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -87,11 +87,8 @@ namespace AtomSampleViewer
             colorMultiplier.StoreToFloat4(&trianglesData[triangleIdx].m_colorMultiplier[0]);
         }
 
-        // Calculate the alignment
-        const uint32_t alignment = RHI::AlignUp(static_cast<uint32_t>(sizeof(InstanceInfo)), m_constantBufferAlighment);
-
         // All triangles data will be uploaded in one go to the constant buffer once per frame.
-        UploadDataToConstantBuffer(trianglesData, alignment, s_numberOfTrianglesTotal);
+        UploadDataToConstantBuffer(trianglesData, static_cast<uint32_t>(sizeof(InstanceInfo)), s_numberOfTrianglesTotal);
         
         BasicRHIComponent::OnFramePrepare(frameGraphBuilder);
     }
@@ -115,9 +112,6 @@ namespace AtomSampleViewer
         using namespace AZ;
 
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-
-        // Cache the alignment
-        m_constantBufferAlighment = device->GetLimits().m_minConstantBufferViewOffset;
 
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -103,9 +103,6 @@ namespace AtomSampleViewer
 
         AZ::RHI::Ptr<AZ::RHI::BufferView> m_constantBufferView;
 
-        // Cached Constant Buffer alignment queued from the device
-        uint32_t m_constantBufferAlighment = 0u;
-
         // --------------------------------------------------------
         // Pipeline state and SRG to be constructed from the shader
         // --------------------------------------------------------

--- a/Gem/Code/Source/SkinnedMeshContainer.cpp
+++ b/Gem/Code/Source/SkinnedMeshContainer.cpp
@@ -95,7 +95,9 @@ namespace AtomSampleViewer
 
                 if (m_skinnedMeshInstances[i].m_boneTransformBuffer)
                 {
-                    AZ::Render::WriteToBuffer(m_skinnedMeshInstances[i].m_boneTransformBuffer->GetRHIBuffer(), m_skinnedMeshes[i].m_proceduralSkinnedMesh.m_boneMatrices);
+                    m_skinnedMeshInstances[i].m_boneTransformBuffer->UpdateData(
+                        m_skinnedMeshes[i].m_proceduralSkinnedMesh.m_boneMatrices.data(),
+                        m_skinnedMeshes[i].m_proceduralSkinnedMesh.m_boneMatrices.size() * sizeof(AZ::Matrix3x4));
                 }
             }
         }


### PR DESCRIPTION
-Fix a buffer overrun in TrianglesConstantBufferExampleComponent
--The buffer view used in this sample and the corresponding map request in UploadDataToConstantBuffer have a 0 offset (a view/update of the entire buffer), so they are aligned already. The 'alignment' from the device that was previously used instead of the element size was causing UploadDataToConstantBuffer to read CPU data that was beyond the bounds of trianglesData and write it beyond the the bounds of the GPU buffer. This was caught by a related PR that adds a buffer overrun check to the map request validation.

-Update the SkinnedMeshContainer to use RPI::Buffer::UpdateData instead of Render::WriteToBuffer.

Pre-commit wizard output:
RHI API: vulkan
Test Script Count: 23
Screenshot Count: 212
Manually Validated Screenshots: 50/208
Screenshot automatic checks failed: 4
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_11_problematicAngle.png 'Level I' 0.107142
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_3.png 'Level I' 0.104953
	scripts/RenderTargetTexture.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/RenderTargetTexture//screenshot_1.png 'Level F' 0.000000
	scripts/RenderTargetTexture.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/RenderTargetTexture//screenshot_2.png 'Level F' 0.000000
Screenshot interactive check 'High Difference'
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_6.png 'Level I' 0.011374
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_esm.png 'Level H' 0.010769
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/010_ambientocclusion.png 'Level H' 0.014633
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_pcf_high.png 'Level H' 0.020805
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_pcf_low.png 'Level H' 0.019140
Screenshot interactive check 'Moderate Difference'
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_esm_pcf.png 'Level H' 0.010934
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_2.png 'Level I' 0.013195
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_5.png 'Level I' 0.018362
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_1.png 'Level I' 0.015213
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_8_offset.png 'Level I' 0.013493
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/100_uvtiling_emissive.png 'Level I' 0.009217
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_2ndUv_1.png 'Level I' 0.015213
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_2ndUv_2.png 'Level I' 0.015213
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/005_usedisplacement_with_blendmasktexture.png 'Level I' 0.009598
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_7.png 'Level I' 0.037426
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/004_usevertexcolors.png 'Level I' 0.016376
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/105_detailmaps_blendmaskusingdetailuvs.png 'Level H' 0.014155
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/100_uvtiling_parallax_b.Angle2.png 'Level L' 0.016896
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/013_specularaa_on.png 'Level J' 0.055055
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_initial.png 'Level H' 0.016402
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_initial.png 'Level H' 0.021465
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/100_uvtiling_parallax_b.Angle1.png 'Level L' 0.027043
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_shadowmap_size.png 'Level H' 0.023003
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_9_offsetClipping.png 'Level I' 0.031651
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_no_red_shadow.png 'Level H' 0.019912
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/100_uvtiling_metallic.png 'Level H' 0.010759
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/005_usedisplacement_with_blendmasktexture_noheightmaps.png 'Level I' 0.011074
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/005_usedisplacement_layer2off.png 'Level I' 0.016601
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_10_offsetClippingSteep.png 'Level I' 0.037697
Screenshot interactive check 'Low Difference'
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/012_parallax_pom_cutout.png 'Level I' 0.049886
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/013_specularaa_off.png 'Level I' 0.039820
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/004_usevertexcolors_modelhasnovertexcolors.png 'Level I' 0.008749
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_cascade_correction.png 'Level H' 0.011730
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/005_usedisplacement.png 'Level I' 0.015129
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_auto_cascade.png 'Level H' 0.009066
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/100_uvtiling_opacity.png 'Level M' 0.018288
Screenshot interactive check 'No Difference'
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/014_clearcoat_normalmap.png 'Level H' 0.009729
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/104_detailmaps_normalwithmask.png 'Level H' 0.012750
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Skin/002_wrinkle_regression_test.png 'Level G' 0.008115
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/001_manyfeatures_layer2off.png 'Level I' 0.010765
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/005_usedisplacement_layer3off.png 'Level I' 0.014618
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/009_opacity_cutout_packedalpha_doublesided.png 'Level H' 0.012951
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/001_manyfeatures.png 'Level I' 0.011318
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//initial.png 'Level H' 0.013891
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/008_normalmap.png 'Level H' 0.011518
	scripts/parallaxtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/ParallaxTest//screenshot_4.png 'Level I' 0.016750
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/001_manyfeatures_layer3off.png 'Level I' 0.010263
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/104_detailmaps_normal.png 'Level H' 0.017585
	scripts/shadowtest.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_manual_cascade.png 'Level H' 0.008061
	scripts/materialscreenshottests.bv.luac D:/GitHub/randombugfixing/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardPBR/012_parallax_pom.png 'Level I' 0.016460


Signed-off-by: Tommy Walton <waltont@amazon.com>