### PR TITLE
adjusting the timeout duration of the ASV main suite job

### DIFF
--- a/Standalone/PythonTests/CMakeLists.txt
+++ b/Standalone/PythonTests/CMakeLists.txt
@@ -17,7 +17,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS AND PAL_TRAIT_BUILD_TESTS_SUPPORTED)
         TEST_REQUIRES gpu
         TEST_SUITE main
         TEST_SERIAL
-        TIMEOUT 1200
+        TIMEOUT 2400
         RUNTIME_DEPENDENCIES
             AssetProcessor
             AssetProcessorBatch


### PR DESCRIPTION
main suite AtomSampleViewer has consistently timed out at 1200 seconds for the full suite.
This change increases the timeout so that we can get past this and reach individual pytest results which themselves have 400 second time-out.

Signed-off-by: Scott Murray <scottmur@amazon.com>