### PR TITLE
Fix build error from scripting change

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -966,7 +966,8 @@ namespace AtomSampleViewer
 
         s_instance->m_executingScripts.insert(scriptAsset.GetId());
 
-        if (!s_instance->m_scriptContext->Execute(scriptAsset->GetScriptBuffer().data(), scriptFilePath.c_str(), scriptAsset->GetScriptBuffer().size()))
+        if (!s_instance->m_scriptContext->Execute(
+                scriptAsset->m_data.GetScriptBuffer().data(), scriptFilePath.c_str(), scriptAsset->m_data.GetScriptBuffer().size()))
         {
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.

--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -966,8 +966,11 @@ namespace AtomSampleViewer
 
         s_instance->m_executingScripts.insert(scriptAsset.GetId());
 
-        if (!s_instance->m_scriptContext->Execute(
-                scriptAsset->m_data.GetScriptBuffer().data(), scriptFilePath.c_str(), scriptAsset->m_data.GetScriptBuffer().size()))
+        bool executeSuccess = false;
+        AZ::ScriptSystemRequestBus::BroadcastResult(
+            executeSuccess, &AZ::ScriptSystemRequestBus::Events::Load, scriptAsset, AZ::k_scriptLoadBinaryOrText,
+            s_instance->m_scriptContext->GetId());
+        if (!executeSuccess)
         {
             // Push an error operation on the back of the queue instead of reporting it immediately so it doesn't get lost
             // in front of a bunch of queued m_scriptOperations.


### PR DESCRIPTION
https://github.com/o3de/o3de/commit/52ebc819804a499c61fb208cd82619dccbcb227f Changed the interface for ScriptAsset to no longer have GetScriptBuffer(), which is causing ASV to not compile. Per feedback from @carlitosan , we should really be using the Load event from ScriptSystemRequestBus to execute the script instead.