### PR TITLE
Improvements to the accuracy and consistency of MaterialHotReloadTest

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1371,7 +1371,7 @@ namespace AtomSampleViewer
     {
         auto operation = [command]()
         {
-            AzFramework::ConsoleRequestBus::Broadcast(&AzFramework::ConsoleRequests::ExecuteConsoleCommand, command.c_str());
+            AZ::Interface<AZ::IConsole>::Get()->PerformCommand(command.c_str());
         };
 
         s_instance->m_scriptOperations.push(AZStd::move(operation));

--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -224,6 +224,15 @@ namespace AtomSampleViewer
             WarningsAndErrors,
             ErrorsOnly
         };
+        
+        // Controls how screenshot reports are sorted
+        // Must match static const char* DiplayOptions in .cpp file
+        enum SortOption : int
+        {
+            Unsorted,
+            OfficialBaselineDiffScore,
+            LocalBaselineDiffScore
+        };
 
         static void ReportScriptError(const AZStd::string& message);
         static void ReportScriptWarning(const AZStd::string& message);
@@ -289,8 +298,11 @@ namespace AtomSampleViewer
             void UpdateColorSettings();
         };
 
-        AZStd::multimap<float, ReportIndex, AZStd::greater<float>> m_descendingThresholdReports;
-        bool m_showReportsSortedByThreshold = true;
+        using SortedReportIndexMap = AZStd::multimap<float, ReportIndex, AZStd::greater<float>>;
+
+        SortedReportIndexMap m_reportsSortedByOfficialBaslineScore;
+        SortedReportIndexMap m_reportsSortedByLocaBaslineScore;
+        SortOption m_currentSortOption = SortOption::OfficialBaselineDiffScore;
 
         ImGuiMessageBox m_messageBox;
 

--- a/Gem/Code/Source/Utils/ImGuiMaterialDetails.cpp
+++ b/Gem/Code/Source/Utils/ImGuiMaterialDetails.cpp
@@ -47,7 +47,12 @@ namespace AtomSampleViewer
                                 {
                                     AZ::RPI::ShaderVariantId requestedVariantId = shaderItem.GetShaderVariantId();
                                     AZ::Data::Asset<AZ::RPI::ShaderVariantAsset> selectedVariantAsset =
-                                        shaderItem.GetShaderAsset()->GetVariant(requestedVariantId);
+                                        shaderItem.GetShaderAsset()->GetVariantAsset(requestedVariantId);
+
+                                    if (!selectedVariantAsset)
+                                    {
+                                        selectedVariantAsset = shaderItem.GetShaderAsset()->GetRootVariantAsset();
+                                    }
 
                                     if (selectedVariantAsset)
                                     {

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -19,6 +19,10 @@ ResizeViewport(500, 500)
 
 SelectImageComparisonToleranceLevel("Level E")
 
+-- The default ShaderVariantAsyncLoader service loop delay is too long and would require this
+-- test script to use too long in IdleSeconds()
+ExecuteConsoleCommand("r_ShaderVariantAsyncLoader_ServiceLoopDelayOverride_ms 10")
+
 function SetColorRed()
     AssetTracking_Start()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
@@ -33,7 +37,7 @@ function SetBlendingOn()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
     AssetTracking_IdleUntilExpectedAssetsFinish(10)
-    IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
+    IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 end
 
 function SetBlendingOff()
@@ -42,7 +46,7 @@ function SetBlendingOff()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
     AssetTracking_IdleUntilExpectedAssetsFinish(10)
-    IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
+    IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 end
 
 CaptureScreenshot(g_screenshotOutputFolder .. '/01_Default.png')
@@ -76,7 +80,7 @@ SetImguiValue('Vertical Pattern', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
+IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png')
 
 SetBlendingOn()
@@ -87,7 +91,7 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
+IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png')
 
 -- This will switch to showing the "Shader Variant: Root" message
@@ -125,7 +129,7 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(1) -- Idle for a bit to give time for the assets to reload
+IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png')
 -- Now that the material is using a fully-baked variant, modify the .azsl file to force *everything* to rebuild. In the failure case, the runtime
 -- holds onto the old fully-baked variant even though a new root variant is available. In the correct case, the root variant should take priority
@@ -150,3 +154,5 @@ SetBlendingOff()
 SetColorRed()
 CaptureScreenshot(g_screenshotOutputFolder .. '/15_Red_AfterShaderReload.png')
 
+-- Clear the service loop override back to the default delay
+ExecuteConsoleCommand("r_ShaderVariantAsyncLoader_ServiceLoopDelayOverride_ms 0")

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -136,15 +136,10 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png')
 -- over the fully-baked variant because it is more recent.
 AssetTracking_Start()
 SetImguiValue('Horizontal Pattern', true)
--- Note that here we explicitly do NOT wait for HotReloadTest.shadervariantlist even though the ShaderVariantAssets will be rebuild here too; 
--- part of this test is to ensure the updated shader code is used as soon as the root variant is available.
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
+AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
--- We want this idle to be short enough that the ShaderVariantAssets don't have time to finish building before we take the screenshot, as part
--- of the validation that the root variant gets applied asap. But it also needs to be long enough to account for some delay between the
--- AssetTracking utility and the asset system triggering the reload. We should avoid increasing this if possible (but maybe we'll have no 
--- choice ... we'll see)
 IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
 CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png')
 


### PR DESCRIPTION
These changes correspond to https://github.com/o3de/o3de/pull/9556 , done in preparation for making a shader details tool.

Updated the MaterialHotReloadTest sample to report the actual shader variant being used by the MeshDrawPacket, rather than reporting what variant the material has requested. This gives more accurate results about what's being rendered, and revealed some edge cases where the expected variants weren't actually being used.

Updated MaterialHotReloadTest to configure a shorter delay for the ShaderVariantAsyncLoader thread, so the IdleSeconds times can be reduced. This sortens the test execution time by about 5 seconds, while also preventing intermittent timing failures especially in debug builds.

Updated the MaterialHotReloadTest "14_HorizontalPattern.png" step to wait for the .shadervariantlist to finish processing. This fixes an intermittent failure (8/30) where sometimes it would have the root variant and sometimes the baked variant. Now it consistently has the baked variant.

Also added support for sorting results according to diff score against the local baseline images, in addition to the official baseline images. (This wasn't directly related the shader details tool work, but I happened to have these changes and it's convenient to just put them on the same feature branch).

