### PR TITLE
Removing include paths to ImguiShaderMetrics which was removed.

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -28,7 +28,6 @@
 
 #include <Atom/RHI/Factory.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
-#include <Atom/RPI.Public/Shader/Metrics/ShaderMetricsSystem.h>
 
 #include <ISystem.h>
 #include <IConsole.h>

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -26,7 +26,6 @@
 #include <Atom/Utils/ImGuiPassTree.h>
 #include <Atom/Utils/ImGuiFrameVisualizer.h>
 #include <Atom/Utils/ImGuiTransientAttachmentProfiler.h>
-#include <Atom/Utils/ImGuiShaderMetrics.h>
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>


### PR DESCRIPTION
ImguiShaderMetrics was removed, but these includes remained, causing a build failure in ASV.