### PR TITLE
Updating the ScriptReporter.cpp to no longer use the zero parameter push_back() extension

### DIFF
--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -178,8 +178,7 @@ namespace AtomSampleViewer
         }
 
         m_currentScriptIndexStack.push_back(m_scriptReports.size());
-        m_scriptReports.push_back();
-        m_scriptReports.back().m_scriptAssetPath = scriptAssetPath;
+        m_scriptReports.emplace_back().m_scriptAssetPath = scriptAssetPath;
         m_scriptReports.back().BusConnect();
     }
 


### PR DESCRIPTION

It now uses emplace_back()

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>