### PR TITLE
Atom Tools: removing shadow catcher opacity from lighting presets

### DIFF
--- a/Gem/Code/Source/CommonSampleComponentBase.cpp
+++ b/Gem/Code/Source/CommonSampleComponentBase.cpp
@@ -259,8 +259,6 @@ namespace AtomSampleViewer
             directionalLightFeatureProcessor,
             cameraConfig,
             m_lightHandles,
-            nullptr,
-            AZ::RPI::MaterialPropertyIndex{},
             useAlternateSkybox);
     }
 


### PR DESCRIPTION
This setting and the shadow catcher are only used in material editor and similar viewports for rendering a planar shadow underneath the viewport model. It was originally added to the lighting preset as a stop gap because there was no other UI for editing the setting at the time. A follow up PR that factors all of the viewport code out of the material editor moves the shadow catcher opacity setting to the viewport settings panel.

Signed-off-by: Guthrie Adams <guthadam@amazon.com>