### PR TITLE
Register the ASV script context with the script system

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -51,10 +51,12 @@ namespace AtomSampleViewer
 
         ScriptableImGui::Create();
 
-        m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
-        m_sriptBehaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
-        ReflectScriptContext(m_sriptBehaviorContext.get());
-        m_scriptContext->BindTo(m_sriptBehaviorContext.get());
+        constexpr AZ::ScriptContextId asvScriptContextId = 12321;
+        AZ::ScriptSystemRequestBus::BroadcastResult(
+            m_scriptContext, &AZ::ScriptSystemRequestBus::Events::AddContextWithId, asvScriptContextId);
+        AZ_Assert(m_scriptContext, "Failed to add the ASV ScriptContext to the ScriptSystem.");
+
+        ReflectScriptContext(m_scriptContext->GetBoundContext());
 
         m_scriptBrowser.SetFilter([](const AZ::Data::AssetInfo& assetInfo)
         {
@@ -73,7 +75,6 @@ namespace AtomSampleViewer
     {
         s_instance = nullptr;
         m_scriptContext = nullptr;
-        m_sriptBehaviorContext = nullptr;
         m_scriptBrowser.Deactivate();
         ScriptableImGui::Destory();
         m_imageComparisonOptions.Deactivate();
@@ -1060,8 +1061,6 @@ namespace AtomSampleViewer
 
     void ScriptManager::ReflectScriptContext(AZ::BehaviorContext* behaviorContext)
     {
-        AZ::MathReflect(behaviorContext);
-
         // Utilities...
         behaviorContext->Method("RunScript", &Script_RunScript);
         behaviorContext->Method("Error", &Script_Error);

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -260,8 +260,7 @@ namespace AtomSampleViewer
         float m_assetTrackingTimeout = 0.0f;
         AssetStatusTracker m_assetStatusTracker;
 
-        AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext; //< Provides the lua scripting system
-        AZStd::unique_ptr<AZ::BehaviorContext> m_sriptBehaviorContext; //< Used to bind script callback functions to lua
+        AZ::ScriptContext* m_scriptContext; //< Provides the lua scripting system
 
         bool m_shouldRestoreViewportSize = false;
         int m_savedViewportWidth = 0;


### PR DESCRIPTION
My previous PR fixed the build error after the latest scripting changes, however using the ScriptSystemRequestBus::Load event to execute a script would fail because ASV's script context was not registered with the script system. This change uses the script system to create the ASV script context, so that the correct context is found when executing scripts.

Signed-off-by: Tommy Walton <waltont@amazon.com>