### PR TITLE
Fixed a timing issue in MaterialHotReloadTest. 

### DIFF
--- a/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
@@ -352,7 +352,7 @@ namespace AtomSampleViewer
                 {
                     shaderVariantStatus = ShaderVariantStatus::FullyBaked;
                 }
-                else if (activeVariantId == activeShaderList[0].m_shader->GetVariant(RootShaderVariantStableId).GetShaderVariantId())
+                else if (activeVariantId.IsEmpty())
                 {
                     shaderVariantStatus = ShaderVariantStatus::Root;
                 }

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -23,12 +23,20 @@ SelectImageComparisonToleranceLevel("Level E")
 -- test script to use too long in IdleSeconds()
 ExecuteConsoleCommand("r_ShaderVariantAsyncLoader_ServiceLoopDelayOverride_ms 10")
 
+function IdleForReload()
+    -- Idle for a bit to give time for assets to reload
+    IdleSeconds(0.25)
+    -- Just in case the above IdleSeconds were consumed by one long frame, idle for a couple more frames, since the full reload
+    -- process can often span multiple frames.
+    IdleFrames(2)
+end
+
 function SetColorRed()
     AssetTracking_Start()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
     SetImguiValue('ColorA = Red', true)
     AssetTracking_IdleUntilExpectedAssetsFinish(10)
-    IdleSeconds(0.25) -- Idle for a bit to give time for the asset to reload
+    IdleForReload()
 end
 
 function SetBlendingOn()
@@ -37,7 +45,7 @@ function SetBlendingOn()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
     AssetTracking_IdleUntilExpectedAssetsFinish(10)
-    IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+    IdleForReload()
 end
 
 function SetBlendingOff()
@@ -46,7 +54,7 @@ function SetBlendingOff()
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
     AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
     AssetTracking_IdleUntilExpectedAssetsFinish(10)
-    IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+    IdleForReload()
 end
 
 CaptureScreenshot(g_screenshotOutputFolder .. '/01_Default.png')
@@ -58,21 +66,21 @@ AssetTracking_Start()
 SetImguiValue('ColorA = Blue', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the asset to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/03_Blue.png')
 
 AssetTracking_Start()
 SetImguiValue('Default Colors', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the asset to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/04_DefaultAgain.png')
 
 AssetTracking_Start()
 SetImguiValue('Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/05_WavyLines.png')
 
 AssetTracking_Start()
@@ -80,7 +88,7 @@ SetImguiValue('Vertical Pattern', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png')
 
 SetBlendingOn()
@@ -91,7 +99,7 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png')
 
 -- This will switch to showing the "Shader Variant: Root" message
@@ -99,7 +107,7 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/Only Straight Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.png')
 
 -- This will switch to showing the "Shader Variant: Fully Baked" message again
@@ -107,7 +115,7 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/Only Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/10_Variants_OnlyWavyLines.png')
 
 -- This screenshot will be identical to the one above because the variants
@@ -129,7 +137,7 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png')
 -- Now that the material is using a fully-baked variant, modify the .azsl file to force *everything* to rebuild. In the failure case, the runtime
 -- holds onto the old fully-baked variant even though a new root variant is available. In the correct case, the root variant should take priority
@@ -140,7 +148,7 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
-IdleSeconds(0.25) -- Idle for a bit to give time for the assets to reload
+IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png')
 
 -- Test a specific scenario that was failing, where color changes fail to reload after making a shader change.


### PR DESCRIPTION
When there were many AssetBuilder.exe processes running, many reload operations seemed to happen on the same frame, which made that frame to take the entire IdleSeconds(0.25). Since the shader reloading process can span multiple frames, this was not enough of a delay. So I made the test idle for 0.25s plus 2 frames.

I also made a slight improvement to MaterialHotReloadTestComponent to check the active shader variant ID without calling GetVariant, which could have impacted the behavior of the test.

This partially addresses https://github.com/o3de/o3de-atom-sampleviewer/issues/458 

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>