### PR TITLE
Add Eye material sample and regression test

### DIFF
--- a/Gem/Code/Source/EyeMaterialExampleComponent.cpp
+++ b/Gem/Code/Source/EyeMaterialExampleComponent.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <EyeMaterialExampleComponent.h>
+
+#include <Atom/Component/DebugCamera/ArcBallControllerComponent.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+
+#include <RHI/BasicRHIComponent.h>
+
+#include <Automation/ScriptableImGui.h>
+
+
+namespace AtomSampleViewer
+{
+    static const char* MeshPath = "objects/eye.azmodel";
+    static const char* MaterialPath = "materials/eye/001_EyeBasic.azmaterial";
+    static const float DefaultCameraHeading = 40.0f;
+    static const float DefaultCameraDistance = 2.0f;
+    
+    static const char* IrisColorName = "iris.baseColor.color";
+    static const char* IrisColorFactorName = "iris.baseColor.factor";
+    static const char* IrisRoughnessName = "iris.roughness.factor";
+    
+    static const char* ScleraColorName = "sclera.baseColor.color";
+    static const char* ScleraColorFactorName = "sclera.baseColor.factor";
+    static const char* ScleraRoughnessName = "sclera.roughness.factor";
+    static const char* ScleraNormalFactorName = "sclera.normal.factor";
+    
+    static const char* IrisDepthName = "eye.irisDepth";
+    static const char* IrisRadiusName = "eye.irisRadius";
+    static const char* InnerEyeIORName = "eye.innerEyeIOR";
+    static const char* LimbusSizeName = "eye.limbusSize";
+
+    static const char* SpecularFactorName = "specularF0.factor";
+
+    static const char* SSSEnableName = "subsurfaceScattering.enableSubsurfaceScattering";
+    static const char* SSSColorName = "subsurfaceScattering.scatterColor";
+    static const char* SSSFactorName = "subsurfaceScattering.subsurfaceScatterFactor";
+
+    void EyeMaterialExampleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<EyeMaterialExampleComponent, AZ::Component>()->Version(0);
+        }
+    }
+
+    EyeMaterialExampleComponent::EyeMaterialExampleComponent()
+    {
+    }
+
+    void EyeMaterialExampleComponent::Activate()
+    {
+        Prepare();
+
+        m_eyeTransform = AZ::Transform::CreateIdentity();
+        LoadMesh(m_eyeTransform);
+
+        InitializeMaterialProperties();
+
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void EyeMaterialExampleComponent::Deactivate()
+    {
+        AZ::Debug::CameraControllerRequestBus::Event(
+            GetCameraEntityId(),
+            &AZ::Debug::CameraControllerRequestBus::Events::Disable);
+
+        m_defaultIbl.Reset();
+
+        GetMeshFeatureProcessor()->ReleaseMesh(m_meshHandle);
+
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+
+    void EyeMaterialExampleComponent::OnTick(float deltaTime, AZ::ScriptTimePoint scriptTime)
+    {
+        AZ_UNUSED(deltaTime);
+        AZ_UNUSED(scriptTime);
+
+        DrawSidebar();
+    }
+
+    void EyeMaterialExampleComponent::LoadMesh(AZ::Transform transform)
+    {
+        m_materialInstance = AZ::RPI::Material::Create(m_materialAsset);
+        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_modelAsset }, m_materialInstance);
+        GetMeshFeatureProcessor()->SetTransform(m_meshHandle, transform);
+    }
+
+    void EyeMaterialExampleComponent::Prepare()
+    {
+        // Camera
+        AZ::Debug::CameraControllerRequestBus::Event(
+            GetCameraEntityId(),
+            &AZ::Debug::CameraControllerRequestBus::Events::Enable,
+            azrtti_typeid<AZ::Debug::ArcBallControllerComponent>());
+        AZ::Debug::ArcBallControllerRequestBus::Event(GetCameraEntityId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetDistance, DefaultCameraDistance);
+        AZ::Debug::ArcBallControllerRequestBus::Event(GetCameraEntityId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetHeading, DefaultCameraHeading);
+
+        // Lighting
+        m_defaultIbl.Init(m_scene);
+        // Model
+        m_modelAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>(MeshPath, AZ::RPI::AssetUtils::TraceLevel::Assert);
+        // Material
+        m_materialAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::MaterialAsset>(MaterialPath, AZ::RPI::AssetUtils::TraceLevel::Assert);
+    }
+
+
+    void EyeMaterialExampleComponent::InitializeMaterialProperties()
+    {
+        // Get material indices of properties
+        m_irisColorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(IrisColorName));
+        m_irisColorFactorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(IrisColorFactorName));
+        m_irisRoughnessIndex = m_materialInstance->FindPropertyIndex(AZ::Name(IrisRoughnessName));
+
+        m_scleraColorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(ScleraColorName));
+        m_scleraColorFactorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(ScleraColorFactorName));
+        m_scleraRoughnessIndex = m_materialInstance->FindPropertyIndex(AZ::Name(ScleraRoughnessName));
+        m_scleraNormalFactorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(ScleraNormalFactorName));
+
+        m_irisDepthIndex = m_materialInstance->FindPropertyIndex(AZ::Name(IrisDepthName));
+        m_irisRadiusIndex = m_materialInstance->FindPropertyIndex(AZ::Name(IrisRadiusName));
+        m_innerEyeIORIndex = m_materialInstance->FindPropertyIndex(AZ::Name(InnerEyeIORName));
+        m_limbusSizeIndex = m_materialInstance->FindPropertyIndex(AZ::Name(LimbusSizeName));
+
+        m_specularFactorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(SpecularFactorName));
+
+        m_SSSEnableIndex = m_materialInstance->FindPropertyIndex(AZ::Name(SSSEnableName));
+        m_SSSColorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(SSSColorName));
+        m_SSSFactorIndex = m_materialInstance->FindPropertyIndex(AZ::Name(SSSFactorName));
+        
+        // Assign material property values to the GUI variables so that ImGui displays them properly
+        m_materialInstance->GetPropertyValue(m_irisColorIndex).GetValue<AZ::Color>().GetAsVector3().StoreToFloat3(m_irisColor);
+        m_irisColorFactor = m_materialInstance->GetPropertyValue(m_irisColorFactorIndex).GetValue<float>();
+        m_irisRoughness = m_materialInstance->GetPropertyValue(m_irisRoughnessIndex).GetValue<float>();
+
+        m_materialInstance->GetPropertyValue(m_scleraColorIndex).GetValue<AZ::Color>().GetAsVector3().StoreToFloat3(m_scleraColor);
+        m_scleraColorFactor = m_materialInstance->GetPropertyValue(m_scleraColorFactorIndex).GetValue<float>();
+        m_scleraRoughness = m_materialInstance->GetPropertyValue(m_scleraRoughnessIndex).GetValue<float>();
+        m_scleraNormalFactor = m_materialInstance->GetPropertyValue(m_scleraNormalFactorIndex).GetValue<float>();
+
+        m_irisDepth = m_materialInstance->GetPropertyValue(m_irisDepthIndex).GetValue<float>();
+        m_irisRadius = m_materialInstance->GetPropertyValue(m_irisRadiusIndex).GetValue<float>();
+        m_innerEyeIOR = m_materialInstance->GetPropertyValue(m_innerEyeIORIndex).GetValue<float>();
+        m_limbusSize = m_materialInstance->GetPropertyValue(m_limbusSizeIndex).GetValue<float>();
+
+        m_specularFactor = m_materialInstance->GetPropertyValue(m_specularFactorIndex).GetValue<float>();
+
+        m_SSSEnable = m_materialInstance->GetPropertyValue(m_SSSEnableIndex).GetValue<bool>();
+        m_materialInstance->GetPropertyValue(m_SSSColorIndex).GetValue<AZ::Color>().GetAsVector3().StoreToFloat3(m_SSSColor);
+        m_SSSFactor = m_materialInstance->GetPropertyValue(m_SSSFactorIndex).GetValue<float>();
+    }
+
+    void EyeMaterialExampleComponent::DrawSidebar()
+    {
+        using namespace AZ::Render;
+
+        if (m_imguiSidebar.Begin())
+        {
+            ImGui::Spacing();
+
+            DrawSidebarMaterialProperties();
+
+            ImGui::Separator();
+
+            if (ScriptableImGui::Button("Material Details..."))
+            {
+                m_imguiMaterialDetails.SetMaterial(m_materialInstance);
+                m_imguiMaterialDetails.OpenDialog();
+            }
+
+            m_imguiSidebar.End();
+        }
+        m_imguiMaterialDetails.Tick();
+    }
+    
+    void EyeMaterialExampleComponent::DrawSidebarMaterialProperties()
+    {
+        bool eyeSettingsChanged = false;
+        if (ImGui::CollapsingHeader("Iris", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            ImGui::Indent();
+            if (ScriptableImGui::ColorEdit3("Color##irisColor", m_irisColor, ImGuiColorEditFlags_None))
+            {
+                m_materialInstance->SetPropertyValue(m_irisColorIndex, AZ::Color(m_irisColor[0], m_irisColor[1], m_irisColor[2], 1.0));
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Color Factor##irisColorFactor", &m_irisColorFactor, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_irisColorFactorIndex, m_irisColorFactor);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Roughness##irisRoughness", &m_irisRoughness, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_irisRoughnessIndex, m_irisRoughness);
+                eyeSettingsChanged = true;
+            }
+            ImGui::Unindent();
+        }
+        if (ImGui::CollapsingHeader("Sclera", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            ImGui::Indent();
+            if (ScriptableImGui::ColorEdit3("Color##scleraColor", m_scleraColor, ImGuiColorEditFlags_None))
+            {
+                m_materialInstance->SetPropertyValue(m_scleraColorIndex, AZ::Color(m_scleraColor[0], m_scleraColor[1], m_scleraColor[2], 1.0));
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Color Factor##scleraColorFactor", &m_scleraColorFactor, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_scleraColorFactorIndex, m_scleraColorFactor);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Roughness##scleraRoughness", &m_scleraRoughness, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_scleraRoughnessIndex, m_scleraRoughness);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Normal Factor", &m_scleraNormalFactor, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_scleraNormalFactorIndex, m_scleraNormalFactor);
+                eyeSettingsChanged = true;
+            }
+            ImGui::Unindent();
+        }
+        if (ImGui::CollapsingHeader("General Eye Properties", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            ImGui::Indent();
+            if (ScriptableImGui::SliderFloat("Iris Depth", &m_irisDepth, 0.f, 0.5f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_irisDepthIndex, m_irisDepth);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Inner Radius", &m_irisRadius, 0.f, 0.5f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_irisRadiusIndex, m_irisRadius);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Inner IOR", &m_innerEyeIOR, 1.f, 2.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_innerEyeIORIndex, m_innerEyeIOR);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Limbus Size", &m_limbusSize, 0.f, 0.5f, "%.3f", ImGuiSliderFlags_Logarithmic))
+            {
+                m_materialInstance->SetPropertyValue(m_limbusSizeIndex, m_limbusSize);
+                eyeSettingsChanged = true;
+            }
+            ImGui::Unindent();
+        }
+        if (ImGui::CollapsingHeader("Specular F0", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            ImGui::Indent();
+            if (ScriptableImGui::SliderFloat("Factor##specularF0Factor", &m_specularFactor, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_specularFactorIndex, m_specularFactor);
+                eyeSettingsChanged = true;
+            }
+            ImGui::Unindent();
+        }
+        if (ImGui::CollapsingHeader("Subsurface Scattering", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            ImGui::Indent();
+            if (ScriptableImGui::Checkbox("Enable##enableSSS", &m_SSSEnable))
+            {
+                m_materialInstance->SetPropertyValue(m_SSSEnableIndex, m_SSSEnable);
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::ColorEdit3("Color##SSSColor", m_SSSColor, ImGuiColorEditFlags_None))
+            {
+                m_materialInstance->SetPropertyValue(m_SSSColorIndex, AZ::Color(m_SSSColor[0], m_SSSColor[1], m_SSSColor[2], 1.0));
+                eyeSettingsChanged = true;
+            }
+            if (ScriptableImGui::SliderFloat("Factor##SSSColorFactor", &m_SSSFactor, 0.f, 1.f, "%.3f"))
+            {
+                m_materialInstance->SetPropertyValue(m_SSSFactorIndex, m_SSSFactor);
+                eyeSettingsChanged = true;
+            }
+            ImGui::Unindent();
+        }
+
+        bool transformChanged = false;
+        
+        if (ImGui::CollapsingHeader("Eye Orientation", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Framed))
+        {
+            ImGui::Indent();
+            if (ScriptableImGui::SliderFloat3("Rotation", m_rotationEuler, -180.0, 180.0)) {
+                transformChanged = true;
+                m_eyeTransform.SetRotation(AZ::Quaternion::CreateFromEulerAnglesDegrees(AZ::Vector3(m_rotationEuler[0], m_rotationEuler[1], m_rotationEuler[2])));
+            }
+
+            ImGui::Unindent();
+        }
+
+        if (eyeSettingsChanged)
+        {
+            m_materialInstance->Compile();
+        }
+
+        if (transformChanged)
+        {
+            GetMeshFeatureProcessor()->SetTransform(m_meshHandle, m_eyeTransform);
+        }
+    }
+}

--- a/Gem/Code/Source/EyeMaterialExampleComponent.h
+++ b/Gem/Code/Source/EyeMaterialExampleComponent.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/TickBus.h>
+#include <CommonSampleComponentBase.h>
+#include <Utils/Utils.h>
+
+#include <Utils/ImGuiSidebar.h>
+#include <Utils/ImGuiMaterialDetails.h>
+
+namespace AtomSampleViewer
+{
+    //! Test sample for the Eye material type
+    class EyeMaterialExampleComponent final
+        : public CommonSampleComponentBase
+        , public AZ::TickBus::Handler
+    {
+    public:
+        AZ_COMPONENT(EyeMaterialExampleComponent, "{591B14E7-72CC-4583-B8D8-5A81EEAE85E7}", CommonSampleComponentBase);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        EyeMaterialExampleComponent();
+        ~EyeMaterialExampleComponent() override = default;
+
+        void Activate() override;
+        void Deactivate() override;
+
+    private:
+
+        AZ_DISABLE_COPY_MOVE(EyeMaterialExampleComponent);
+
+        // AZ::TickBus::Handler overrides...
+        void OnTick(float deltaTime, AZ::ScriptTimePoint scriptTime) override;
+
+        void Prepare();
+        void LoadMesh(AZ::Transform transform);
+
+        void InitializeMaterialProperties();
+
+        void DrawSidebar();
+        void DrawSidebarMaterialProperties();
+
+        AZ::Data::Asset<AZ::RPI::ModelAsset> m_modelAsset;
+        AZ::Data::Asset<AZ::RPI::MaterialAsset> m_materialAsset;
+        AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
+        AZ::Data::Instance<AZ::RPI::Material> m_materialInstance;
+        Utils::DefaultIBL m_defaultIbl;
+
+        AZ::Transform m_eyeTransform;
+
+        // Property Index
+        AZ::RPI::MaterialPropertyIndex m_irisColorIndex;
+        AZ::RPI::MaterialPropertyIndex m_irisColorFactorIndex;
+        AZ::RPI::MaterialPropertyIndex m_irisRoughnessIndex;
+
+        AZ::RPI::MaterialPropertyIndex m_scleraColorIndex;
+        AZ::RPI::MaterialPropertyIndex m_scleraColorFactorIndex;
+        AZ::RPI::MaterialPropertyIndex m_scleraRoughnessIndex;
+        AZ::RPI::MaterialPropertyIndex m_scleraNormalFactorIndex;
+
+        AZ::RPI::MaterialPropertyIndex m_irisDepthIndex;
+        AZ::RPI::MaterialPropertyIndex m_irisRadiusIndex;
+        AZ::RPI::MaterialPropertyIndex m_innerEyeIORIndex;
+        AZ::RPI::MaterialPropertyIndex m_limbusSizeIndex;
+
+        AZ::RPI::MaterialPropertyIndex m_specularFactorIndex;
+
+        AZ::RPI::MaterialPropertyIndex m_SSSEnableIndex;
+        AZ::RPI::MaterialPropertyIndex m_SSSColorIndex;
+        AZ::RPI::MaterialPropertyIndex m_SSSFactorIndex;
+
+        // GUI
+        float m_irisColor[3];
+        float m_irisColorFactor;
+        float m_irisRoughness;
+
+        float m_scleraColor[3];
+        float m_scleraColorFactor;
+        float m_scleraRoughness;
+        float m_scleraNormalFactor;
+
+        float m_irisDepth;
+        float m_irisRadius;
+        float m_innerEyeIOR;
+        float m_limbusSize;
+
+        float m_specularFactor;
+
+        bool m_SSSEnable;
+        float m_SSSColor[3];
+        float m_SSSFactor;
+
+        float m_rotationEuler[3];
+
+        ImGuiSidebar m_imguiSidebar;
+        ImGuiMaterialDetails m_imguiMaterialDetails;
+        
+    };
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -82,6 +82,7 @@
 #include <DynamicMaterialTestComponent.h>
 #include <MaterialHotReloadTestComponent.h>
 #include <ExposureExampleComponent.h>
+#include <EyeMaterialExampleComponent.h>
 #include <SceneReloadSoakTestComponent.h>
 #include <LightCullingExampleComponent.h>
 #include <MeshExampleComponent.h>
@@ -299,6 +300,7 @@ namespace AtomSampleViewer
             NewFeaturesSample<DepthOfFieldExampleComponent>("DepthOfField"),
             NewFeaturesSample<DiffuseGIExampleComponent>("DiffuseGI", []() {return Utils::GetRHIDevice()->GetFeatures().m_rayTracing; }),
             NewFeaturesSample<ExposureExampleComponent>("Exposure"),
+            NewFeaturesSample<EyeMaterialExampleComponent>("EyeMaterial"),
             NewFeaturesSample<LightCullingExampleComponent>("LightCulling"),
             NewFeaturesSample<ParallaxMappingExampleComponent>("Parallax"),
             NewFeaturesSample<ShadowExampleComponent>("Shadow"),

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -127,6 +127,8 @@ set(FILES
     Source/EntityUtilityFunctions.h
     Source/ExposureExampleComponent.cpp
     Source/ExposureExampleComponent.h
+    Source/EyeMaterialExampleComponent.h
+    Source/EyeMaterialExampleComponent.cpp
     Source/LightCullingExampleComponent.cpp
     Source/LightCullingExampleComponent.h
     Source/MaterialHotReloadTestComponent.cpp

--- a/Materials/Eye/001_EyeBasic.material
+++ b/Materials/Eye/001_EyeBasic.material
@@ -1,0 +1,20 @@
+{
+    "materialType": "Materials/Types/Eye.materialtype",
+    "materialTypeVersion": 1,
+    "propertyValues": {
+        "eye.innerEyeIOR": 1.2000000476837158,
+        "eye.irisDepth": 0.46000000834465027,
+        "iris.baseColor.color": [
+            0.503395140171051,
+            0.7551079392433167,
+            0.7341268062591553,
+            1.0
+        ],
+        "iris.baseColor.textureMap": "Materials/Eye/Textures/eyeIrisBW.png",
+        "iris.roughness.factor": 0.05999999865889549,
+        "sclera.baseColor.textureMap": "Materials/Eye/Textures/eyeSclera.png",
+        "sclera.normal.factor": 0.2800000011920929,
+        "sclera.normal.textureMap": "Materials/Eye/Textures/proceduralBump.png",
+        "sclera.roughness.factor": 0.17000000178813934
+    }
+}

--- a/Materials/Eye/Textures/eyeIrisBW.png
+++ b/Materials/Eye/Textures/eyeIrisBW.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dbd3712383c1cd3ebfcbafca86617a31cedcdb8a7ad31d6675aa5b7fc3ec68f
+size 338525

--- a/Materials/Eye/Textures/eyeSclera.png
+++ b/Materials/Eye/Textures/eyeSclera.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a4e7e9024981c04eeb9918441a3dea9f2e9823220db750c8bd2bfaed6af9ef4
+size 975570

--- a/Materials/Eye/Textures/proceduralBump.png
+++ b/Materials/Eye/Textures/proceduralBump.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5862abeaa44c25f41420e8009a15cc97e13a8467703290e0b813fd9d2db97ed6
+size 2003143

--- a/Objects/eye.fbx
+++ b/Objects/eye.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d175ec311c84a29b7229e06c315c54dfdcfe2189898a1fa0dc6f936aaf4db494
+size 128492

--- a/Scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
+++ b/Scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53d5181d52bbf9e7eb921429b4c791839a34e1d3f6ceb4330997e6f3a04605b7
+size 402760

--- a/Scripts/EyeMaterialTest.bv.lua
+++ b/Scripts/EyeMaterialTest.bv.lua
@@ -1,0 +1,9 @@
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/EyeMaterial/')
+Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
+
+OpenSample('Features/EyeMaterial')
+ResizeViewport(1600, 900)
+SelectImageComparisonToleranceLevel("Level F")
+
+-- Test with default values
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_eye.png')

--- a/Scripts/_FullTestSuite_.bv.lua
+++ b/Scripts/_FullTestSuite_.bv.lua
@@ -46,6 +46,7 @@ tests= {
     RunScriptWrapper('scripts/decals.bv.luac'),
     RunScriptWrapper('scripts/dynamicdraw.bv.luac'),
     RunScriptWrapper('scripts/dynamicmaterialtest.bv.luac'),
+    RunScriptWrapper('scripts/EyeMaterialTest.bv.luac'),
     RunScriptWrapper('scripts/materialscreenshottests.bv.luac'),
     RunScriptWrapper('scripts/materialhotreloadtest.bv.luac'),
     RunScriptWrapper('scripts/msaa_rpi_test.bv.luac'),

--- a/atomsampleviewer_asset_files.cmake
+++ b/atomsampleviewer_asset_files.cmake
@@ -28,6 +28,7 @@ set(FILES
     Scripts/AreaLightTest.bv.lua
     Scripts/CheckerboardTest.bv.lua
     Scripts/CullingAndLod.bv.lua
+    Scripts/EyeMaterialTest.bv.lua
     Scripts/Decals.bv.lua
     Scripts/DiffuseGITest.bv.lua
     Scripts/DynamicDraw.bv.lua


### PR DESCRIPTION
Follow-up PR for https://github.com/o3de/o3de/issues/8721 adding a new sample and test in ASV for the Eye material (added in https://github.com/o3de/o3de/pull/8129).

The sample exposes the parameters that have most influence on the eye visualization, but not all of them (which can be checked in the Material Editor/Inspector).

As can be observed, the model and textures have not been crafted by an artist, therefore these are not production-ready assets, but should be enough for the sample and test. 
Specifically, the UV layout at the back of the eyeball could be improved, but note that in most use cases this part will be hidden, so the front hemisphere would be enough.
### Sample Video Demo

https://user-images.githubusercontent.com/44426596/163544022-da9b738d-6d4e-4463-81f8-edddbe226746.mp4

  
### Test screenshot
![image](https://user-images.githubusercontent.com/44426596/163547344-b8662391-8aa4-4795-951f-d3b345f5758e.png)


Signed-off-by: Santi Paprika <santi.gonzalez@huawei.com>