### PR TITLE
Added AZ::IO::Streamer's profiler.

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -137,6 +137,7 @@ namespace AtomSampleViewer
         void ShowFrameGraphVisualizerWindow();
         void ShowCpuProfilerWindow();
         void ShowGpuProfilerWindow();
+        void ShowFileIoProfilerWindow();
         void ShowShaderMetricsWindow();
         void ShowTransientAttachmentProfilerWindow();
 
@@ -210,6 +211,7 @@ namespace AtomSampleViewer
         bool m_showCullingDebugWindow = false;
         bool m_showCpuProfiler = false;
         bool m_showGpuProfiler = false;
+        bool m_showFileIoProfiler = false;
         bool m_showTransientAttachmentProfiler = false;
         bool m_showShaderMetrics = false;
 

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -22,4 +22,5 @@ set(ENABLED_GEMS
     Sponza
     MaterialEditor
     UiBasics
+    StreamerProfiler
 )


### PR DESCRIPTION
This adds the new profiler for AZ::IO::Streamer to the AtomSampleViewer next to other profilers. The option will only be available if the StreamerProfiler gem is loaded, which is enabled by default. See https://github.com/o3de/o3de/pull/9493 for details on the profiler itself.

Signed-off-by: AMZN-koppersr <82230785+AMZN-koppersr@users.noreply.github.com>