### PR TITLE
adding Exposure sample screenshot compare test

### DIFF
--- a/Scripts/ExpectedScreenshots/ExposureTest/screenshot_exposure.png
+++ b/Scripts/ExpectedScreenshots/ExposureTest/screenshot_exposure.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d376381c9d8519d27e8e4a03117919582f936eb709bf76d1885c84d1cf71e682
+size 512689

--- a/Scripts/ExposureTest.bv.lua
+++ b/Scripts/ExposureTest.bv.lua
@@ -1,0 +1,24 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ExposureTest/')
+Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
+
+OpenSample('Features/Exposure')
+ResizeViewport(800, 600)
+SelectImageComparisonToleranceLevel("Level E")
+
+-- eye adaptation has a default speed. we are waiting 9 seconds for the sample to reach stable state
+IdleSeconds(9)
+
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_exposure.png')
+
+OpenSample(nil)

--- a/Scripts/_FullTestSuite_.bv.lua
+++ b/Scripts/_FullTestSuite_.bv.lua
@@ -69,6 +69,7 @@ tests= {
     RunScriptWrapper('scripts/PassTree.bv.luac'),
     RunScriptWrapper('scripts/ReadbackTest.bv.luac'),
     RunScriptWrapper('scripts/depthoffieldtest.bv.luac'),
+    RunScriptWrapper('scripts/exposuretest.bv.luac'),
 
     --Fast checking for the samples which don't have a test. Samples should be removed from this list once they have their own tests
 
@@ -103,7 +104,6 @@ tests= {
     FastCheckSample('RPI/RootConstants'),
 
     FastCheckSample('Features/Bloom'),
-    FastCheckSample('Features/Exposure'),
     FastCheckSample('Features/SkinnedMesh'),
     FastCheckSample('Features/SSAO'),
     FastCheckSample('Features/SSR'),


### PR DESCRIPTION
Adds Exposure sample screenshot compare test to full suite.
This is set to take 9 seconds for eye adaptation to stabilize before the screenshot is taken.
This does not change any render code, it simply adds a screenshot test for an existing sample.

vulkan:
![exposure_vulkan](https://user-images.githubusercontent.com/26234397/170391175-b8320cc6-159e-4f05-bdb8-aa0bd63363ce.png)
DX12:
![exposure_dx12](https://user-images.githubusercontent.com/26234397/170391166-b406607c-8b53-4520-bccc-5d3da4e1d258.png)

Signed-off-by: Scott Murray <scottmur@amazon.com>