### PR TITLE
AtomSampleViewer nightly GPU test timeout increase

### DIFF
--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -52,7 +52,7 @@ class TestAutomationMainSuite:
                                 "Trace::Assert",
                                 "Traceback (most recent call last):"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
-                unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=240)
+                unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=400)
         except ly_test_tools.log.log_monitor.LogMonitorException as e:
             expected_screenshots_path = os.path.join(
                 workspace.paths.project(), "Scripts", "ExpectedScreenshots")


### PR DESCRIPTION
Bumps the AtomSampleViewer nightly GPU test timeout to 400 since it has been timing out for several nights

Signed-off-by: Scott Murray <scottmur@amazon.com>