### PR TITLE
adding a 'c' to the script command line argument so the luac is loaded

### DIFF
--- a/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
@@ -37,7 +37,7 @@ class TestPerformanceBenchmarksPeriodicSuite:
                            'AtomSampleViewerStandalone.exe '
                            f'--project-path={workspace.paths.project()} '
                            f'--rhi {rhi} '
-                           f'--runtestsuite scripts/{benchmark_script} '
+                           f'--runtestsuite scripts/{benchmark_script}c '
                            '--exitontestend')
 
         def teardown():
@@ -48,7 +48,7 @@ class TestPerformanceBenchmarksPeriodicSuite:
         process_utils.safe_check_call(cmd, stderr=subprocess.STDOUT, encoding='UTF-8', shell=True)
         try:
             expected_lines = ["Script: Capturing complete."]
-            atomsampleviewer_log_monitor.monitor_log_for_lines(expected_lines, timeout=180)
+            atomsampleviewer_log_monitor.monitor_log_for_lines(expected_lines, timeout=210)
 
             aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')
             aggregator.upload_metrics(rhi)

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -37,7 +37,7 @@ class TestAutomationMainSuite:
                            'AtomSampleViewerStandalone.exe '
                            f'--project-path={workspace.paths.project()} '
                            f'--rhi {rhi} '
-                           f'--runtestsuite scripts/{test_script} '
+                           f'--runtestsuite scripts/{test_script}c '
                            '--exitontestend')
 
         def teardown():


### PR DESCRIPTION
A recent change to the script system results in AssetProcessor no longer copying unprocessed lua scripts to the cache. Only the compiled luac files are in the cache.
--runtestsuite must now specify a luac script not the lua source name.
local run time for performance benchmark was also 200 seconds so I'm upping the timeout to avoid hitting as the current limit is 180.
I am currently building the branch in jenkins...
Signed-off-by: Scott Murray <scottmur@amazon.com>