### PR TITLE
Update ASV material versions so warnings should be gone

### DIFF
--- a/Materials/Decal/airship_nose_number_decal.material
+++ b/Materials/Decal/airship_nose_number_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/airship_nose_number_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/airship_nose_number_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/airship_nose_number_decal.tif",

--- a/Materials/Decal/airship_symbol_decal.material
+++ b/Materials/Decal/airship_symbol_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/airship_symbol_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/airship_symbol_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/airship_symbol_decal.tif",

--- a/Materials/Decal/airship_tail_01_decal.material
+++ b/Materials/Decal/airship_tail_01_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/airship_tail_01_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/airship_tail_01_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/airship_tail_01_decal_nrm.tif",

--- a/Materials/Decal/airship_tail_02_decal.material
+++ b/Materials/Decal/airship_tail_02_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/airship_tail_02_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/airship_tail_02_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/airship_tail_02_decal.tif",

--- a/Materials/Decal/am_mud_decal.material
+++ b/Materials/Decal/am_mud_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/am_mud_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/am_mud_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/am_mud_decal.tif",

--- a/Materials/Decal/am_road_dust_decal.material
+++ b/Materials/Decal/am_road_dust_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/am_road_dust_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/am_road_dust_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/am_road_dust_decal.tif",

--- a/Materials/Decal/brushstoke_01_decal.material
+++ b/Materials/Decal/brushstoke_01_decal.material
@@ -1,13 +1,13 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/brushstoke_01_decal.tif",
         "general.applySpecularAA": false,
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/brushstoke_01_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/brushstoke_01_decal.tif",

--- a/Materials/Decal/scorch_01_decal.material
+++ b/Materials/Decal/scorch_01_decal.material
@@ -1,12 +1,12 @@
 {
     "materialType": "Materials/Types/StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/Decal/scorch_01_decal.tif",
+        "general.doubleSided": true,
         "metallic.useTexture": false,
         "normal.textureMap": "Materials/Decal/scorch_01_decal_nrm.tif",
         "opacity.alphaSource": "Split",
-        "opacity.doubleSided": true,
         "opacity.factor": 0.6899999976158142,
         "opacity.mode": "Cutout",
         "opacity.textureMap": "Materials/Decal/scorch_01_decal.tif",

--- a/Materials/DefaultPBR.material
+++ b/Materials/DefaultPBR.material
@@ -1,5 +1,5 @@
 {
     "materialType": "Materials/Types/StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "parentMaterial": "Materials/Presets/PBR/default_grid.material"
 }

--- a/Materials/DefaultPBRTransparent.material
+++ b/Materials/DefaultPBRTransparent.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials/Types/StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "parentMaterial": "Materials/Presets/PBR/default_grid.material",
     "propertyValues": {
         "opacity.mode": "Blended"

--- a/Materials/DiffuseGIExample/blue.material
+++ b/Materials/DiffuseGIExample/blue.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.0,
@@ -9,7 +9,7 @@
             1.0
         ],
         "baseColor.useTexture": false,
-        "irradiance.color": [
+        "irradiance.manualColor": [
             0.0,
             0.0,
             1.0,

--- a/Materials/DiffuseGIExample/green.material
+++ b/Materials/DiffuseGIExample/green.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.0,
@@ -9,7 +9,7 @@
             1.0
         ],
         "baseColor.useTexture": false,
-        "irradiance.color": [
+        "irradiance.manualColor": [
             0.0,
             1.0,
             0.0,

--- a/Materials/DiffuseGIExample/red.material
+++ b/Materials/DiffuseGIExample/red.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             1.0,
@@ -9,7 +9,7 @@
             1.0
         ],
         "baseColor.useTexture": false,
-        "irradiance.color": [
+        "irradiance.manualColor": [
             1.0,
             0.0,
             0.0,

--- a/Materials/DiffuseGIExample/white.material
+++ b/Materials/DiffuseGIExample/white.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             1.0,
@@ -9,7 +9,7 @@
             1.0
         ],
         "baseColor.useTexture": false,
-        "irradiance.color": [
+        "irradiance.manualColor": [
             1.0,
             1.0,
             1.0,

--- a/Materials/DiffuseGIExample/yellow.material
+++ b/Materials/DiffuseGIExample/yellow.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             1.0,
@@ -9,7 +9,7 @@
             1.0
         ],
         "baseColor.useTexture": false,
-        "irradiance.color": [
+        "irradiance.manualColor": [
             1.0,
             1.0,
             0.0,

--- a/Materials/HotReloadTest/TestData/VariantSelection_FullyBaked.material
+++ b/Materials/HotReloadTest/TestData/VariantSelection_FullyBaked.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials/Types/StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.0,
@@ -17,6 +17,6 @@
         "emissive.enable": true,
         "emissive.intensity": 3.0,
         "emissive.textureMap": "Materials/HotReloadTest/TestData/VariantSelection_FullyBaked.png",
-        "opacity.doubleSided": true
+        "general.doubleSided": true
     }
 }

--- a/Materials/HotReloadTest/TestData/VariantSelection_Root.material
+++ b/Materials/HotReloadTest/TestData/VariantSelection_Root.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials/Types/StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.0,
@@ -16,6 +16,6 @@
         ],
         "emissive.enable": true,
         "emissive.textureMap": "Materials/HotReloadTest/TestData/VariantSelection_Root.png",
-        "opacity.doubleSided": true
+        "general.doubleSided": true
     }
 }

--- a/Materials/SSRExample/Cube.material
+++ b/Materials/SSRExample/Cube.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             1.0,

--- a/Materials/SSRExample/GroundPlaneAluminum.material
+++ b/Materials/SSRExample/GroundPlaneAluminum.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.9130998849868774,

--- a/Materials/SSRExample/GroundPlaneChrome.material
+++ b/Materials/SSRExample/GroundPlaneChrome.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.5529412031173706,

--- a/Materials/SSRExample/GroundPlaneMirror.material
+++ b/Materials/SSRExample/GroundPlaneMirror.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             1.0,

--- a/Materials/SSRExample/GroundPlaneWood.material
+++ b/Materials/SSRExample/GroundPlaneWood.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.textureMap": "Materials/SSRExample/wood_planks_512_diff.tif",
         "metallic.factor": 0.0,

--- a/Materials/SSRExample/ShaderBall.material
+++ b/Materials/SSRExample/ShaderBall.material
@@ -1,6 +1,6 @@
 {
     "materialType": "Materials\\Types\\StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "propertyValues": {
         "baseColor.color": [
             0.0,
@@ -9,7 +9,7 @@
             1.0
         ],
         "baseColor.useTexture": false,
-        "irradiance.color": [
+        "irradiance.manualColor": [
             0.0,
             0.0,
             1.0,

--- a/Materials/TransparentDoubleSide.material
+++ b/Materials/TransparentDoubleSide.material
@@ -1,9 +1,9 @@
 {
     "materialType": "Materials/Types/StandardPBR.materialtype",
-    "materialTypeVersion": 3,
+    "materialTypeVersion": 5,
     "parentMaterial": "Materials/Presets/PBR/default_grid.material",
     "propertyValues": {
-        "opacity.doubleSided": true,
+        "general.doubleSided": true,
         "opacity.mode": "Blended"
     }
 }


### PR DESCRIPTION
Other updates in https://github.com/o3de/o3de/pull/11123
Tested on related samples.
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>