### PR TITLE
Scene reset and multiscene fixes

### DIFF
--- a/Gem/Code/Source/CommonSampleComponentBase.cpp
+++ b/Gem/Code/Source/CommonSampleComponentBase.cpp
@@ -307,6 +307,7 @@ namespace AtomSampleViewer
     void CommonSampleComponentBase::ResetScene()
     {
         m_meshFeatureProcessor = nullptr;
+        m_scene = RPI::RPISystemInterface::Get()->GetSceneByName(AZ::Name("RPI"));
     }
 
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -82,7 +82,7 @@ namespace AtomSampleViewer
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::PointLightFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::PostProcessFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::QuadLightFeatureProcessor");
-        sceneDesc.m_featureProcessorNames.push_back("ReflectionProbeFeatureProcessor");
+        sceneDesc.m_featureProcessorNames.push_back("AZ::Render::ReflectionProbeFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::SkyBoxFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::TransformServiceFeatureProcessor");
         sceneDesc.m_featureProcessorNames.push_back("AZ::Render::ProjectedShadowFeatureProcessor");


### PR DESCRIPTION
Fixes the multi-scene example component using the wrong name for requesting the reflection probe feature processor. Also fixes `ResetScene()` so it actually gets the new scene instead of holding onto a possibly stale pointer.

Fixes: https://github.com/o3de/o3de-atom-sampleviewer/issues/487