### PR TITLE
ATOM-17550 RPI/BakedShaderVariant: Sample crashes when exiting the ap…

### DIFF
--- a/Gem/Code/Source/CommonSampleComponentBase.h
+++ b/Gem/Code/Source/CommonSampleComponentBase.h
@@ -75,8 +75,6 @@ namespace AtomSampleViewer
 
         AZ::Render::MeshFeatureProcessorInterface* GetMeshFeatureProcessor() const;
 
-        void OnLightingPresetEntityShutdown(const AZ::EntityId& entityId);
-
         // Preload assets 
         void PreloadAssets(const AZStd::vector<AZ::AssetCollectionAsyncLoader::AssetToLoadInfo>& assetList);
 
@@ -126,7 +124,7 @@ namespace AtomSampleViewer
         constexpr static int32_t InvalidLightingPresetIndex = -1;
         int32_t m_currentLightingPresetIndex = InvalidLightingPresetIndex;
         bool m_useAlternateSkybox = false; //!< LightingPresets have an alternate skybox that can be used, when this is true. This is usually a blurred version of the primary skybox.
-
+         AZ::Render::ExposureControlSettingsInterface* m_exposureControlSettingInterface = nullptr;
     };
 
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/CommonSampleComponentBase.h
+++ b/Gem/Code/Source/CommonSampleComponentBase.h
@@ -124,7 +124,6 @@ namespace AtomSampleViewer
         constexpr static int32_t InvalidLightingPresetIndex = -1;
         int32_t m_currentLightingPresetIndex = InvalidLightingPresetIndex;
         bool m_useAlternateSkybox = false; //!< LightingPresets have an alternate skybox that can be used, when this is true. This is usually a blurred version of the primary skybox.
-         AZ::Render::ExposureControlSettingsInterface* m_exposureControlSettingInterface = nullptr;
     };
 
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/MeshExampleComponent.cpp
+++ b/Gem/Code/Source/MeshExampleComponent.cpp
@@ -405,7 +405,6 @@ namespace AtomSampleViewer
 
     void MeshExampleComponent::OnEntityDestruction(const AZ::EntityId& entityId)
     {
-        OnLightingPresetEntityShutdown(entityId);
         AZ::EntityBus::MultiHandler::BusDisconnect(entityId);
     }
 

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -858,7 +858,6 @@ namespace AtomSampleViewer
                 if (ImGui::MenuItem("Exit", "Ctrl-Q"))
                 {
                     RequestExit();
-                    return;
                 }
                 if (ImGui::MenuItem("Capture Frame...", "Ctrl-P"))
                 {


### PR DESCRIPTION
…plication

The post effect entity was deleted twice if exist the app when the sample is running.
Remove the entity since it's not necessary.
There is an another fix which fix a debug assert with imgui menu when exit ASV from the 'exit' menu option in debug build.

The idea pattern to delete an entity created from the component, is to save the entity id and remove the entity by id. We should change all ASV code using this pattern.
This can simplify the code which we shouldn't need to connect to EntityBus and listen to OnEntityDestruction() event anymore.

Signed-off-by: Qing Tao <55564570+VickyAtAZ@users.noreply.github.com>