### PR TITLE
More accurate FrameTime stats

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -201,7 +201,9 @@ namespace AtomSampleViewer
 
         int32_t m_selectedSampleIndex = -1;
 
-        static constexpr uint32_t FrameTimeLogSize = 100;
+        static constexpr uint32_t FrameTimeDefaultLogSize = 100;
+        static constexpr uint32_t FrameTimeMinLogSize = FrameTimeDefaultLogSize;
+        static constexpr uint32_t FrameTimeMaxLogSize = 1000000; // 1M
         AZStd::unique_ptr<ImGuiHistogramQueue> m_imGuiFrameTimer;
 
         ImGuiMessageBox m_contentWarningDialog;

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -200,7 +200,7 @@ namespace AtomSampleViewer
 
         int32_t m_selectedSampleIndex = -1;
 
-        static constexpr uint32_t FrameTimeLogSize = 30;
+        static constexpr uint32_t FrameTimeLogSize = 500;
         ImGuiHistogramQueue m_imGuiFrameTimer;
 
         ImGuiMessageBox m_contentWarningDialog;

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -33,6 +33,7 @@
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/map.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/smart_ptr/unique_ptr.h>
 
 #include <AzFramework/Input/Events/InputChannelEventListener.h>
 #include <AzFramework/Entity/EntityContextBus.h>
@@ -200,8 +201,8 @@ namespace AtomSampleViewer
 
         int32_t m_selectedSampleIndex = -1;
 
-        static constexpr uint32_t FrameTimeLogSize = 500;
-        ImGuiHistogramQueue m_imGuiFrameTimer;
+        static constexpr uint32_t FrameTimeLogSize = 100;
+        AZStd::unique_ptr<ImGuiHistogramQueue> m_imGuiFrameTimer;
 
         ImGuiMessageBox m_contentWarningDialog;
 

--- a/Gem/Code/Source/Utils/ImGuiHistogramQueue.cpp
+++ b/Gem/Code/Source/Utils/ImGuiHistogramQueue.cpp
@@ -69,7 +69,7 @@ namespace AtomSampleViewer
         // Calculate average for numeric display
         if (m_timeSinceLastDisplayUpdate >= m_numericDisplayDelay || m_samplesSinceLastDisplayUpdate >= m_maxSamples)
         {
-            m_displayedAverage = UpdateDisplayedValues(m_samplesSinceLastDisplayUpdate, m_displayedMinimum, m_displayedMaximum);
+            m_displayedAverage = UpdateDisplayedValues(m_maxSamples, m_displayedMinimum, m_displayedMaximum);
 
             m_timeSinceLastDisplayUpdate = 0.0f;
             m_samplesSinceLastDisplayUpdate = 0;


### PR DESCRIPTION
Increased the number of recorded frames to 500 to better average out ASV's variablility.
Made the average calculation use all the frame times rather than just the ones in the last 1/4 second.

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>