### PR TITLE
Changed the construction of divider string for the ImGuiShaderUtils.

### DIFF
--- a/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp
+++ b/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp
@@ -29,7 +29,7 @@ namespace AtomSampleViewer
             }
 
             AZStd::string header = AZStd::string::format("%-*s |  Bits | Requested | Selected", longestOptionNameLength, "Option Name");
-            AZStd::string divider{header.size(), '-'};
+            AZStd::string divider(header.size(), '-');
 
             ImGui::Text("%s", header.c_str());
             ImGui::Text("%s", divider.c_str());


### PR DESCRIPTION
It was using curly braces, now it is using parenthesis.
It was causing a compilation on a developers machine.

```
D:/github/AtomSampleViewer/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp(32,46): error C2398: Element '1': conversion from 'unsigned __int64' to '_Elem' requires a narrowing conversion
3>        with
3>        [
3>            _Elem=char
3>        ]
3>            AZStd::string divider{header.size(), '-'};
3>                                             ^
3>D:/github/AtomSampleViewer/Gem/Code/Source/Utils/ImGuiShaderUtils.cpp(32,53): warning C4267: 'initializing': conversion from 'size_t' to '_Elem', possible loss of data
3>        with
3>        [
3>            _Elem=char
3>        ]
3>            AZStd::string divider{header.size(), '-'};
```

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>