### PR TITLE
Remove GridMate from AtomSampleViewer

### DIFF
--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -27,7 +27,6 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzGameFramework/Application/GameApplication.h>
-#include <GridMate/GridMate.h>
 
 namespace AtomSampleViewer
 {

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -342,14 +342,7 @@ namespace AtomSampleViewer
             customRunCode();
         }
 
-        //GridMate allocator is created in StartCommon
-        const GridMate::GridMateDesc desc;
-        GridMate::IGridMate* gridMate = GridMate::GridMateCreate(desc);
-        AZ_Assert(gridMate, "Failed to create gridmate!");
-
         app.RunMainLoop();
-
-        GridMate::GridMateDestroy(gridMate);
 
         app.Stop();
 

--- a/Standalone/Platform/Mac/main_mac.mm
+++ b/Standalone/Platform/Mac/main_mac.mm
@@ -10,9 +10,6 @@
 
 #include <AzGameFramework/Application/GameApplication.h>
 
-#include <GridMate/GridMate.h>
-#include <GridMate/Session/LANSession.h>
-
 #include "MacO3DEApplication.h"
 #include <mach-o/dyld.h>
 #include <libgen.h>

--- a/Standalone/Platform/iOS/main_ios.mm
+++ b/Standalone/Platform/iOS/main_ios.mm
@@ -10,9 +10,6 @@
 
 #include <AzGameFramework/Application/GameApplication.h>
 
-#include <GridMate/GridMate.h>
-#include <GridMate/Session/LANSession.h>
-
 #import <Foundation/Foundation.h>
 #include <UIKit/UIKit.h>
 


### PR DESCRIPTION
This should fix compile issues caused by GridMate's removal from O3DE. As far as I can tell, GridMate is functionally unused in this project.

Signed-off-by: puvvadar <puvvadar@amazon.com>