### PR TITLE
ShaderReloadTestComponent Fix

### DIFF
--- a/Gem/Code/Source/ShaderReloadTestComponent.cpp
+++ b/Gem/Code/Source/ShaderReloadTestComponent.cpp
@@ -200,7 +200,7 @@ namespace AtomSampleViewer
         m_scene->RemoveRenderPipeline(m_originalPipeline->GetId());
 
         // add the checker board pipeline
-        const AZStd::string pipelineName("Fullscreen");
+        const AZStd::string pipelineName("FullscreenPipeline");
         AZ::RPI::RenderPipelineDescriptor pipelineDesc;
         pipelineDesc.m_mainViewTagName = "MainCamera";
         pipelineDesc.m_name = pipelineName;


### PR DESCRIPTION
Matching pipeline pass name to the "FullscreenPipeline" name used for ImGui lookup in OnAllAssetsReadyActivate(), which fixes imgui for ShaderReloadTestComponent

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>