### PR TITLE
TonemappingExample: Rename to DisplayMapperSRGB as per the engine

### DIFF
--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -297,7 +297,7 @@ namespace AtomSampleViewer
             "AcesOutputTransform",
             "AcesLutPass",
             "DisplayMapperPassthrough",
-            "DisplayMapperOnlyGammaCorrection",
+            "DisplayMapperSRGB",
             "OutputTransform"
         };
 


### PR DESCRIPTION
This aligns the display mapper names with the engine, cf. https://github.com/o3de/o3de/pull/10669