### PR TITLE
update frame capture notification bus to use frame capture id as the address

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1462,7 +1462,7 @@ namespace AtomSampleViewer
                 AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshot, filePath);
                 if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
                 {
-                    s_instance->AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusConnect(frameCaptureId);
+                    s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
                 }
             }
@@ -1496,7 +1496,7 @@ namespace AtomSampleViewer
                 AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshot, filePath);
                 if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
                 {
-                    s_instance->AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusConnect(frameCaptureId);
+                    s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
                 }
             }
@@ -1527,7 +1527,7 @@ namespace AtomSampleViewer
                 AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshotWithPreview, filePath);
                 if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
                 {
-                    s_instance->AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusConnect(frameCaptureId);
+                    s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
                 }
             }
@@ -1625,7 +1625,7 @@ namespace AtomSampleViewer
                 AZ::Render::FrameCaptureRequestBus::BroadcastResult(frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CapturePassAttachment, passHierarchy, slot, outputFilePath, readbackOption);
                 if (frameCaptureId != AZ::Render::InvalidFrameCaptureId)
                 {
-                    s_instance->AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusConnect(frameCaptureId);
+                    s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
                 }
             }
@@ -1638,11 +1638,11 @@ namespace AtomSampleViewer
             });
     }
 
-    void ScriptManager::OnFrameCaptureFinished(AZ::Render::FrameCaptureId frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string &info)
+    void ScriptManager::OnFrameCaptureFinished(AZ::Render::FrameCaptureResult result, const AZStd::string &info)
     {
         m_isCapturePending = false;
         m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
-        AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusDisconnect(frameCaptureId);
+        AZ::Render::FrameCaptureNotificationBus::Handler::BusDisconnect();
         ResumeScript();
 
         // This is checking for the exact scenario that results from an HDR setup. The goal is to add a very specific and prominent message that will

--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -1465,6 +1465,13 @@ namespace AtomSampleViewer
                     s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
                 }
+                else
+                {
+                    AZ_Error("Automation", false, "Failed to initiate frame capture for '%s'", filePath.c_str());
+                    s_instance->m_isCapturePending = false;
+                    s_instance->m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+                    s_instance->ResumeScript();
+                }
             }
         };
 
@@ -1499,6 +1506,13 @@ namespace AtomSampleViewer
                     s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
                 }
+                else
+                {
+                    AZ_Error("Automation", false, "Failed to initiate frame capture for '%s'", filePath.c_str());
+                    s_instance->m_isCapturePending = false;
+                    s_instance->m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+                    s_instance->ResumeScript();
+                }
             }
         };
 
@@ -1529,6 +1543,13 @@ namespace AtomSampleViewer
                 {
                     s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
+                }
+                else
+                {
+                    AZ_Error("Automation", false, "Failed to initiate frame capture for '%s'", filePath.c_str());
+                    s_instance->m_isCapturePending = false;
+                    s_instance->m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+                    s_instance->ResumeScript();
                 }
             }
         };
@@ -1627,6 +1648,13 @@ namespace AtomSampleViewer
                 {
                     s_instance->AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(frameCaptureId);
                     s_instance->m_frameCaptureId = frameCaptureId;
+                }
+                else
+                {
+                    AZ_Error("Automation", false, "Failed to initiate frame capture for '%s'", outputFilePath.c_str());
+                    s_instance->m_isCapturePending = false;
+                    s_instance->m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
+                    s_instance->ResumeScript();
                 }
             }
         };

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -49,7 +49,7 @@ namespace AtomSampleViewer
         : public ScriptRepeaterRequestBus::Handler
         , public ScriptRunnerRequestBus::Handler
         , public AZ::Debug::CameraControllerNotificationBus::Handler
