### PR TITLE
Screenshots stored from nightly Jenkins ASV "Test GPU Profile" only contain Vulkan versions, not DX12 versions

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1094,7 +1094,6 @@ namespace AtomSampleViewer
         behaviorContext->Method("CaptureScreenshotWithImGui", &Script_CaptureScreenshotWithImGui);
         behaviorContext->Method("CaptureScreenshotWithPreview", &Script_CaptureScreenshotWithPreview);
         behaviorContext->Method("CapturePassAttachment", &Script_CapturePassAttachment);
-        behaviorContext->Method("QueryRenderBackend", &Script_QueryRenderBackend);
 
         // Profiling data...
         behaviorContext->Method("CapturePassTimestamp", &Script_CapturePassTimestamp);
@@ -1527,7 +1526,7 @@ namespace AtomSampleViewer
             });
     }
 
-    AZStd::string ScriptManager::Script_QueryRenderBackend()
+    AZStd::string ScriptManager::Script_GetRenderApiName()
     {
         AZ::Name renderApi = AZ::RPI::RPISystemInterface::Get()->GetRenderApiName();
         return AZStd::string(renderApi.GetCStr());

--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1453,11 +1453,10 @@ namespace AtomSampleViewer
     {
         Script_SetShowImGui(false);
 
-        const AZStd::string& envPath = s_instance->m_envPath;
-        auto operation = [filePath, envPath]()
+        auto operation = [filePath]()
         {
             // Note this will pause the script until the capture is complete
-            if (PrepareForScreenCapture(filePath, envPath))
+            if (PrepareForScreenCapture(filePath, s_instance->m_envPath))
             {
                 AZ_Assert(s_instance->m_frameCaptureId == AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId, "Attempting to start a capture while one is in progress");
                 uint32_t frameCaptureId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
@@ -1487,11 +1486,10 @@ namespace AtomSampleViewer
     {
         Script_SetShowImGui(true);
 
-        const AZStd::string& envPath = s_instance->m_envPath;
-        auto operation = [filePath, envPath]()
+        auto operation = [filePath]()
         {
             // Note this will pause the script until the capture is complete
-            if (PrepareForScreenCapture(filePath, envPath))
+            if (PrepareForScreenCapture(filePath, s_instance->m_envPath))
             {
                 AZ_Assert(s_instance->m_frameCaptureId == AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId, "Attempting to start a capture while one is in progress");
                 uint32_t frameCaptureId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
@@ -1518,11 +1516,10 @@ namespace AtomSampleViewer
 
     void ScriptManager::Script_CaptureScreenshotWithPreview(const AZStd::string& filePath)
     {
-        const AZStd::string& envPath = s_instance->m_envPath;
-        auto operation = [filePath, envPath]()
+        auto operation = [filePath]()
         {
             // Note this will pause the script until the capture is complete
-            if (PrepareForScreenCapture(filePath, envPath))
+            if (PrepareForScreenCapture(filePath, s_instance->m_envPath))
             {
                 AZ_Assert(s_instance->m_frameCaptureId == AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId, "Attempting to start a capture while one is in progress");
                 uint32_t frameCaptureId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
@@ -1616,11 +1613,10 @@ namespace AtomSampleViewer
             }
         }
 
-        const AZStd::string& envPath = s_instance->m_envPath;
-        auto operation = [passHierarchy, slot, outputFilePath, envPath, readbackOption]()
+        auto operation = [passHierarchy, slot, outputFilePath, readbackOption]()
         {
             // Note this will pause the script until the capture is complete
-            if (PrepareForScreenCapture(outputFilePath, envPath))
+            if (PrepareForScreenCapture(outputFilePath, s_instance->m_envPath))
             {
                 AZ_Assert(s_instance->m_frameCaptureId == AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId, "Attempting to start a capture while one is in progress");
                 uint32_t frameCaptureId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -136,8 +136,10 @@ namespace AtomSampleViewer
         // but with "Screenshots" replaced with "ExpectedScreenshots". For example, the expected file for
         // "Scripts/Screenshots/StandardPbr/test.ppm" should be at "Scripts/ExpectedScreenshots/StandardPbr/test.ppm".
 
-        static void Script_CaptureScreenshot(const AZStd::string& filePath);
-        static void Script_CaptureScreenshotWithImGui(const AZStd::string& filePath);
+        static void Script_CaptureScreenshot(const AZStd::string& filePath, const AZStd::string& suffix);
+        static void Script_CaptureScreenshotWithImGui(const AZStd::string& filePath, const AZStd::string& suffix);
+
+        static AZStd::string Script_QueryRenderBackend();
 
         // Capture a pass attachment and save it to a file (*.ppm or *.dds for image, *.buffer for buffer)
         // The order of input parameters in ScriptDataContext would be
@@ -148,7 +150,7 @@ namespace AtomSampleViewer
         static void Script_CapturePassAttachment(AZ::ScriptDataContext& dc);
 
         // Capture a screentshot with pass image attachment preview when the preview enabled.
-        static void Script_CaptureScreenshotWithPreview(const AZStd::string& filePath);
+        static void Script_CaptureScreenshotWithPreview(const AZStd::string& filePath, const AZStd::string& suffix);
 
         // Profiling statistics data...
         static void Script_CapturePassTimestamp(AZ::ScriptDataContext& dc);
@@ -233,7 +235,7 @@ namespace AtomSampleViewer
         // Validates the ScriptDataContext for ProfilingCapture script requests
         static bool ValidateProfilingCaptureScripContexts(AZ::ScriptDataContext& dc, AZStd::string& outputFilePath);
 
-        static bool PrepareForScreenCapture(const AZStd::string& path);
+        static bool PrepareForScreenCapture(const AZStd::string& path, const AZStd::string& suffix);
 
         // show/hide imgui
         void SetShowImGui(bool show);

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -124,6 +124,8 @@ namespace AtomSampleViewer
         static void Script_ShowTool(const AZStd::string& toolName, bool enable);
 
         // Screenshots...
+        // Store the test environment path of the screenshots. It will be used to figure out the baseline path.
+        static void Script_SetTestEnvPath(const AZStd::string& envPath);
 
         // Call this function before capturing screenshots to indicate which comparison tolerance level should be used.
         // The list of available tolerance levels can be found in "AtomSampleViewer/Config/ImageComparisonToleranceLevels.azasset".
@@ -136,10 +138,8 @@ namespace AtomSampleViewer
         // but with "Screenshots" replaced with "ExpectedScreenshots". For example, the expected file for
         // "Scripts/Screenshots/StandardPbr/test.ppm" should be at "Scripts/ExpectedScreenshots/StandardPbr/test.ppm".
 
-        static void Script_CaptureScreenshot(const AZStd::string& filePath, const AZStd::string& suffix);
-        static void Script_CaptureScreenshotWithImGui(const AZStd::string& filePath, const AZStd::string& suffix);
-
-        static AZStd::string Script_GetRenderApiName();
+        static void Script_CaptureScreenshot(const AZStd::string& filePath);
+        static void Script_CaptureScreenshotWithImGui(const AZStd::string& filePath);
 
         // Capture a pass attachment and save it to a file (*.ppm or *.dds for image, *.buffer for buffer)
         // The order of input parameters in ScriptDataContext would be
@@ -150,7 +150,7 @@ namespace AtomSampleViewer
         static void Script_CapturePassAttachment(AZ::ScriptDataContext& dc);
 
         // Capture a screentshot with pass image attachment preview when the preview enabled.
-        static void Script_CaptureScreenshotWithPreview(const AZStd::string& filePath, const AZStd::string& suffix);
+        static void Script_CaptureScreenshotWithPreview(const AZStd::string& filePath);
 
         // Profiling statistics data...
         static void Script_CapturePassTimestamp(AZ::ScriptDataContext& dc);
@@ -235,7 +235,7 @@ namespace AtomSampleViewer
         // Validates the ScriptDataContext for ProfilingCapture script requests
         static bool ValidateProfilingCaptureScripContexts(AZ::ScriptDataContext& dc, AZStd::string& outputFilePath);
 
-        static bool PrepareForScreenCapture(const AZStd::string& path, const AZStd::string& suffix);
+        static bool PrepareForScreenCapture(const AZStd::string& path, const AZStd::string& envPath);
 
         // show/hide imgui
         void SetShowImGui(bool show);
@@ -250,6 +250,8 @@ namespace AtomSampleViewer
         };
 
         TestSuiteExecutionConfig m_testSuiteRunConfig;
+
+        AZStd::string m_envPath = "";
 
         static constexpr float DefaultPauseTimeout = 5.0f;
 

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -139,7 +139,7 @@ namespace AtomSampleViewer
         static void Script_CaptureScreenshot(const AZStd::string& filePath, const AZStd::string& suffix);
         static void Script_CaptureScreenshotWithImGui(const AZStd::string& filePath, const AZStd::string& suffix);
 
-        static AZStd::string Script_QueryRenderBackend();
+        static AZStd::string Script_GetRenderApiName();
 
         // Capture a pass attachment and save it to a file (*.ppm or *.dds for image, *.buffer for buffer)
         // The order of input parameters in ScriptDataContext would be

--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -45,7 +45,7 @@ namespace AtomSampleViewer
 
         AZStd::string GetLocalBaselineFolder(bool resolvePath)
         {
-            AZStd::string path = AZStd::string::format("@user@/scripts/screenshotslocalbaseline/%s", AZ::RHI::Factory::Get().GetName().GetCStr());
+            AZStd::string path = AZStd::string::format("@user@/scripts/screenshotslocalbaseline/");
 
             if (resolvePath)
             {
@@ -76,10 +76,10 @@ namespace AtomSampleViewer
             {
                 newPath = "";
             }
-            return newPath;
+            return Utils::ResolvePath(newPath);
         }
 
-        AZStd::string GetOfficialBaseline(const AZStd::string& forScreenshotFile)
+        AZStd::string GetOfficialBaseline(const AZStd::string& forScreenshotFile, const AZStd::string& envPath)
         {
             AZStd::string path = forScreenshotFile;
             const AZStd::string userPath = Utils::ResolvePath("@user@");
@@ -96,6 +96,10 @@ namespace AtomSampleViewer
                 return "";
             }
 
+            if (!AzFramework::StringFunc::Replace(path, envPath.c_str(), ""))
+            {
+                return "";
+            }
             // Turn it back into a full path
             path = Utils::ResolvePath("@projectroot@/" + path);
 
@@ -204,15 +208,18 @@ namespace AtomSampleViewer
         return !m_currentScriptIndexStack.empty();
     }
 
-    bool ScriptReporter::AddScreenshotTest(const AZStd::string& filePathWithoutSuffix, const AZStd::string& filePathWithSuffix)
+    ScriptReporter::ScreenshotTestInfo::ScreenshotTestInfo(const AZStd::string& screenshotFilePath, const AZStd::string& envPath)
+        : m_screenshotFilePath(Utils::ResolvePath(screenshotFilePath))
+    {
+        m_officialBaselineScreenshotFilePath = ScreenshotPaths::GetOfficialBaseline(m_screenshotFilePath, envPath);
+        m_localBaselineScreenshotFilePath = ScreenshotPaths::GetLocalBaseline(m_screenshotFilePath);
+    }
+
+    bool ScriptReporter::AddScreenshotTest(const AZStd::string& path, const AZStd::string& envPath)
     {
         AZ_Assert(GetCurrentScriptReport(), "There is no active script");
 
-        ScreenshotTestInfo screenshotTestInfo;
-        screenshotTestInfo.m_screenshotFilePathWithSuffix = filePathWithSuffix;
-        screenshotTestInfo.m_screenshotFilePathWithoutSuffix = filePathWithoutSuffix;
-        screenshotTestInfo.m_officialBaselineScreenshotFilePath = ScreenshotPaths::GetOfficialBaseline(filePathWithoutSuffix);
-        screenshotTestInfo.m_localBaselineScreenshotFilePath = ScreenshotPaths::GetLocalBaseline(filePathWithoutSuffix);
+        ScreenshotTestInfo screenshotTestInfo(path, envPath);
         GetCurrentScriptReport()->m_screenshotTests.push_back(AZStd::move(screenshotTestInfo));
 
         return true;
@@ -334,7 +341,7 @@ namespace AtomSampleViewer
         AzFramework::StringFunc::Path::StripExtension(scriptFilenameWithouExtension);
 
         AZStd::string screenshotFilenameWithouExtension;
-        AzFramework::StringFunc::Path::GetFileName(screenshotTest.m_screenshotFilePathWithSuffix.c_str(), screenshotFilenameWithouExtension);
+        AzFramework::StringFunc::Path::GetFileName(screenshotTest.m_screenshotFilePath.c_str(), screenshotFilenameWithouExtension);
         AzFramework::StringFunc::Path::StripExtension(screenshotFilenameWithouExtension);
 
         AZStd::string imageDiffFilename = "imageDiff_" + scriptFilenameWithouExtension + "_" + screenshotFilenameWithouExtension + "_" + m_uniqueTimestamp + ".png";
@@ -523,7 +530,7 @@ namespace AtomSampleViewer
                             const bool localBaselineWarning = screenshotResult.m_localComparisonResult.m_resultCode != ImageComparisonResult::ResultCode::Pass;
 
                             AZStd::string fileName;
-                            AzFramework::StringFunc::Path::GetFullFileName(screenshotResult.m_screenshotFilePathWithSuffix.c_str(), fileName);
+                            AzFramework::StringFunc::Path::GetFullFileName(screenshotResult.m_screenshotFilePath.c_str(), fileName);
 
                             std::stringstream headerSummary;
                             if (!screenshotPassed)
@@ -583,7 +590,7 @@ namespace AtomSampleViewer
                         const bool screenshotPassed = screenshotResult.m_officialComparisonResult.m_resultCode == ImageComparisonResult::ResultCode::Pass;
 
                         AZStd::string fileName;
-                        AzFramework::StringFunc::Path::GetFullFileName(screenshotResult.m_screenshotFilePathWithSuffix.c_str(), fileName);
+                        AzFramework::StringFunc::Path::GetFullFileName(screenshotResult.m_screenshotFilePath.c_str(), fileName);
 
                         AZStd::string header = AZStd::string::format("%f %s %s %s '%s'",
                             diffScore,
@@ -634,7 +641,7 @@ namespace AtomSampleViewer
         {
             ResetTextHighlight();
 
-            ImGui::Text("Screenshot:        %s", screenshotResult.m_screenshotFilePathWithSuffix.c_str());
+            ImGui::Text("Screenshot:        %s", screenshotResult.m_screenshotFilePath.c_str());
 
             ImGui::Spacing();
 
@@ -676,7 +683,7 @@ namespace AtomSampleViewer
                 ResetTextHighlight();
 
                 ImGui::PushID("Official");
-                ShowDiffButton("View Diff", screenshotResult.m_officialBaselineScreenshotFilePath, screenshotResult.m_screenshotFilePathWithSuffix);
+                ShowDiffButton("View Diff", screenshotResult.m_officialBaselineScreenshotFilePath, screenshotResult.m_screenshotFilePath);
                 ImGui::PopID();
 
                 if ((m_forceShowExportPngDiffButtons ||
@@ -727,7 +734,7 @@ namespace AtomSampleViewer
                 ResetTextHighlight();
 
                 ImGui::PushID("Local");
-                ShowDiffButton("View Diff", screenshotResult.m_localBaselineScreenshotFilePath, screenshotResult.m_screenshotFilePathWithSuffix);
+                ShowDiffButton("View Diff", screenshotResult.m_localBaselineScreenshotFilePath, screenshotResult.m_screenshotFilePath);
                 ImGui::PopID();
 
                 if ((localBaselineWarning || m_forceShowUpdateButtons) && ImGui::Button("Update##Local"))
@@ -1003,7 +1010,7 @@ namespace AtomSampleViewer
     
     bool ScriptReporter::UpdateLocalBaselineImage(ScreenshotTestInfo& screenshotTest, bool showResultDialog)
     {
-        const AZStd::string destinationFile = ScreenshotPaths::GetLocalBaseline(screenshotTest.m_screenshotFilePathWithoutSuffix);
+        const AZStd::string destinationFile = screenshotTest.m_localBaselineScreenshotFilePath;
 
         AZStd::string destinationFolder = destinationFile;
         AzFramework::StringFunc::Path::StripFullName(destinationFolder);
@@ -1016,10 +1023,10 @@ namespace AtomSampleViewer
             AZ_Error("ScriptReporter", false, "Failed to create folder '%s'.", destinationFolder.c_str());
         }
 
-        if (!AZ::IO::LocalFileIO::GetInstance()->Copy(screenshotTest.m_screenshotFilePathWithSuffix.c_str(), destinationFile.c_str()))
+        if (!AZ::IO::LocalFileIO::GetInstance()->Copy(screenshotTest.m_screenshotFilePath.c_str(), destinationFile.c_str()))
         {
             failed = true;
-            AZ_Error("ScriptReporter", false, "Failed to copy '%s' to '%s'.", screenshotTest.m_screenshotFilePathWithSuffix.c_str(), destinationFile.c_str());
+            AZ_Error("ScriptReporter", false, "Failed to copy '%s' to '%s'.", screenshotTest.m_screenshotFilePath.c_str(), destinationFile.c_str());
         }
 
         if (!failed)
@@ -1058,7 +1065,7 @@ namespace AtomSampleViewer
         }
 
         // Get official cache baseline file
-        const AZStd::string cacheFilePath = ScreenshotPaths::GetOfficialBaseline(screenshotTest.m_screenshotFilePathWithoutSuffix);
+        const AZStd::string cacheFilePath = screenshotTest.m_officialBaselineScreenshotFilePath;
 
         // Divide cache file path into components to we can access the file name and the parent folder
         AZStd::fixed_vector<AZ::IO::FixedMaxPathString, 16> reversePathComponents;
@@ -1084,10 +1091,10 @@ namespace AtomSampleViewer
         }
 
         // Replace source screenshot with new result
-        if (success && !io->Copy(screenshotTest.m_screenshotFilePathWithSuffix.c_str(), sourceFilePath.c_str()))
+        if (success && !io->Copy(screenshotTest.m_screenshotFilePath.c_str(), sourceFilePath.c_str()))
         {
             success = false;
-            AZ_Error("ScriptReporter", false, "Failed to copy '%s' to '%s'.", screenshotTest.m_screenshotFilePathWithSuffix.c_str(), sourceFilePath.c_str());
+            AZ_Error("ScriptReporter", false, "Failed to copy '%s' to '%s'.", screenshotTest.m_screenshotFilePath.c_str(), sourceFilePath.c_str());
         }
 
         if (success)
@@ -1165,7 +1172,7 @@ namespace AtomSampleViewer
 
         if (screenshotTestInfo.m_officialBaselineScreenshotFilePath.empty())
         {
-            ReportScriptError(AZStd::string::format("Screenshot check failed. Could not determine expected screenshot path for '%s'", screenshotTestInfo.m_screenshotFilePathWithSuffix.c_str()));
+            ReportScriptError(AZStd::string::format("Screenshot check failed. Could not determine expected screenshot path for '%s'", screenshotTestInfo.m_screenshotFilePath.c_str()));
             screenshotTestInfo.m_officialComparisonResult.m_resultCode = ImageComparisonResult::ResultCode::FileNotFound;
         }
         else
@@ -1173,7 +1180,7 @@ namespace AtomSampleViewer
             bool imagesWereCompared = DiffImages(
                 screenshotTestInfo.m_officialComparisonResult,
                 screenshotTestInfo.m_officialBaselineScreenshotFilePath,
-                screenshotTestInfo.m_screenshotFilePathWithSuffix,
+                screenshotTestInfo.m_screenshotFilePath,
                 TraceLevel::Error);
 
             if (imagesWereCompared)
@@ -1194,7 +1201,7 @@ namespace AtomSampleViewer
                         AZStd::string::format("Screenshot check failed. Diff score %f exceeds threshold of %f ('%s').",
                             screenshotTestInfo.m_officialComparisonResult.m_finalDiffScore, toleranceLevel->m_threshold, toleranceLevel->m_name.c_str()),
                         screenshotTestInfo.m_officialBaselineScreenshotFilePath,
-                        screenshotTestInfo.m_screenshotFilePathWithSuffix,
+                        screenshotTestInfo.m_screenshotFilePath,
                         TraceLevel::Error);
                     screenshotTestInfo.m_officialComparisonResult.m_resultCode = ImageComparisonResult::ResultCode::ThresholdExceeded;
                 }
@@ -1203,7 +1210,7 @@ namespace AtomSampleViewer
 
         if (screenshotTestInfo.m_localBaselineScreenshotFilePath.empty())
         {
-            ReportScriptWarning(AZStd::string::format("Screenshot check failed. Could not determine local baseline screenshot path for '%s'", screenshotTestInfo.m_screenshotFilePathWithSuffix.c_str()));
+            ReportScriptWarning(AZStd::string::format("Screenshot check failed. Could not determine local baseline screenshot path for '%s'", screenshotTestInfo.m_screenshotFilePath.c_str()));
             screenshotTestInfo.m_localComparisonResult.m_resultCode = ImageComparisonResult::ResultCode::FileNotFound;
         }
         else
@@ -1214,7 +1221,7 @@ namespace AtomSampleViewer
             bool imagesWereCompared = DiffImages(
                 screenshotTestInfo.m_localComparisonResult,
                 screenshotTestInfo.m_localBaselineScreenshotFilePath,
-                screenshotTestInfo.m_screenshotFilePathWithSuffix,
+                screenshotTestInfo.m_screenshotFilePath,
                 TraceLevel::Warning);
 
             if (imagesWereCompared)
@@ -1228,7 +1235,7 @@ namespace AtomSampleViewer
                     ReportScreenshotComparisonIssue(
                         AZStd::string::format("Screenshot check failed. Screenshot does not match the local baseline; something has changed. Diff score is %f.", screenshotTestInfo.m_localComparisonResult.m_standardDiffScore),
                         screenshotTestInfo.m_localBaselineScreenshotFilePath,
-                        screenshotTestInfo.m_screenshotFilePathWithSuffix,
+                        screenshotTestInfo.m_screenshotFilePath,
                         TraceLevel::Warning);
                     screenshotTestInfo.m_localComparisonResult.m_resultCode = ImageComparisonResult::ResultCode::ThresholdExceeded;
                 }
@@ -1261,7 +1268,7 @@ namespace AtomSampleViewer
 
                 for (const ScreenshotTestInfo& screenshotTest : scriptReport.m_screenshotTests)
                 {
-                    const AZStd::string screenshotPath = AZStd::string::format("Test screenshot path: %s \n", screenshotTest.m_screenshotFilePathWithSuffix.c_str());
+                    const AZStd::string screenshotPath = AZStd::string::format("Test screenshot path: %s \n", screenshotTest.m_screenshotFilePath.c_str());
                     const AZStd::string officialBaselineScreenshotPath = AZStd::string::format("Official baseline screenshot path: %s \n", screenshotTest.m_officialBaselineScreenshotFilePath.c_str());
                     const AZStd::string toleranceLevelLogLine = AZStd::string::format("Tolerance level: %s \n", screenshotTest.m_toleranceLevel.ToString().c_str());
                     const AZStd::string officialComparisonLogLine = AZStd::string::format("Image comparison result: %s \n", screenshotTest.m_officialComparisonResult.GetSummaryString().c_str());
@@ -1280,7 +1287,7 @@ namespace AtomSampleViewer
     {
         using namespace AZ::Utils;
         PngFile officialBaseline = PngFile::Load(screenshotTestInfo.m_officialBaselineScreenshotFilePath.c_str());
-        PngFile actualScreenshot = PngFile::Load(screenshotTestInfo.m_screenshotFilePathWithSuffix.c_str());
+        PngFile actualScreenshot = PngFile::Load(screenshotTestInfo.m_screenshotFilePath.c_str());
 
         const size_t bufferSize = officialBaseline.GetBuffer().size();
 

--- a/Gem/Code/Source/Automation/ScriptReporter.cpp
+++ b/Gem/Code/Source/Automation/ScriptReporter.cpp
@@ -204,12 +204,14 @@ namespace AtomSampleViewer
         return !m_currentScriptIndexStack.empty();
     }
 
-    bool ScriptReporter::AddScreenshotTest(const AZStd::string& path)
+    bool ScriptReporter::AddScreenshotTest(const AZStd::string& path, const AZStd::string& filePathWithSuffix)
     {
         AZ_Assert(GetCurrentScriptReport(), "There is no active script");
 
         ScreenshotTestInfo screenshotTestInfo;
-        screenshotTestInfo.m_screenshotFilePath = path;
+        screenshotTestInfo.m_screenshotFilePath = filePathWithSuffix;
+        screenshotTestInfo.m_officialBaselineScreenshotFilePath = ScreenshotPaths::GetOfficialBaseline(path);
+        screenshotTestInfo.m_localBaselineScreenshotFilePath = ScreenshotPaths::GetLocalBaseline(path);
         GetCurrentScriptReport()->m_screenshotTests.push_back(AZStd::move(screenshotTestInfo));
 
         return true;
@@ -1160,7 +1162,6 @@ namespace AtomSampleViewer
 
         screenshotTestInfo.m_toleranceLevel = *toleranceLevel;
 
-        screenshotTestInfo.m_officialBaselineScreenshotFilePath = ScreenshotPaths::GetOfficialBaseline(screenshotTestInfo.m_screenshotFilePath);
         if (screenshotTestInfo.m_officialBaselineScreenshotFilePath.empty())
         {
             ReportScriptError(AZStd::string::format("Screenshot check failed. Could not determine expected screenshot path for '%s'", screenshotTestInfo.m_screenshotFilePath.c_str()));
@@ -1199,7 +1200,6 @@ namespace AtomSampleViewer
             }
         }
 
-        screenshotTestInfo.m_localBaselineScreenshotFilePath = ScreenshotPaths::GetLocalBaseline(screenshotTestInfo.m_screenshotFilePath);
         if (screenshotTestInfo.m_localBaselineScreenshotFilePath.empty())
         {
             ReportScriptWarning(AZStd::string::format("Screenshot check failed. Could not determine local baseline screenshot path for '%s'", screenshotTestInfo.m_screenshotFilePath.c_str()));

--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -75,7 +75,7 @@ namespace AtomSampleViewer
         bool HasActiveScript() const;
 
         //! Indicates that a new screenshot is about to be captured.
-        bool AddScreenshotTest(const AZStd::string& path);
+        bool AddScreenshotTest(const AZStd::string& path, const AZStd::string& filePathWithSuffix);
 
         //! Check the latest screenshot using default thresholds.
         void CheckLatestScreenshot(const ImageComparisonToleranceLevel* comparisonPreset);

--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -38,7 +38,7 @@ namespace AtomSampleViewer
         AZStd::string GetLocalBaseline(const AZStd::string& forScreenshotFile);
 
         //! Returns the path to the official baseline image that corresponds to @forScreenshotFile
-        AZStd::string GetOfficialBaseline(const AZStd::string& forScreenshotFile);
+        AZStd::string GetOfficialBaseline(const AZStd::string& forScreenshotFile, const AZStd::string& envPath);
     }
 
     //! Collects data about each script run by the ScriptManager.
@@ -75,7 +75,7 @@ namespace AtomSampleViewer
         bool HasActiveScript() const;
 
         //! Indicates that a new screenshot is about to be captured.
-        bool AddScreenshotTest(const AZStd::string& filePathWithoutSuffix, const AZStd::string& filePathWithSuffix);
+        bool AddScreenshotTest(const AZStd::string& path, const AZStd::string& envPath);
 
         //! Check the latest screenshot using default thresholds.
         void CheckLatestScreenshot(const ImageComparisonToleranceLevel* comparisonPreset);
@@ -133,13 +133,14 @@ namespace AtomSampleViewer
         //! Records all the information about a screenshot comparison test.
         struct ScreenshotTestInfo
         {
-            AZStd::string m_screenshotFilePathWithSuffix;       //!< The file path is appended with additional info, such as GPU info, render API
-            AZStd::string m_screenshotFilePathWithoutSuffix;    //!< The file path without additional info
+            AZStd::string m_screenshotFilePath;
             AZStd::string m_officialBaselineScreenshotFilePath; //!< The path to the official baseline image that is checked into source control
             AZStd::string m_localBaselineScreenshotFilePath;    //!< The path to a local baseline image that was established by the user
             ImageComparisonToleranceLevel m_toleranceLevel;     //!< Tolerance for checking against the official baseline image
             ImageComparisonResult m_officialComparisonResult;   //!< Result of comparing against the official baseline image, for reporting test failure
             ImageComparisonResult m_localComparisonResult;      //!< Result of comparing against a local baseline, for reporting warnings
+
+            ScreenshotTestInfo(const AZStd::string& screenshotFilePath, const AZStd::string& envPath);
         };
 
         //! Records all the information about a single test script.

--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -75,7 +75,7 @@ namespace AtomSampleViewer
         bool HasActiveScript() const;
 
         //! Indicates that a new screenshot is about to be captured.
-        bool AddScreenshotTest(const AZStd::string& path, const AZStd::string& filePathWithSuffix);
+        bool AddScreenshotTest(const AZStd::string& filePathWithoutSuffix, const AZStd::string& filePathWithSuffix);
 
         //! Check the latest screenshot using default thresholds.
         void CheckLatestScreenshot(const ImageComparisonToleranceLevel* comparisonPreset);
@@ -133,7 +133,8 @@ namespace AtomSampleViewer
         //! Records all the information about a screenshot comparison test.
         struct ScreenshotTestInfo
         {
-            AZStd::string m_screenshotFilePath;
+            AZStd::string m_screenshotFilePathWithSuffix;       //!< The file path is appended with additional info, such as GPU info, render API
+            AZStd::string m_screenshotFilePathWithoutSuffix;    //!< The file path without additional info
             AZStd::string m_officialBaselineScreenshotFilePath; //!< The path to the official baseline image that is checked into source control
             AZStd::string m_localBaselineScreenshotFilePath;    //!< The path to a local baseline image that was established by the user
             ImageComparisonToleranceLevel m_toleranceLevel;     //!< Tolerance for checking against the official baseline image

--- a/Scripts/AreaLightTest.bv.lua
+++ b/Scripts/AreaLightTest.bv.lua
@@ -111,7 +111,7 @@ function VaryMetallicOnly()
     SetImguiValue('AreaLightSample/Min Max Metallic', Vector2(0.0, 1.0))
 end
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/AreaLights/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/AreaLights/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 SelectImageComparisonToleranceLevel("Level E")
 
@@ -154,7 +154,7 @@ do
         materialSetupFunction()
         
         IdleFrames(1) 
-        CaptureScreenshot(g_screenshotOutputFolder .. '/' .. lightName .. '_' .. materialName ..'.png', g_envSuffix)
+        CaptureScreenshot(g_screenshotOutputFolder .. '/' .. lightName .. '_' .. materialName ..'.png')
     end
 end
 

--- a/Scripts/AreaLightTest.bv.lua
+++ b/Scripts/AreaLightTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 function SetupPointLights()
     SetImguiValue('AreaLightSample/LightType/Point', true)
     SetImguiValue('AreaLightSample/Position Offset', Vector3(0.0, 0.0, 0.0))
@@ -152,7 +154,7 @@ do
         materialSetupFunction()
         
         IdleFrames(1) 
-        CaptureScreenshot(g_screenshotOutputFolder .. '/' .. lightName .. '_' .. materialName ..'.png')
+        CaptureScreenshot(g_screenshotOutputFolder .. '/' .. lightName .. '_' .. materialName ..'.png', g_envSuffix)
     end
 end
 

--- a/Scripts/AuxGeom.bv.lua
+++ b/Scripts/AuxGeom.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 function TakeScreenShotBoxes()
 
     NoClipCameraController_SetFov(DegToRad(70))
@@ -16,7 +18,7 @@ function TakeScreenShotBoxes()
     NoClipCameraController_SetPitch(DegToRad(20))
 
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_boxes.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_boxes.png', g_envSuffix)
 end
 
 function TakeScreenShotShapes()
@@ -26,7 +28,7 @@ function TakeScreenShotShapes()
     NoClipCameraController_SetPitch(DegToRad(30))
 
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_shapes.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_shapes.png', g_envSuffix)
 end
 
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/AuxGeom/')

--- a/Scripts/AuxGeom.bv.lua
+++ b/Scripts/AuxGeom.bv.lua
@@ -18,7 +18,7 @@ function TakeScreenShotBoxes()
     NoClipCameraController_SetPitch(DegToRad(20))
 
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_boxes.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_boxes.png')
 end
 
 function TakeScreenShotShapes()
@@ -28,10 +28,10 @@ function TakeScreenShotShapes()
     NoClipCameraController_SetPitch(DegToRad(30))
 
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_shapes.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/auxgeom_shapes.png')
 end
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/AuxGeom/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/AuxGeom/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/AuxGeom')

--- a/Scripts/CheckerboardTest.bv.lua
+++ b/Scripts/CheckerboardTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Checkerboard/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/Checkerboard/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/Checkerboard')
@@ -21,6 +21,6 @@ SelectImageComparisonToleranceLevel("Level F")
 
 IdleFrames(10) 
 
-CaptureScreenshot(g_screenshotOutputFolder .. 'frame1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. 'frame1.png')
 
 OpenSample(nil)

--- a/Scripts/CheckerboardTest.bv.lua
+++ b/Scripts/CheckerboardTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Checkerboard/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -19,6 +21,6 @@ SelectImageComparisonToleranceLevel("Level F")
 
 IdleFrames(10) 
 
-CaptureScreenshot(g_screenshotOutputFolder .. 'frame1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. 'frame1.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/CullingAndLod.bv.lua
+++ b/Scripts/CullingAndLod.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/CullingAndLod/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/CullingAndLod/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/CullingAndLod')
@@ -21,7 +21,7 @@ SelectImageComparisonToleranceLevel("Level G")
 
 SetImguiValue("Begin Verification", true)
 IdleFrames(5)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
 IdleFrames(1)
 SetImguiValue("End Verification", true)
 IdleFrames(1) -- make sure all outstanding imgui comamnds are processed before closing sample.

--- a/Scripts/CullingAndLod.bv.lua
+++ b/Scripts/CullingAndLod.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/CullingAndLod/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -19,7 +21,7 @@ SelectImageComparisonToleranceLevel("Level G")
 
 SetImguiValue("Begin Verification", true)
 IdleFrames(5)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 IdleFrames(1)
 SetImguiValue("End Verification", true)
 IdleFrames(1) -- make sure all outstanding imgui comamnds are processed before closing sample.

--- a/Scripts/Decals.bv.lua
+++ b/Scripts/Decals.bv.lua
@@ -9,8 +9,10 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 function TakeScreenshots()
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png', g_envSuffix)
 end
 
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Decals/')

--- a/Scripts/Decals.bv.lua
+++ b/Scripts/Decals.bv.lua
@@ -12,10 +12,10 @@
 RunScript("scripts/TestEnvironment.luac")
 
 function TakeScreenshots()
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png')
 end
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Decals/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/Decals/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/Decals')

--- a/Scripts/DepthOfFieldTest.bv.lua
+++ b/Scripts/DepthOfFieldTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DepthOfFieldTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/DepthOfFieldTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/DepthOfField')
@@ -20,6 +20,6 @@ SelectImageComparisonToleranceLevel("Level D")
 
 IdleSeconds(5)
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_depth_of_field.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_depth_of_field.png')
 
 OpenSample(nil)

--- a/Scripts/DepthOfFieldTest.bv.lua
+++ b/Scripts/DepthOfFieldTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DepthOfFieldTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -18,6 +20,6 @@ SelectImageComparisonToleranceLevel("Level D")
 
 IdleSeconds(5)
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_depth_of_field.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_depth_of_field.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/DiffuseGITest.bv.lua
+++ b/Scripts/DiffuseGITest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 if GetRenderApiName() == "vulkan" or GetRenderApiName() == "metal" then
     Warning("Vulkan or metal is not supported by this test.")
 else
@@ -21,7 +23,7 @@ else
 
     IdleSeconds(5)
 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_cornellbox.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_cornellbox.png', g_envSuffix)
 end
 
 OpenSample(nil)

--- a/Scripts/DiffuseGITest.bv.lua
+++ b/Scripts/DiffuseGITest.bv.lua
@@ -14,7 +14,7 @@ RunScript("scripts/TestEnvironment.luac")
 if GetRenderApiName() == "vulkan" or GetRenderApiName() == "metal" then
     Warning("Vulkan or metal is not supported by this test.")
 else
-    g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DiffuseGITest/')
+    g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/DiffuseGITest/')
     Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
     OpenSample('Features/DiffuseGI')
@@ -23,7 +23,7 @@ else
 
     IdleSeconds(5)
 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_cornellbox.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_cornellbox.png')
 end
 
 OpenSample(nil)

--- a/Scripts/DynamicDraw.bv.lua
+++ b/Scripts/DynamicDraw.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DynamicDraw/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -18,6 +20,6 @@ ResizeViewport(800, 500)
 -- Vulkan's line width is different than dx12's 
 SelectImageComparisonToleranceLevel("Level F") 
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/DynamicDraw.bv.lua
+++ b/Scripts/DynamicDraw.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DynamicDraw/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/DynamicDraw/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/DynamicDraw')
@@ -20,6 +20,6 @@ ResizeViewport(800, 500)
 -- Vulkan's line width is different than dx12's 
 SelectImageComparisonToleranceLevel("Level F") 
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
 
 OpenSample(nil)

--- a/Scripts/DynamicMaterialTest.bv.lua
+++ b/Scripts/DynamicMaterialTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DynamicMaterialTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -38,7 +40,7 @@ function TakeScreenshotSeries(filenamePrefix)
 
     SetImguiValue("Pause", true)
     IdleFrames(1) -- Give extra time to make sure any material changes are applied, especially in case an asset hot-load causes the material to reinitialize itself.
-    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_A.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_A.png', g_envSuffix)
     SetImguiValue("Pause", false)
 
     -- Let the animation run for 1 second
@@ -46,7 +48,7 @@ function TakeScreenshotSeries(filenamePrefix)
 
     SetImguiValue("Pause", true)
     IdleFrames(1) -- Give extra time to make sure any material changes are applied, especially in case an asset hot-load causes the material to reinitialize itself.
-    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_B.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_B.png', g_envSuffix)
     SetImguiValue("Pause", false)
 end
 

--- a/Scripts/DynamicMaterialTest.bv.lua
+++ b/Scripts/DynamicMaterialTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/DynamicMaterialTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/DynamicMaterialTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/DynamicMaterialTest')
@@ -40,7 +40,7 @@ function TakeScreenshotSeries(filenamePrefix)
 
     SetImguiValue("Pause", true)
     IdleFrames(1) -- Give extra time to make sure any material changes are applied, especially in case an asset hot-load causes the material to reinitialize itself.
-    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_A.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_A.png')
     SetImguiValue("Pause", false)
 
     -- Let the animation run for 1 second
@@ -48,7 +48,7 @@ function TakeScreenshotSeries(filenamePrefix)
 
     SetImguiValue("Pause", true)
     IdleFrames(1) -- Give extra time to make sure any material changes are applied, especially in case an asset hot-load causes the material to reinitialize itself.
-    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_B.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. filenamePrefix .. '_B.png')
     SetImguiValue("Pause", false)
 end
 

--- a/Scripts/ExposureTest.bv.lua
+++ b/Scripts/ExposureTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ExposureTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -19,6 +21,6 @@ SelectImageComparisonToleranceLevel("Level E")
 -- eye adaptation has a default speed. we are waiting 9 seconds for the sample to reach stable state
 IdleSeconds(9)
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_exposure.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_exposure.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/ExposureTest.bv.lua
+++ b/Scripts/ExposureTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ExposureTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/ExposureTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/Exposure')
@@ -21,6 +21,6 @@ SelectImageComparisonToleranceLevel("Level E")
 -- eye adaptation has a default speed. we are waiting 9 seconds for the sample to reach stable state
 IdleSeconds(9)
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_exposure.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_exposure.png')
 
 OpenSample(nil)

--- a/Scripts/EyeMaterialTest.bv.lua
+++ b/Scripts/EyeMaterialTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/EyeMaterial/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/EyeMaterial/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/EyeMaterial')
@@ -19,4 +19,4 @@ ResizeViewport(1600, 900)
 SelectImageComparisonToleranceLevel("Level F")
 
 -- Test with default values
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_eye.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_eye.png')

--- a/Scripts/EyeMaterialTest.bv.lua
+++ b/Scripts/EyeMaterialTest.bv.lua
@@ -1,3 +1,16 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/EyeMaterial/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -6,4 +19,4 @@ ResizeViewport(1600, 900)
 SelectImageComparisonToleranceLevel("Level F")
 
 -- Test with default values
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_eye.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_eye.png', g_envSuffix)

--- a/Scripts/LightCulling.bv.lua
+++ b/Scripts/LightCulling.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 function ResetEntityCounts()
     SetImguiValue('Point Lights/Point light count', 0)
     SetImguiValue('Decals/Decal count', 0)
@@ -31,7 +33,7 @@ function TakeScreenshotPointLights()
 
     IdleFrames(1) 
 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_pointlights.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_pointlights.png', g_envSuffix)
 end
 
 function TakeScreenshotDiskLights()
@@ -42,7 +44,7 @@ function TakeScreenshotDiskLights()
     SetImguiValue('Disk Lights/Disk light count', 200)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_disklights.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_disklights.png', g_envSuffix)
 end
 
 function TakeScreenshotCapsuleLights()
@@ -53,7 +55,7 @@ function TakeScreenshotCapsuleLights()
     SetImguiValue('Capsule Lights/Capsule light count', 200)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_capsulelights.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_capsulelights.png', g_envSuffix)
 end
 
 function TakeScreenshotQuadLights()
@@ -67,7 +69,7 @@ function TakeScreenshotQuadLights()
     SetImguiValue('Quad Lights/Quad light height', 5)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_quadlights.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_quadlights.png', g_envSuffix)
 end
 
 
@@ -79,7 +81,7 @@ function TakeScreenshotDecals()
     SetImguiValue('Decals/Decal count', 200)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png', g_envSuffix)
 end
 
 function TakeScreenShotLookingStraightDown()
@@ -94,7 +96,7 @@ function TakeScreenShotLookingStraightDown()
     SetImguiValue('Point Lights/Point Intensity', 200)
 
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_lookingdown.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_lookingdown.png', g_envSuffix)
 end
 
 function EnableOnlyTestHeatmap()

--- a/Scripts/LightCulling.bv.lua
+++ b/Scripts/LightCulling.bv.lua
@@ -33,7 +33,7 @@ function TakeScreenshotPointLights()
 
     IdleFrames(1) 
 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_pointlights.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_pointlights.png')
 end
 
 function TakeScreenshotDiskLights()
@@ -44,7 +44,7 @@ function TakeScreenshotDiskLights()
     SetImguiValue('Disk Lights/Disk light count', 200)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_disklights.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_disklights.png')
 end
 
 function TakeScreenshotCapsuleLights()
@@ -55,7 +55,7 @@ function TakeScreenshotCapsuleLights()
     SetImguiValue('Capsule Lights/Capsule light count', 200)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_capsulelights.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_capsulelights.png')
 end
 
 function TakeScreenshotQuadLights()
@@ -69,7 +69,7 @@ function TakeScreenshotQuadLights()
     SetImguiValue('Quad Lights/Quad light height', 5)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_quadlights.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_quadlights.png')
 end
 
 
@@ -81,7 +81,7 @@ function TakeScreenshotDecals()
     SetImguiValue('Decals/Decal count', 200)
     
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_decals.png')
 end
 
 function TakeScreenShotLookingStraightDown()
@@ -96,7 +96,7 @@ function TakeScreenShotLookingStraightDown()
     SetImguiValue('Point Lights/Point Intensity', 200)
 
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_lookingdown.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_lookingdown.png')
 end
 
 function EnableOnlyTestHeatmap()
@@ -105,7 +105,7 @@ function EnableOnlyTestHeatmap()
     SetImguiValue('Heatmap/Opacity', 1.0)
 end
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/LightCulling/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/LightCulling/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 SelectImageComparisonToleranceLevel("Level E")
 

--- a/Scripts/MSAA_RPI_Test.bv.lua
+++ b/Scripts/MSAA_RPI_Test.bv.lua
@@ -9,13 +9,15 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 function TakeScreenShot4xCylinder()
 
     SetImguiValue('Mode/MSAA 4x', true)
     SetImguiValue('Model/ShaderBall', true)
     ArcBallCameraController_SetDistance(4.0)
     IdleFrames(10) -- Need a few frames to let all Ibl mip levels load in 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_msaa4x_cylinder.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_msaa4x_cylinder.png', g_envSuffix)
 end
 
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MSAA_RPI/')

--- a/Scripts/MSAA_RPI_Test.bv.lua
+++ b/Scripts/MSAA_RPI_Test.bv.lua
@@ -17,10 +17,10 @@ function TakeScreenShot4xCylinder()
     SetImguiValue('Model/ShaderBall', true)
     ArcBallCameraController_SetDistance(4.0)
     IdleFrames(10) -- Need a few frames to let all Ibl mip levels load in 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_msaa4x_cylinder.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_msaa4x_cylinder.png')
 end
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MSAA_RPI/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/MSAA_RPI/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/MSAA')

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MaterialHotReloadTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/MaterialHotReloadTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 g_assetFolder = "materials/hotreloadtest/temp/";
@@ -59,31 +59,31 @@ function SetBlendingOff()
     IdleForReload()
 end
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/01_Default.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/01_Default.png')
 
 SetColorRed()
-CaptureScreenshot(g_screenshotOutputFolder .. '/02_Red.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/02_Red.png')
 
 AssetTracking_Start()
 SetImguiValue('ColorA = Blue', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/03_Blue.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/03_Blue.png')
 
 AssetTracking_Start()
 SetImguiValue('Default Colors', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/04_DefaultAgain.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/04_DefaultAgain.png')
 
 AssetTracking_Start()
 SetImguiValue('Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/05_WavyLines.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/05_WavyLines.png')
 
 AssetTracking_Start()
 SetImguiValue('Vertical Pattern', true)
@@ -91,10 +91,10 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png')
 
 SetBlendingOn()
-CaptureScreenshot(g_screenshotOutputFolder .. '/07_BlendingOn.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/07_BlendingOn.png')
 
 -- This will switch to showing the "Shader Variant: Fully Baked" message
 AssetTracking_Start()
@@ -102,7 +102,7 @@ SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png')
 
 -- This will switch to showing the "Shader Variant: Root" message
 AssetTracking_Start()
@@ -110,7 +110,7 @@ SetImguiValue('ShaderVariantList/Only Straight Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.png')
 
 -- This will switch to showing the "Shader Variant: Fully Baked" message again
 AssetTracking_Start()
@@ -118,7 +118,7 @@ SetImguiValue('ShaderVariantList/Only Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/10_Variants_OnlyWavyLines.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/10_Variants_OnlyWavyLines.png')
 
 -- This screenshot will be identical to the one above because the variants
 -- are still loaded in memory even though they have been removed from disk
@@ -126,14 +126,14 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/None', true)
 IdleSeconds(1.0) -- Idle for a bit to give time for the assets to disappear
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/11_Variants_None.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/11_Variants_None.png')
 
 -- Now, changing the .shader file will force the shader to reload and will not find
 -- any baked variants, since we switched to "None" above, and so this screenshot will 
 -- switch back to showing the "Shader Variant: Root" message.
 SetBlendingOff()
 --[GFX TODO] This test is consistently failing due to an Asset Processor bug. Re-enable this test once that is fixed.
---CaptureScreenshot(g_screenshotOutputFolder .. '/12_Variants_None_AfterUpdatingShader.png', g_envSuffix)
+--CaptureScreenshot(g_screenshotOutputFolder .. '/12_Variants_None_AfterUpdatingShader.png')
 
 -- Here we prepare to test a specific edge case. First, the material should be using a full baked shader variant, so we set up that precondition and verify with a screenshot.
 AssetTracking_Start()
@@ -142,7 +142,7 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3)
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(3.0)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png')
 -- Now that the material is using a fully-baked variant, modify the .azsl file to force *everything* to rebuild. In the failure case, the runtime
 -- holds onto the old fully-baked variant even though a new root variant is available. In the correct case, the root variant should take priority
 -- over the fully-baked variant because it is more recent.
@@ -154,7 +154,7 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3)
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(4.0)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png')
 
 -- Test a specific scenario that was failing, where color changes fail to reload after making a shader change.
 SetBlendingOn()
@@ -163,7 +163,7 @@ SetBlendingOff()
 IdleForReload()
 SetColorRed()
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/15_Red_AfterShaderReload.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/15_Red_AfterShaderReload.png')
 
 -- Clear the service loop override back to the default delay
 ExecuteConsoleCommand("r_ShaderVariantAsyncLoader_ServiceLoopDelayOverride_ms 0")

--- a/Scripts/MaterialHotReloadTest.bv.lua
+++ b/Scripts/MaterialHotReloadTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MaterialHotReloadTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -57,31 +59,31 @@ function SetBlendingOff()
     IdleForReload()
 end
 
-CaptureScreenshot(g_screenshotOutputFolder .. '/01_Default.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/01_Default.png', g_envSuffix)
 
 SetColorRed()
-CaptureScreenshot(g_screenshotOutputFolder .. '/02_Red.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/02_Red.png', g_envSuffix)
 
 AssetTracking_Start()
 SetImguiValue('ColorA = Blue', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/03_Blue.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/03_Blue.png', g_envSuffix)
 
 AssetTracking_Start()
 SetImguiValue('Default Colors', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.material")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/04_DefaultAgain.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/04_DefaultAgain.png', g_envSuffix)
 
 AssetTracking_Start()
 SetImguiValue('Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/05_WavyLines.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/05_WavyLines.png', g_envSuffix)
 
 AssetTracking_Start()
 SetImguiValue('Vertical Pattern', true)
@@ -89,10 +91,10 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.materialtype")
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shader")
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/06_VerticalPattern.png', g_envSuffix)
 
 SetBlendingOn()
-CaptureScreenshot(g_screenshotOutputFolder .. '/07_BlendingOn.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/07_BlendingOn.png', g_envSuffix)
 
 -- This will switch to showing the "Shader Variant: Fully Baked" message
 AssetTracking_Start()
@@ -100,7 +102,7 @@ SetImguiValue('ShaderVariantList/All', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3) -- Waiting for 3 products, the list asset and two variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/08_Variants_All.png', g_envSuffix)
 
 -- This will switch to showing the "Shader Variant: Root" message
 AssetTracking_Start()
@@ -108,7 +110,7 @@ SetImguiValue('ShaderVariantList/Only Straight Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/09_Variants_OnlyStraightLines.png', g_envSuffix)
 
 -- This will switch to showing the "Shader Variant: Fully Baked" message again
 AssetTracking_Start()
@@ -116,7 +118,7 @@ SetImguiValue('ShaderVariantList/Only Wavy Lines', true)
 AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 2) -- Waiting for 2 products, the list asset and one variant assets
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/10_Variants_OnlyWavyLines.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/10_Variants_OnlyWavyLines.png', g_envSuffix)
 
 -- This screenshot will be identical to the one above because the variants
 -- are still loaded in memory even though they have been removed from disk
@@ -124,14 +126,14 @@ AssetTracking_Start()
 SetImguiValue('ShaderVariantList/None', true)
 IdleSeconds(1.0) -- Idle for a bit to give time for the assets to disappear
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/11_Variants_None.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/11_Variants_None.png', g_envSuffix)
 
 -- Now, changing the .shader file will force the shader to reload and will not find
 -- any baked variants, since we switched to "None" above, and so this screenshot will 
 -- switch back to showing the "Shader Variant: Root" message.
 SetBlendingOff()
 --[GFX TODO] This test is consistently failing due to an Asset Processor bug. Re-enable this test once that is fixed.
---CaptureScreenshot(g_screenshotOutputFolder .. '/12_Variants_None_AfterUpdatingShader.png')
+--CaptureScreenshot(g_screenshotOutputFolder .. '/12_Variants_None_AfterUpdatingShader.png', g_envSuffix)
 
 -- Here we prepare to test a specific edge case. First, the material should be using a full baked shader variant, so we set up that precondition and verify with a screenshot.
 AssetTracking_Start()
@@ -140,7 +142,7 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3)
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(3.0)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/13_Variants_All.png', g_envSuffix)
 -- Now that the material is using a fully-baked variant, modify the .azsl file to force *everything* to rebuild. In the failure case, the runtime
 -- holds onto the old fully-baked variant even though a new root variant is available. In the correct case, the root variant should take priority
 -- over the fully-baked variant because it is more recent.
@@ -152,7 +154,7 @@ AssetTracking_ExpectAsset(g_assetFolder .. "HotReloadTest.shadervariantlist", 3)
 AssetTracking_IdleUntilExpectedAssetsFinish(10)
 IdleSeconds(4.0)
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/14_HorizontalPattern.png', g_envSuffix)
 
 -- Test a specific scenario that was failing, where color changes fail to reload after making a shader change.
 SetBlendingOn()
@@ -161,7 +163,7 @@ SetBlendingOff()
 IdleForReload()
 SetColorRed()
 IdleForReload()
-CaptureScreenshot(g_screenshotOutputFolder .. '/15_Red_AfterShaderReload.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/15_Red_AfterShaderReload.png', g_envSuffix)
 
 -- Clear the service loop override back to the default delay
 ExecuteConsoleCommand("r_ShaderVariantAsyncLoader_ServiceLoopDelayOverride_ms 0")

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -9,6 +9,7 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
 
 g_shaderballModel = 'materialeditor/viewportmodels/shaderball.azmodel'
 g_cubeModel = 'materialeditor/viewportmodels/cube.azmodel'
@@ -77,7 +78,7 @@ function GenerateMaterialScreenshot(imageComparisonThresholdLevel, materialName,
     end
     
     SelectImageComparisonToleranceLevel(imageComparisonThresholdLevel)
-    CaptureScreenshot(filename)
+    CaptureScreenshot(filename, g_envSuffix)
 end
 
 OpenSample('RPI/Mesh')

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -78,7 +78,7 @@ function GenerateMaterialScreenshot(imageComparisonThresholdLevel, materialName,
     end
     
     SelectImageComparisonToleranceLevel(imageComparisonThresholdLevel)
-    CaptureScreenshot(filename, g_envSuffix)
+    CaptureScreenshot(filename)
 end
 
 OpenSample('RPI/Mesh')
@@ -93,7 +93,7 @@ SetImguiValue('Show Ground Plane', false)
 -- StandardPBR Materials...
 
 g_testMaterialsFolder = 'testdata/materials/standardpbrtestcases/'
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/StandardPBR/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/StandardPBR/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 GenerateMaterialScreenshot('Level C', '001_DefaultWhite')
@@ -162,7 +162,7 @@ GenerateMaterialScreenshot('Level H', '105_DetailMaps_BlendMaskUsingDetailUVs', 
 -- StandardMultilayerPBR Materials...
 
 g_testMaterialsFolder = 'testdata/materials/standardmultilayerpbrtestcases/'
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/StandardMultilayerPBR/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/StandardMultilayerPBR/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 GenerateMaterialScreenshot('Level I', '001_ManyFeatures', {model=g_cubeModel, cameraHeading=-125.0, cameraPitch=-16.0, cameraZ=0.12})
@@ -186,7 +186,7 @@ GenerateMaterialScreenshot('Level I', '005_UseDisplacement_With_BlendMaskTexture
 -- Skin Materials...
 
 g_testMaterialsFolder = 'testdata/materials/skintestcases/'
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Skin/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/Skin/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 -- We should eventually replace this with realistic skin test cases, these are just placeholders for regression testing
@@ -197,7 +197,7 @@ GenerateMaterialScreenshot('Level G', '002_wrinkle_regression_test', {model=g_mo
 -- MinimalPBR Materials...
 
 g_testMaterialsFolder = 'materials/minimalpbr/'
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MinimalPBR/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/MinimalPBR/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 GenerateMaterialScreenshot('Level B', 'MinimalPbr_Default')
@@ -209,7 +209,7 @@ GenerateMaterialScreenshot('Level D', 'MinimalPbr_RedDielectric')
 -- This test is here only temporarily for regression testing until StandardMultilayerPBR is refactored to use reused nested property groups.
 
 g_testMaterialsFolder = 'materials/types/'
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MinimalPBR/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/MinimalPBR/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 GenerateMaterialScreenshot('Level G', 'MinimalMultilayerExample')
@@ -217,7 +217,7 @@ GenerateMaterialScreenshot('Level G', 'MinimalMultilayerExample')
 ----------------------------------------------------------------------
 -- AutoBrick Materials...
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/AutoBrick/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/AutoBrick/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 g_testMaterialsFolder = 'testdata/materials/autobrick/'

--- a/Scripts/MultiRenderPipeline.bv.lua
+++ b/Scripts/MultiRenderPipeline.bv.lua
@@ -9,18 +9,20 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MultiRenderPipeline/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 function TakeScreenShotForWindow1(fileName)
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. fileName)
+    CaptureScreenshot(g_screenshotOutputFolder .. fileName, g_envSuffix)
 end
 
 function TakeScreenShotForWindow2(fileName)
     IdleFrames(1) 
     SetShowImGui(false)
-    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName)
+    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName, g_envSuffix)
     SetShowImGui(true)
 end
 

--- a/Scripts/MultiRenderPipeline.bv.lua
+++ b/Scripts/MultiRenderPipeline.bv.lua
@@ -11,18 +11,18 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MultiRenderPipeline/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/MultiRenderPipeline/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 function TakeScreenShotForWindow1(fileName)
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. fileName, g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. fileName)
 end
 
 function TakeScreenShotForWindow2(fileName)
     IdleFrames(1) 
     SetShowImGui(false)
-    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName, g_envSuffix)
+    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName)
     SetShowImGui(true)
 end
 

--- a/Scripts/MultiScene.bv.lua
+++ b/Scripts/MultiScene.bv.lua
@@ -9,17 +9,19 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MultiScene/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 function TakeScreenShotFromPrimaryWindow(fileName)
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. fileName)
+    CaptureScreenshot(g_screenshotOutputFolder .. fileName, g_envSuffix)
 end
 
 function TakeScreenShotFromSecondaryWindow(fileName)
     IdleFrames(1) 
-    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName)
+    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName, g_envSuffix)
 end
 
 function WaitForDepthOfFieldFocus()

--- a/Scripts/MultiScene.bv.lua
+++ b/Scripts/MultiScene.bv.lua
@@ -11,17 +11,17 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/MultiScene/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/MultiScene/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 function TakeScreenShotFromPrimaryWindow(fileName)
     IdleFrames(1) 
-    CaptureScreenshot(g_screenshotOutputFolder .. fileName, g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. fileName)
 end
 
 function TakeScreenShotFromSecondaryWindow(fileName)
     IdleFrames(1) 
-    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName, g_envSuffix)
+    CapturePassAttachment({"SecondPipeline", "CopyToSwapChain"}, "Output", g_screenshotOutputFolder .. fileName)
 end
 
 function WaitForDepthOfFieldFocus()

--- a/Scripts/ParallaxDepthArtifacts.bv.lua
+++ b/Scripts/ParallaxDepthArtifacts.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ParallaxDepthArtifacts/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -35,31 +37,31 @@ ArcBallCameraController_SetDistance(3.000000)
 ArcBallCameraController_SetHeading(DegToRad(-38.356312))
 ArcBallCameraController_SetPitch(DegToRad(-2.705635))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 
 ArcBallCameraController_SetHeading(DegToRad(-66.861877))
 ArcBallCameraController_SetPitch(DegToRad(-4.933800))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
 
 ArcBallCameraController_SetHeading(DegToRad(30.230936))
 ArcBallCameraController_SetPitch(DegToRad(-3.819724))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png', g_envSuffix)
 
 ArcBallCameraController_SetHeading(DegToRad(-140.709763))
 ArcBallCameraController_SetPitch(DegToRad(-3.501410))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png', g_envSuffix)
 
 ArcBallCameraController_SetHeading(DegToRad(135.264740))
 ArcBallCameraController_SetPitch(DegToRad(-2.387333))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png', g_envSuffix)
 
 ArcBallCameraController_SetHeading(DegToRad(20.355005))
 ArcBallCameraController_SetPitch(DegToRad(-4.456343))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/ParallaxDepthArtifacts.bv.lua
+++ b/Scripts/ParallaxDepthArtifacts.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ParallaxDepthArtifacts/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/ParallaxDepthArtifacts/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/Parallax')
@@ -37,31 +37,31 @@ ArcBallCameraController_SetDistance(3.000000)
 ArcBallCameraController_SetHeading(DegToRad(-38.356312))
 ArcBallCameraController_SetPitch(DegToRad(-2.705635))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
 
 ArcBallCameraController_SetHeading(DegToRad(-66.861877))
 ArcBallCameraController_SetPitch(DegToRad(-4.933800))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png')
 
 ArcBallCameraController_SetHeading(DegToRad(30.230936))
 ArcBallCameraController_SetPitch(DegToRad(-3.819724))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png')
 
 ArcBallCameraController_SetHeading(DegToRad(-140.709763))
 ArcBallCameraController_SetPitch(DegToRad(-3.501410))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png')
 
 ArcBallCameraController_SetHeading(DegToRad(135.264740))
 ArcBallCameraController_SetPitch(DegToRad(-2.387333))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png')
 
 ArcBallCameraController_SetHeading(DegToRad(20.355005))
 ArcBallCameraController_SetPitch(DegToRad(-4.456343))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png')
 
 OpenSample(nil)

--- a/Scripts/ParallaxTest.bv.lua
+++ b/Scripts/ParallaxTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ParallaxTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/ParallaxTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/Parallax')
@@ -24,7 +24,7 @@ SetImguiValue('Lighting/Direction', DegToRad(110))
 SetImguiValue('Parallax Setting/Heightmap Scale', 0.05)
 SetImguiValue('Parallax Setting/Enable Pdo', false)
 IdleFrames(2)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
 
 -- Test alternate UV streams...
 -- Purpose of 2 shots
@@ -34,15 +34,15 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 -- the expected image of the second test is copied from screenshot_1.png
 SetImguiValue('Parallax Setting/UV', "UV1")
 IdleFrames(2)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_1.png', g_envSuffix)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_2.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_2.png')
 SetImguiValue('Parallax Setting/UV', "UV0")
 
 -- Test with PDO on, also Plane rotated...
 SetImguiValue('Parallax Setting/Enable Pdo', true)
 SetImguiValue('Plane Setting/Rotation', DegToRad(45))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png')
 
 -- Algorithm "Relief", also Directional Light at 120 degrees and uv parameters changed
 ArcBallCameraController_SetHeading(DegToRad(120))
@@ -56,7 +56,7 @@ SetImguiValue('Plane Setting/Offset V', 0.6)
 SetImguiValue('Plane Setting/Rotation UV', 275)
 SetImguiValue('Plane Setting/Scale UV', 0.6)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png')
 
 -- Algorithm Contact Refinement, also Directional Light at 240 degrees with uv parameters changed again 
 ArcBallCameraController_SetHeading(DegToRad(240))
@@ -70,7 +70,7 @@ SetImguiValue('Plane Setting/Offset V', -0.6)
 SetImguiValue('Plane Setting/Rotation UV', 138)
 SetImguiValue('Plane Setting/Scale UV', 1.6)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png')
 
 -- Algorithm "POM", switch to Spot Light 0 degree, also Plate rotated again 
 ArcBallCameraController_SetHeading(DegToRad(0))
@@ -78,7 +78,7 @@ SetImguiValue('Lighting/Spot Light', true)
 SetImguiValue('Parallax Setting/Algorithm', "POM")
 SetImguiValue('Plane Setting/Rotation', DegToRad(135))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png')
 
 -- Algorithm "Relief", also Spot Light rotated with uv parameters changed again
 ArcBallCameraController_SetHeading(DegToRad(120))
@@ -92,7 +92,7 @@ SetImguiValue('Plane Setting/Offset V', 0.2)
 SetImguiValue('Plane Setting/Rotation UV', 125)
 SetImguiValue('Plane Setting/Scale UV', 0.3)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png')
 
 -- Algorithm "Contact Refinement" Spot Light rotated again, with uv parameter changed again
 ArcBallCameraController_SetHeading(DegToRad(240))
@@ -106,7 +106,7 @@ SetImguiValue('Plane Setting/Offset V', -0.3)
 SetImguiValue('Plane Setting/Rotation UV', 74)
 SetImguiValue('Plane Setting/Scale UV', 1.3)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_7.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_7.png')
 
 -- Test offset
 ArcBallCameraController_SetHeading(DegToRad(-135))
@@ -116,21 +116,21 @@ SetImguiValue('Lighting/Direction', DegToRad(350))
 SetImguiValue('Parallax Setting/Heightmap Scale', 0.1)
 SetImguiValue('Parallax Setting/Offset', -0.1)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_8_offset.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_8_offset.png')
 
 -- Test offset clipping
 ArcBallCameraController_SetPitch(DegToRad(-15)) -- Use a harsh angle as that could reveal artifacts we've seen in the past and fixed.
 SetImguiValue('Parallax Setting/Offset', 0.05)
 SetImguiValue('Parallax Setting/Show Clipping', true)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_9_offsetClipping.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_9_offsetClipping.png')
 
 -- Testing a specific case where offset clamping was not calculated correctly, and clamped a bit below the surface instead of right on the surface.
 SetImguiValue('Parallax Setting/Offset', 0.06)
 SetImguiValue('Parallax Setting/Heightmap Scale', 0.1)
 SetImguiValue('Parallax Setting/Algorithm', "Steep")
 SetImguiValue('Parallax Setting/Show Clipping', true)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_10_offsetClippingSteep.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_10_offsetClippingSteep.png')
 
 -- Test some different combinations that might result in divide-by-0 related crashes (which did happen at one point)
 SetImguiValue('Parallax Setting/Offset', 0.0)
@@ -154,6 +154,6 @@ ArcBallCameraController_SetHeading(1.95481825)
 ArcBallCameraController_SetPitch(-0.169443831)
 ArcBallCameraController_SetDistance(6.000000)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_11_problematicAngle.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_11_problematicAngle.png')
 
 OpenSample(nil)

--- a/Scripts/ParallaxTest.bv.lua
+++ b/Scripts/ParallaxTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ParallaxTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -22,7 +24,7 @@ SetImguiValue('Lighting/Direction', DegToRad(110))
 SetImguiValue('Parallax Setting/Heightmap Scale', 0.05)
 SetImguiValue('Parallax Setting/Enable Pdo', false)
 IdleFrames(2)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 
 -- Test alternate UV streams...
 -- Purpose of 2 shots
@@ -32,15 +34,15 @@ CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
 -- the expected image of the second test is copied from screenshot_1.png
 SetImguiValue('Parallax Setting/UV', "UV1")
 IdleFrames(2)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_1.png')
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_2.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2ndUv_2.png', g_envSuffix)
 SetImguiValue('Parallax Setting/UV', "UV0")
 
 -- Test with PDO on, also Plane rotated...
 SetImguiValue('Parallax Setting/Enable Pdo', true)
 SetImguiValue('Plane Setting/Rotation', DegToRad(45))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
 
 -- Algorithm "Relief", also Directional Light at 120 degrees and uv parameters changed
 ArcBallCameraController_SetHeading(DegToRad(120))
@@ -54,7 +56,7 @@ SetImguiValue('Plane Setting/Offset V', 0.6)
 SetImguiValue('Plane Setting/Rotation UV', 275)
 SetImguiValue('Plane Setting/Scale UV', 0.6)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_3.png', g_envSuffix)
 
 -- Algorithm Contact Refinement, also Directional Light at 240 degrees with uv parameters changed again 
 ArcBallCameraController_SetHeading(DegToRad(240))
@@ -68,7 +70,7 @@ SetImguiValue('Plane Setting/Offset V', -0.6)
 SetImguiValue('Plane Setting/Rotation UV', 138)
 SetImguiValue('Plane Setting/Scale UV', 1.6)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_4.png', g_envSuffix)
 
 -- Algorithm "POM", switch to Spot Light 0 degree, also Plate rotated again 
 ArcBallCameraController_SetHeading(DegToRad(0))
@@ -76,7 +78,7 @@ SetImguiValue('Lighting/Spot Light', true)
 SetImguiValue('Parallax Setting/Algorithm', "POM")
 SetImguiValue('Plane Setting/Rotation', DegToRad(135))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_5.png', g_envSuffix)
 
 -- Algorithm "Relief", also Spot Light rotated with uv parameters changed again
 ArcBallCameraController_SetHeading(DegToRad(120))
@@ -90,7 +92,7 @@ SetImguiValue('Plane Setting/Offset V', 0.2)
 SetImguiValue('Plane Setting/Rotation UV', 125)
 SetImguiValue('Plane Setting/Scale UV', 0.3)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_6.png', g_envSuffix)
 
 -- Algorithm "Contact Refinement" Spot Light rotated again, with uv parameter changed again
 ArcBallCameraController_SetHeading(DegToRad(240))
@@ -104,7 +106,7 @@ SetImguiValue('Plane Setting/Offset V', -0.3)
 SetImguiValue('Plane Setting/Rotation UV', 74)
 SetImguiValue('Plane Setting/Scale UV', 1.3)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_7.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_7.png', g_envSuffix)
 
 -- Test offset
 ArcBallCameraController_SetHeading(DegToRad(-135))
@@ -114,21 +116,21 @@ SetImguiValue('Lighting/Direction', DegToRad(350))
 SetImguiValue('Parallax Setting/Heightmap Scale', 0.1)
 SetImguiValue('Parallax Setting/Offset', -0.1)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_8_offset.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_8_offset.png', g_envSuffix)
 
 -- Test offset clipping
 ArcBallCameraController_SetPitch(DegToRad(-15)) -- Use a harsh angle as that could reveal artifacts we've seen in the past and fixed.
 SetImguiValue('Parallax Setting/Offset', 0.05)
 SetImguiValue('Parallax Setting/Show Clipping', true)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_9_offsetClipping.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_9_offsetClipping.png', g_envSuffix)
 
 -- Testing a specific case where offset clamping was not calculated correctly, and clamped a bit below the surface instead of right on the surface.
 SetImguiValue('Parallax Setting/Offset', 0.06)
 SetImguiValue('Parallax Setting/Heightmap Scale', 0.1)
 SetImguiValue('Parallax Setting/Algorithm', "Steep")
 SetImguiValue('Parallax Setting/Show Clipping', true)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_10_offsetClippingSteep.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_10_offsetClippingSteep.png', g_envSuffix)
 
 -- Test some different combinations that might result in divide-by-0 related crashes (which did happen at one point)
 SetImguiValue('Parallax Setting/Offset', 0.0)
@@ -152,6 +154,6 @@ ArcBallCameraController_SetHeading(1.95481825)
 ArcBallCameraController_SetPitch(-0.169443831)
 ArcBallCameraController_SetDistance(6.000000)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_11_problematicAngle.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_11_problematicAngle.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/PassTree.bv.lua
+++ b/Scripts/PassTree.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/PassTree/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/PassTree/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 -- Select an attachment; take a screenshot with preview output (used for screenshot comparison); capture and save the attachment.
@@ -19,7 +19,7 @@ Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 function TestAttachment(attachmentName, screenshotFileName)
     SetImguiValue(attachmentName, true)
     IdleFrames(2)
-    CaptureScreenshotWithPreview(g_screenshotOutputFolder .. screenshotFileName, g_envSuffix)
+    CaptureScreenshotWithPreview(g_screenshotOutputFolder .. screenshotFileName)
     IdleFrames(1)
     SetImguiValue('Save Attachment', true)
     IdleFrames(3)

--- a/Scripts/PassTree.bv.lua
+++ b/Scripts/PassTree.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/PassTree/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -17,7 +19,7 @@ Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 function TestAttachment(attachmentName, screenshotFileName)
     SetImguiValue(attachmentName, true)
     IdleFrames(2)
-    CaptureScreenshotWithPreview(g_screenshotOutputFolder .. screenshotFileName)
+    CaptureScreenshotWithPreview(g_screenshotOutputFolder .. screenshotFileName, g_envSuffix)
     IdleFrames(1)
     SetImguiValue('Save Attachment', true)
     IdleFrames(3)

--- a/Scripts/ReadbackTest.bv.lua
+++ b/Scripts/ReadbackTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Readback')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/Readback')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/Readback')
@@ -26,7 +26,7 @@ SetImguiValue('Height', 512)
 IdleFrames(1)
 SetImguiValue('Readback', true)
 IdleFrames(5)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
 IdleFrames(1)
 
 -- Then at 1024x1024
@@ -36,7 +36,7 @@ SetImguiValue('Height', 1024)
 IdleFrames(1)
 SetImguiValue('Readback', true)
 IdleFrames(5)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png')
 IdleFrames(1)
 
 

--- a/Scripts/ReadbackTest.bv.lua
+++ b/Scripts/ReadbackTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Readback')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -24,7 +26,7 @@ SetImguiValue('Height', 512)
 IdleFrames(1)
 SetImguiValue('Readback', true)
 IdleFrames(5)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 IdleFrames(1)
 
 -- Then at 1024x1024
@@ -34,7 +36,7 @@ SetImguiValue('Height', 1024)
 IdleFrames(1)
 SetImguiValue('Readback', true)
 IdleFrames(5)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
 IdleFrames(1)
 
 

--- a/Scripts/RenderTargetTexture.bv.lua
+++ b/Scripts/RenderTargetTexture.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/RenderTargetTexture/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -28,11 +30,11 @@ SetShowImGui(false)
 SetImguiValue('Show Preview', true)
 SetImguiValue('Next Frame', true)
 IdleFrames(1) 
-CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_1.png')
+CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
 
 SetImguiValue('Next Frame', true)
 IdleFrames(2) 
-CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_2.png')
+CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
 
 SetShowImGui(false)
 

--- a/Scripts/RenderTargetTexture.bv.lua
+++ b/Scripts/RenderTargetTexture.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/RenderTargetTexture/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/RenderTargetTexture/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/RenderTargetTexture')
@@ -30,11 +30,11 @@ SetShowImGui(false)
 SetImguiValue('Show Preview', true)
 SetImguiValue('Next Frame', true)
 IdleFrames(1) 
-CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_1.png', g_envSuffix)
+CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_1.png')
 
 SetImguiValue('Next Frame', true)
 IdleFrames(2) 
-CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_2.png', g_envSuffix)
+CaptureScreenshotWithPreview(g_screenshotOutputFolder .. '/screenshot_2.png')
 
 SetShowImGui(false)
 

--- a/Scripts/SceneReloadSoakTest.bv.lua
+++ b/Scripts/SceneReloadSoakTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/SceneReloadSoakTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/SceneReloadSoakTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 -- First we capture a screenshot to make sure everything is rendering correctly...
@@ -21,7 +21,7 @@ ResizeViewport(500, 500)
 NoClipCameraController_SetFov(DegToRad(90))
 IdleSeconds(1.0)
 SelectImageComparisonToleranceLevel("Level G")
-CaptureScreenshot(g_screenshotOutputFolder .. 'screenshot.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. 'screenshot.png')
 
 -- Unlock the frame time now that we have our screen capture, so the actual "soaking" can happen at a natural rate
 UnlockFrameTime()

--- a/Scripts/SceneReloadSoakTest.bv.lua
+++ b/Scripts/SceneReloadSoakTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/SceneReloadSoakTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -19,7 +21,7 @@ ResizeViewport(500, 500)
 NoClipCameraController_SetFov(DegToRad(90))
 IdleSeconds(1.0)
 SelectImageComparisonToleranceLevel("Level G")
-CaptureScreenshot(g_screenshotOutputFolder .. 'screenshot.png')
+CaptureScreenshot(g_screenshotOutputFolder .. 'screenshot.png', g_envSuffix)
 
 -- Unlock the frame time now that we have our screen capture, so the actual "soaking" can happen at a natural rate
 UnlockFrameTime()

--- a/Scripts/ShaderReloadSoakTest.bv.lua
+++ b/Scripts/ShaderReloadSoakTest.bv.lua
@@ -12,6 +12,8 @@
 -- WARNING: This is a soak test, do not add this test to the fully automated
 -- test suites.
 
+RunScript("scripts/TestEnvironment.luac")
+
 OpenSample('RPI/ShaderReloadTest')
 ResizeViewport(500, 500)
 

--- a/Scripts/ShadowTest.bv.lua
+++ b/Scripts/ShadowTest.bv.lua
@@ -47,7 +47,7 @@ function TestDirectionalLight()
     SetImguiValue('Size##Directional', '2048')
     SetImguiValue('4', true) -- cascade count
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_initial.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_initial.png')
 
     -- Directional Light Manual Cascade Split
     SetImguiValue('Debug Coloring', true)
@@ -59,25 +59,25 @@ function TestDirectionalLight()
     IdleFrames(1)
     SetImguiValue('FarDepth 2', 6.0)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_manual_cascade.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_manual_cascade.png')
 
     -- Directional Light Automatic Cascade Split
     SetImguiValue('Automatic Cascade Split', true)
     IdleFrames(1)
     SetImguiValue('Ratio', 0.25)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_auto_cascade.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_auto_cascade.png')
 
     -- Directional Light Cascade Position Correction
     SetImguiValue('Cascade Position Correction', true)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_cascade_correction.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_cascade_correction.png')
     SetImguiValue('Cascade Position Correction', false)
 
     -- Directional Light Cascade Position Correction
     SetImguiValue('Use Fullscreen Blur', true)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_fullscreen_blur.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_fullscreen_blur.png')
     SetImguiValue('Use Fullscreen Blur', false)
 
     -- Directional Light PCF low
@@ -85,22 +85,22 @@ function TestDirectionalLight()
     SetImguiValue('Filter Method##Directional', 'PCF')
     SetImguiValue('Filtering # ##Directional', 4)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_low.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_low.png')
 
     -- Directional Light PCF high
     SetImguiValue('Filtering # ##Directional', 64)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_high.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_high.png')
 
     -- Directional Light ESM
     SetImguiValue('Filter Method##Directional', 'ESM')
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm.png')
 
     -- Directional Light ESM+PCF
     SetImguiValue('Filter Method##Directional', 'ESM+PCF')
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm_pcf.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm_pcf.png')
 end
 
 function TestDiskLights()
@@ -111,13 +111,13 @@ function TestDiskLights()
     -- Disabling directional light
     SetImguiValue('Intensity##Directional', 0.0)
     EnablePositionalLights()
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_initial.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_initial.png')
 
     -- Positional Light Disabling Shadow for Red
     SetImguiValue('Red', true)
     SetImguiValue('Enable Shadow', false)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_no_red_shadow.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_no_red_shadow.png')
 
     -- Positional Light Various Shadowmap Sizes
     SetImguiValue('Red', true)
@@ -131,7 +131,7 @@ function TestDiskLights()
     SetImguiValue('Blue', true)
     SetImguiValue('Size##Positional', '512')
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_shadowmap_size.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_shadowmap_size.png')
 
     -- Positional Light Various Filter Methods
     SetImguiValue('Red', true)
@@ -148,7 +148,7 @@ function TestDiskLights()
     IdleFrames(1)
     SetImguiValue('Filtering # ##Positional', 64)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter_method.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter_method.png')
 end
 
 function TestPointLights()
@@ -160,10 +160,10 @@ function TestPointLights()
 
     EnablePositionalLights()
 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/point_lights.png', g_envSuffix)
+    CaptureScreenshot(g_screenshotOutputFolder .. '/point_lights.png')
 end
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Shadow/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/Shadow/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/Shadow')
@@ -177,7 +177,7 @@ SetImguiValue('Auto Rotation##Positional', false)
 SetImguiValue('Direction##Directional', 0.0)
 SetImguiValue('Base Direction##Positional', 0.0)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png')
 
 TestDirectionalLight()
 TestPointLights()

--- a/Scripts/ShadowTest.bv.lua
+++ b/Scripts/ShadowTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 function EnablePositionalLights()
     SetImguiValue('Red', true)
     SetImguiValue('Intensity##Positional', 500.0)
@@ -45,7 +47,7 @@ function TestDirectionalLight()
     SetImguiValue('Size##Directional', '2048')
     SetImguiValue('4', true) -- cascade count
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_initial.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_initial.png', g_envSuffix)
 
     -- Directional Light Manual Cascade Split
     SetImguiValue('Debug Coloring', true)
@@ -57,25 +59,25 @@ function TestDirectionalLight()
     IdleFrames(1)
     SetImguiValue('FarDepth 2', 6.0)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_manual_cascade.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_manual_cascade.png', g_envSuffix)
 
     -- Directional Light Automatic Cascade Split
     SetImguiValue('Automatic Cascade Split', true)
     IdleFrames(1)
     SetImguiValue('Ratio', 0.25)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_auto_cascade.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_auto_cascade.png', g_envSuffix)
 
     -- Directional Light Cascade Position Correction
     SetImguiValue('Cascade Position Correction', true)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_cascade_correction.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_cascade_correction.png', g_envSuffix)
     SetImguiValue('Cascade Position Correction', false)
 
     -- Directional Light Cascade Position Correction
     SetImguiValue('Use Fullscreen Blur', true)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_fullscreen_blur.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_fullscreen_blur.png', g_envSuffix)
     SetImguiValue('Use Fullscreen Blur', false)
 
     -- Directional Light PCF low
@@ -83,22 +85,22 @@ function TestDirectionalLight()
     SetImguiValue('Filter Method##Directional', 'PCF')
     SetImguiValue('Filtering # ##Directional', 4)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_low.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_low.png', g_envSuffix)
 
     -- Directional Light PCF high
     SetImguiValue('Filtering # ##Directional', 64)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_high.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_pcf_high.png', g_envSuffix)
 
     -- Directional Light ESM
     SetImguiValue('Filter Method##Directional', 'ESM')
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm.png', g_envSuffix)
 
     -- Directional Light ESM+PCF
     SetImguiValue('Filter Method##Directional', 'ESM+PCF')
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm_pcf.png')    
+    CaptureScreenshot(g_screenshotOutputFolder .. '/directional_esm_pcf.png', g_envSuffix)
 end
 
 function TestDiskLights()
@@ -109,13 +111,13 @@ function TestDiskLights()
     -- Disabling directional light
     SetImguiValue('Intensity##Directional', 0.0)
     EnablePositionalLights()
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_initial.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_initial.png', g_envSuffix)
 
     -- Positional Light Disabling Shadow for Red
     SetImguiValue('Red', true)
     SetImguiValue('Enable Shadow', false)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_no_red_shadow.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_no_red_shadow.png', g_envSuffix)
 
     -- Positional Light Various Shadowmap Sizes
     SetImguiValue('Red', true)
@@ -129,7 +131,7 @@ function TestDiskLights()
     SetImguiValue('Blue', true)
     SetImguiValue('Size##Positional', '512')
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_shadowmap_size.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_shadowmap_size.png', g_envSuffix)
 
     -- Positional Light Various Filter Methods
     SetImguiValue('Red', true)
@@ -146,7 +148,7 @@ function TestDiskLights()
     IdleFrames(1)
     SetImguiValue('Filtering # ##Positional', 64)
     IdleFrames(1)
-    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter_method.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter_method.png', g_envSuffix)
 end
 
 function TestPointLights()
@@ -158,7 +160,7 @@ function TestPointLights()
 
     EnablePositionalLights()
 
-    CaptureScreenshot(g_screenshotOutputFolder .. '/point_lights.png')
+    CaptureScreenshot(g_screenshotOutputFolder .. '/point_lights.png', g_envSuffix)
 end
 
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/Shadow/')
@@ -175,7 +177,7 @@ SetImguiValue('Auto Rotation##Positional', false)
 SetImguiValue('Direction##Directional', 0.0)
 SetImguiValue('Base Direction##Positional', 0.0)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png', g_envSuffix)
 
 TestDirectionalLight()
 TestPointLights()

--- a/Scripts/ShadowedSponzaTest.bv.lua
+++ b/Scripts/ShadowedSponzaTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ShadowedSponza/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -55,7 +57,7 @@ SelectImageComparisonToleranceLevel("Level H")
 
 -- Initial
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png', g_envSuffix)
 
 SetNumSpotlightsActive(0)
 SetDirectionalLightOrientation(-45, 95)
@@ -63,12 +65,12 @@ SetDirectionalLightOrientation(-45, 95)
 -- Directional Light None-filtering 
 SetDirectionalNoneFiltering()
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/directional_nofilter.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/directional_nofilter.png', g_envSuffix)
 
 -- Directional Light Filtering 
 SetDirectionalFiltering()
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/directional_filter.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/directional_filter.png', g_envSuffix)
 
 SetNumSpotlightsActive(17)
 
@@ -76,11 +78,11 @@ SetNumSpotlightsActive(17)
 SetSpotNoneFiltering()
 SetImguiValue('Intensity##directional', 0.0)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/spot_nofilter.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/spot_nofilter.png', g_envSuffix)
 
 -- Spot Light Filtering 
 SetSpotFiltering()
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/ShadowedSponzaTest.bv.lua
+++ b/Scripts/ShadowedSponzaTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/ShadowedSponza/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/ShadowedSponza/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 
@@ -57,7 +57,7 @@ SelectImageComparisonToleranceLevel("Level H")
 
 -- Initial
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/initial.png')
 
 SetNumSpotlightsActive(0)
 SetDirectionalLightOrientation(-45, 95)
@@ -65,12 +65,12 @@ SetDirectionalLightOrientation(-45, 95)
 -- Directional Light None-filtering 
 SetDirectionalNoneFiltering()
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/directional_nofilter.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/directional_nofilter.png')
 
 -- Directional Light Filtering 
 SetDirectionalFiltering()
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/directional_filter.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/directional_filter.png')
 
 SetNumSpotlightsActive(17)
 
@@ -78,11 +78,11 @@ SetNumSpotlightsActive(17)
 SetSpotNoneFiltering()
 SetImguiValue('Intensity##directional', 0.0)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/spot_nofilter.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/spot_nofilter.png')
 
 -- Spot Light Filtering 
 SetSpotFiltering()
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/spot_filter.png')
 
 OpenSample(nil)

--- a/Scripts/SkinnedMesh.bv.lua
+++ b/Scripts/SkinnedMesh.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/SkinnedMesh/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -27,6 +29,6 @@ SetImguiValue('Draw bones', false)
 NoClipCameraController_SetPosition(Vector3(-0.125466, -2.129441, 1.728536))
 NoClipCameraController_SetHeading(DegToRad(-8.116900))
 NoClipCameraController_SetPitch(DegToRad(-31.035244))
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_skinnedmesh.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_skinnedmesh.png', g_envSuffix)
 
 OpenSample(nil)

--- a/Scripts/SkinnedMesh.bv.lua
+++ b/Scripts/SkinnedMesh.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/SkinnedMesh/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/SkinnedMesh/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/SkinnedMesh')
@@ -29,6 +29,6 @@ SetImguiValue('Draw bones', false)
 NoClipCameraController_SetPosition(Vector3(-0.125466, -2.129441, 1.728536))
 NoClipCameraController_SetHeading(DegToRad(-8.116900))
 NoClipCameraController_SetPitch(DegToRad(-31.035244))
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_skinnedmesh.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_skinnedmesh.png')
 
 OpenSample(nil)

--- a/Scripts/StreamingImageTest.bv.lua
+++ b/Scripts/StreamingImageTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/StreamingImage/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/StreamingImage/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('RPI/StreamingImage')
@@ -20,18 +20,18 @@ ResizeViewport(900, 900)
 SelectImageComparisonToleranceLevel("Level H")
 
 -- capture screenshot with all 2d images
-CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming2dImages.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming2dImages.png')
 
 -- capture screenshot for hot loading
 SetImguiValue('Switch texture', true)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. 'HotReloading.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. 'HotReloading.png')
 
 
 -- capture screenshot for 3d images
 SetImguiValue('View 3D Images', true)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming3dImage.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming3dImage.png')
 
 
 OpenSample(nil)

--- a/Scripts/StreamingImageTest.bv.lua
+++ b/Scripts/StreamingImageTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/StreamingImage/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -18,18 +20,18 @@ ResizeViewport(900, 900)
 SelectImageComparisonToleranceLevel("Level H")
 
 -- capture screenshot with all 2d images
-CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming2dImages.png')
+CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming2dImages.png', g_envSuffix)
 
 -- capture screenshot for hot loading
 SetImguiValue('Switch texture', true)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. 'HotReloading.png')
+CaptureScreenshot(g_screenshotOutputFolder .. 'HotReloading.png', g_envSuffix)
 
 
 -- capture screenshot for 3d images
 SetImguiValue('View 3D Images', true)
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming3dImage.png')
+CaptureScreenshot(g_screenshotOutputFolder .. 'Streaming3dImage.png', g_envSuffix)
 
 
 OpenSample(nil)

--- a/Scripts/TestEnvironment.lua
+++ b/Scripts/TestEnvironment.lua
@@ -1,3 +1,8 @@
 g_renderApiName = GetRenderApiName()
 
-g_envSuffix = "+" .. g_renderApiName;
+-- surround the actual env so that it won't match other part of the path when IO is operating the file path.
+stringCollisionProtector = '___'
+
+g_testEnv = stringCollisionProtector .. g_renderApiName .. stringCollisionProtector;
+
+SetTestEnvPath(g_testEnv)

--- a/Scripts/TestEnvironment.lua
+++ b/Scripts/TestEnvironment.lua
@@ -1,0 +1,3 @@
+g_renderBackend = QueryRenderBackend()
+
+g_envSuffix = "+" .. g_renderBackend;

--- a/Scripts/TestEnvironment.lua
+++ b/Scripts/TestEnvironment.lua
@@ -1,3 +1,3 @@
-g_renderBackend = QueryRenderBackend()
+g_renderApiName = GetRenderApiName()
 
-g_envSuffix = "+" .. g_renderBackend;
+g_envSuffix = "+" .. g_renderApiName;

--- a/Scripts/TransparentTest.bv.lua
+++ b/Scripts/TransparentTest.bv.lua
@@ -11,7 +11,7 @@
 
 RunScript("scripts/TestEnvironment.luac")
 
-g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/TransparentTest/')
+g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/' .. g_testEnv .. '/TransparentTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
 OpenSample('Features/Transparency')
@@ -22,10 +22,10 @@ ArcBallCameraController_SetDistance(2.0)
 ArcBallCameraController_SetHeading(DegToRad(45))
 ArcBallCameraController_SetPitch(DegToRad(-35))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_front.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_front.png')
 
 ArcBallCameraController_SetHeading(DegToRad(135))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_back.png', g_envSuffix)
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_back.png')
 
 OpenSample(nil)

--- a/Scripts/TransparentTest.bv.lua
+++ b/Scripts/TransparentTest.bv.lua
@@ -9,6 +9,8 @@
 --
 ----------------------------------------------------------------------------------------------------
 
+RunScript("scripts/TestEnvironment.luac")
+
 g_screenshotOutputFolder = ResolvePath('@user@/Scripts/Screenshots/TransparentTest/')
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder))
 
@@ -20,10 +22,10 @@ ArcBallCameraController_SetDistance(2.0)
 ArcBallCameraController_SetHeading(DegToRad(45))
 ArcBallCameraController_SetPitch(DegToRad(-35))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_front.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_front.png', g_envSuffix)
 
 ArcBallCameraController_SetHeading(DegToRad(135))
 IdleFrames(1)
-CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_back.png')
+CaptureScreenshot(g_screenshotOutputFolder .. '/screenshot_back.png', g_envSuffix)
 
 OpenSample(nil)

--- a/atomsampleviewer_asset_files.cmake
+++ b/atomsampleviewer_asset_files.cmake
@@ -56,6 +56,7 @@ set(FILES
     Scripts/ShadowTest.bv.lua
     Scripts/SkinnedMesh.bv.lua
     Scripts/StreamingImageTest.bv.lua
+    Scripts/TestEnvironment.lua
     Scripts/TransparentTest.bv.lua
     Scripts/_AutomatedPeriodicBenchmarkSuite_.bv.lua
     Scripts/_FullTestSuite_.bv.lua


### PR DESCRIPTION
The original cause for the issue is screenshot tests run on dx12 and vulkan sequentially, so that the old screenshots will be overwritten by the newer ones because they have the same names.

To solve this, we can either generate different file names for screenshots, or having them stored in different folders.
The PR insert an env path in the middle of the screenshot path, specified in lua. 

Tested the full test suit, and updating local baseline images.
A single test result looks like below:
![Screenshot update](https://user-images.githubusercontent.com/51759646/186794253-dd98d7ad-9502-4f5e-8b19-9aa7eacb7253.JPG)