### PR TITLE
ASV skinning screenshot test

### DIFF
--- a/Gem/Code/Source/SkinnedMeshContainer.cpp
+++ b/Gem/Code/Source/SkinnedMeshContainer.cpp
@@ -27,7 +27,7 @@
 
 namespace
 {
-    static const char* const SkinnedMeshMaterial = "shaders/debugvertexnormals.azmaterial";
+    static const char* const SkinnedMeshMaterial = "materials/special/debugvertexstreams.azmaterial";
 }
 
 namespace AtomSampleViewer
@@ -223,7 +223,10 @@ namespace AtomSampleViewer
         // Release the per-instance data
         RenderData& renderData = m_skinnedMeshInstances[i];
         m_skinnedMeshFeatureProcessor->ReleaseSkinnedMesh(renderData.m_skinnedMeshHandle);
-        m_meshFeatureProcessor->ReleaseMesh(*renderData.m_meshHandle);
+        if (renderData.m_meshHandle)
+        {
+            m_meshFeatureProcessor->ReleaseMesh(*renderData.m_meshHandle);
+        }
 
         renderData.m_skinnedMeshInstance.reset();
         renderData.m_boneTransformBuffer.reset();

--- a/Scripts/ExpectedScreenshots/SkinnedMesh/screenshot_skinnedmesh.png
+++ b/Scripts/ExpectedScreenshots/SkinnedMesh/screenshot_skinnedmesh.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7ff2973787e511b0927d7fd925d1812d6219792f2fe73b64441584ca8642d3b
+size 113018

--- a/Scripts/SkinnedMesh.bv.lua
+++ b/Scripts/SkinnedMesh.bv.lua
@@ -1,0 +1,32 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/SkinnedMesh/')
+Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
+
+OpenSample('Features/SkinnedMesh')
+ResizeViewport(1600, 900)
+SelectImageComparisonToleranceLevel("Level B")
+
+SetImguiValue('Sub-mesh count', 3)
+SetImguiValue('Bones Per-Mesh', 78)
+SetImguiValue('Vertices Per-Segment', 693)
+SetImguiValue('Segments Per-Mesh', 65.000000)
+SetImguiValue('Use Fixed Animation Time', true)
+SetImguiValue('Fixed Animation Time', 4.751000)
+SetImguiValue('Draw bones', false)
+
+NoClipCameraController_SetPosition(Vector3(-0.125466, -2.129441, 1.728536))
+NoClipCameraController_SetHeading(DegToRad(-8.116900))
+NoClipCameraController_SetPitch(DegToRad(-31.035244))
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_skinnedmesh.png')
+
+OpenSample(nil)

--- a/Scripts/_FullTestSuite_.bv.lua
+++ b/Scripts/_FullTestSuite_.bv.lua
@@ -64,6 +64,7 @@ tests= {
     RunScriptWrapper('scripts/multiscene.bv.luac'),
     RunScriptWrapper('scripts/shadowtest.bv.luac'),
     RunScriptWrapper('scripts/shadowedsponzatest.bv.luac'),
+    RunScriptWrapper('scripts/skinnedmesh.bv.luac'),
     RunScriptWrapper('scripts/RenderTargetTexture.bv.luac'),
     RunScriptWrapper('scripts/PassTree.bv.luac'),
     RunScriptWrapper('scripts/ReadbackTest.bv.luac'),


### PR DESCRIPTION
New screenshot test for skinned meshes in ASV
Also fixed a crash when changing the settings such that a skinned mesh is created which is too large to fit in the skinning buffer

![screenshot_skinnedmesh](https://user-images.githubusercontent.com/82672795/167958844-21a30d35-d830-4675-931a-a084260bf06c.png)


Tested on both Vulkan and DX12

RHI API: dx12
Test Script Count: 26
Screenshot Count: 221
Manually Validated Screenshots: 5/220
Screenshot automatic checks failed: 1
	scripts/shadowtest.bv.luac D:/GitHub/development/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_filter_method.png 'Level H' 0.065216
Screenshot interactive check 'High Difference'
	scripts/shadowtest.bv.luac D:/GitHub/development/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//directional_pcf_high.png 'Level H' 0.020760
Screenshot interactive check 'Low Difference'
	scripts/shadowtest.bv.luac D:/GitHub/development/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_initial.png 'Level H' 0.021211
	scripts/shadowtest.bv.luac D:/GitHub/development/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_shadowmap_size.png 'Level H' 0.022739
	scripts/shadowtest.bv.luac D:/GitHub/development/o3de/AtomSampleViewer/user/Scripts/Screenshots/Shadow//spot_no_red_shadow.png 'Level H' 0.019665
Screenshot interactive check 'No Difference'
	scripts/materialscreenshottests.bv.luac D:/GitHub/development/o3de/AtomSampleViewer/user/Scripts/Screenshots/StandardMultilayerPBR/002_parallaxpdo.png 'Level J' 0.028025
