### PR TITLE
Fix compilation on Linux for the following error:

### DIFF
--- a/Gem/Code/Source/CommonSampleComponentBase.h
+++ b/Gem/Code/Source/CommonSampleComponentBase.h
@@ -114,9 +114,6 @@ namespace AtomSampleViewer
         //! Lights created by lighting presets.
         AZStd::vector<AZ::Render::DirectionalLightFeatureProcessorInterface::LightHandle> m_lightHandles;
 
-        //! Post process entity to handle ExposureControlSettings.
-        AZ::Entity* m_postProcessEntity = nullptr;
-
         //! Dirty flag is set to true when m_lightingPresets is modified.
         bool m_lightingPresetsDirty = true;
 


### PR DESCRIPTION
https://github.com/o3de/o3de-atom-sampleviewer/issues/434

In file included from /mnt/D/GIT/STAB/o3de/build/External/AtomSampleViewer-4c24181b/Gem/Code/CMakeFiles/AtomSampleViewer.Private.Static.dir/Unity/unity_5_cxx.cxx:3:
In file included from /mnt/D/GIT/STAB/o3de/AtomSampleViewer/Gem/Code/Source/AuxGeomExampleComponent.cpp:9:
In file included from /mnt/D/GIT/STAB/o3de/AtomSampleViewer/Gem/Code/Source/AuxGeomExampleComponent.h:11:
/mnt/D/GIT/STAB/o3de/AtomSampleViewer/Gem/Code/Source/CommonSampleComponentBase.h:118:21: error: private field 'm_postProcessEntity' is not used [-Werror,-Wunused-private-field]
        AZ::Entity* m_postProcessEntity = nullptr;

Signed-off-by: Galib Arrieta <66021303+galibzon@users.noreply.github.com>