### PR TITLE
Fix aux geom feature processor in rhi samples.

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1546,7 +1546,7 @@ namespace AtomSampleViewer
         // Create and register the rhi scene with only feature processors required for AtomShimRenderer (only for AtomSampleViewerLauncher)
         RPI::SceneDescriptor sceneDesc;
         sceneDesc.m_nameId = AZ::Name("RHI");
-        sceneDesc.m_featureProcessorNames.push_back("AuxGeomFeatureProcessor");
+        sceneDesc.m_featureProcessorNames.push_back("AZ::Render::AuxGeomFeatureProcessor");
         m_rhiScene = RPI::Scene::CreateScene(sceneDesc);
         m_rhiScene->Activate();
 


### PR DESCRIPTION
The rtti for aux geom was updated to include the namespace (which is standard) so this place needs to be updated to reference that namespace as well.

Signed-off-by: Ken Pruiksma <pruiksma@amazon.com>