### PR TITLE
Fix the 15th screenshot having root variant instead of fully baked

### DIFF
--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -156,9 +156,10 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png')
 
 -- Test a specific scenario that was failing, where color changes fail to reload after making a shader change.
 SetBlendingOn()
+IdleForReload()
 SetBlendingOff()
+IdleForReload()
 SetColorRed()
-IdleSeconds(4.0)
 IdleForReload()
 CaptureScreenshot(g_screenshotOutputFolder .. '/15_Red_AfterShaderReload.png')
 


### PR DESCRIPTION
The test is introduced in https://github.com/o3de/o3de-atom-sampleviewer/pull/459
By removing the fix in the above PR, it still failed to changed the color, as the test was intended to do.
(Note some shader reload code was already removed in https://github.com/o3de/o3de/pull/5142)

Intended failure without the fix:
![1](https://user-images.githubusercontent.com/51759646/184997231-17940d37-aced-4764-bed2-dc3fc8481328.JPG)

Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>