-        , public AZ::Render::FrameCaptureNotificationBus::MultiHandler
+        , public AZ::Render::FrameCaptureNotificationBus::Handler
         , public AZ::Render::ProfilingCaptureNotificationBus::Handler
         , public AZ::Debug::ProfilerNotificationBus::Handler
     {
@@ -219,7 +219,7 @@ namespace AtomSampleViewer
         void OnCameraMoveEnded(AZ::TypeId controllerTypeId, uint32_t channels) override;
 
         // FrameCaptureNotificationBus overrides...
-        void OnFrameCaptureFinished(AZ::Render::FrameCaptureId frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
+        void OnFrameCaptureFinished(AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
 
         // ProfilingCaptureNotificationBus overrides...
         void OnCaptureQueryTimestampFinished(bool result, const AZStd::string& info) override;

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -49,7 +49,7 @@ namespace AtomSampleViewer
         : public ScriptRepeaterRequestBus::Handler
         , public ScriptRunnerRequestBus::Handler
         , public AZ::Debug::CameraControllerNotificationBus::Handler
-        , public AZ::Render::FrameCaptureNotificationBus::Handler
+        , public AZ::Render::FrameCaptureNotificationBus::MultiHandler
         , public AZ::Render::ProfilingCaptureNotificationBus::Handler
         , public AZ::Debug::ProfilerNotificationBus::Handler
     {
@@ -219,7 +219,7 @@ namespace AtomSampleViewer
         void OnCameraMoveEnded(AZ::TypeId controllerTypeId, uint32_t channels) override;
 
         // FrameCaptureNotificationBus overrides...
-        void OnCaptureFinished(uint32_t frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
+        void OnFrameCaptureFinished(AZ::Render::FrameCaptureId frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
 
         // ProfilingCaptureNotificationBus overrides...
         void OnCaptureQueryTimestampFinished(bool result, const AZStd::string& info) override;
@@ -342,7 +342,7 @@ namespace AtomSampleViewer
         bool m_showPrecommitWizard = false;
         PrecommitWizardSettings m_wizardSettings;
 
-        uint32_t m_frameCaptureId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
+        AZ::Render::FrameCaptureId m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
         bool m_showScriptRunnerDialog = false;
         bool m_isCapturePending = false;
         bool m_frameTimeIsLocked = false;

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -639,7 +639,7 @@ namespace AtomSampleViewer
                 AZ::Render::FrameCaptureRequestBus::BroadcastResult(m_frameCaptureId, &AZ::Render::FrameCaptureRequestBus::Events::CaptureScreenshot, m_frameCaptureFilePath);
                 if (m_frameCaptureId != AZ::Render::InvalidFrameCaptureId ) // if unsuccessfull leave state to attempt again next tick
                 {
-                    AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusConnect(m_frameCaptureId);
+                    AZ::Render::FrameCaptureNotificationBus::Handler::BusConnect(m_frameCaptureId);
 
                     m_countdownForFrameCapture = -1; // Don't call CaptureScreenshot again
                 }
@@ -1229,9 +1229,9 @@ namespace AtomSampleViewer
         }
     }
 
-    void SampleComponentManager::OnFrameCaptureFinished(AZ::Render::FrameCaptureId captureId [[maybe_unused]], AZ::Render::FrameCaptureResult /*result*/, const AZStd::string& /*info*/)
+    void SampleComponentManager::OnFrameCaptureFinished(AZ::Render::FrameCaptureResult /*result*/, const AZStd::string& /*info*/)
     {
-        AZ::Render::FrameCaptureNotificationBus::MultiHandler::BusDisconnect(captureId);
+        AZ::Render::FrameCaptureNotificationBus::Handler::BusDisconnect();
 
         if (m_hideImGuiDuringFrameCapture)
         {

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -82,7 +82,7 @@ namespace AtomSampleViewer
         , public SampleComponentManagerRequestBus::Handler
         , public AZ::TickBus::Handler
         , public AzFramework::InputChannelEventListener
-        , public AZ::Render::FrameCaptureNotificationBus::Handler
+        , public AZ::Render::FrameCaptureNotificationBus::MultiHandler
         , public AzFramework::AssetCatalogEventBus::Handler
         , public AZ::Render::ImGuiSystemNotificationBus::Handler
 
@@ -161,7 +161,7 @@ namespace AtomSampleViewer
         void ClearRPIScene() override;
 
         // FrameCaptureNotificationBus overrides...
-        void OnCaptureFinished(uint32_t frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
+        void OnFrameCaptureFinished(AZ::Render::FrameCaptureId frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
 
         // AzFramework::AssetCatalogEventBus::Handler overrides ...
         void OnCatalogLoaded(const char* catalogFile) override;
@@ -247,7 +247,7 @@ namespace AtomSampleViewer
         bool m_isFrameCapturePending = false;
         bool m_hideImGuiDuringFrameCapture = true;
         int m_countdownForFrameCapture = 0;
-        uint32_t m_frameCaptureId = AZ::Render::FrameCaptureRequests::s_InvalidFrameCaptureId;
+        AZ::Render::FrameCaptureId m_frameCaptureId = AZ::Render::InvalidFrameCaptureId;
         AZStd::string m_frameCaptureFilePath;
 
         AZStd::unique_ptr<ScriptManager> m_scriptManager;

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -82,7 +82,7 @@ namespace AtomSampleViewer
         , public SampleComponentManagerRequestBus::Handler
         , public AZ::TickBus::Handler
         , public AzFramework::InputChannelEventListener
-        , public AZ::Render::FrameCaptureNotificationBus::MultiHandler
+        , public AZ::Render::FrameCaptureNotificationBus::Handler
         , public AzFramework::AssetCatalogEventBus::Handler
         , public AZ::Render::ImGuiSystemNotificationBus::Handler
 
@@ -161,7 +161,7 @@ namespace AtomSampleViewer
         void ClearRPIScene() override;
 
         // FrameCaptureNotificationBus overrides...
-        void OnFrameCaptureFinished(AZ::Render::FrameCaptureId frameCaptureId, AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
+        void OnFrameCaptureFinished(AZ::Render::FrameCaptureResult result, const AZStd::string& info) override;
 
         // AzFramework::AssetCatalogEventBus::Handler overrides ...
         void OnCatalogLoaded(const char* catalogFile) override;


### PR DESCRIPTION
AtomSampleViewer change to match O3DE change https://github.com/o3de/o3de/pull/10592.

Testing ran ASV full suite.
DX12
![image](https://user-images.githubusercontent.com/82187279/188722913-a762b96c-bb59-4bf4-99fa-9890796f0b77.png)
Vulkan
![image](https://user-images.githubusercontent.com/82187279/188724130-806c2f04-c4bf-4d62-b7d3-1c883906f66d.png)
