### PR TITLE
Fix TraceMessageBus for AtomSampleViewer

### DIFF
--- a/Gem/Code/Source/Automation/ScriptReporter.h
+++ b/Gem/Code/Source/Automation/ScriptReporter.h
@@ -146,6 +146,11 @@ namespace AtomSampleViewer
         //! Records all the information about a single test script.
         struct ScriptReport : public AZ::Debug::TraceMessageBus::Handler
         {
+            ScriptReport()
+            {
+                AZ::Debug::TraceMessageBus::Handler::BusConnect();
+            }
+
             ~ScriptReport()
             {
                 AZ::Debug::TraceMessageBus::Handler::BusDisconnect();

--- a/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.cpp
@@ -331,6 +331,7 @@ namespace AtomSampleViewer
 
     int RunGameCommon(int argc, char** argv, AZStd::function<void()> customRunCode)
     {
+        const AZ::Debug::Trace tracer;
         AtomSampleViewer::AtomSampleViewerApplication app(&argc, &argv);
 
         const AzGameFramework::GameApplication::StartupParameters gameAppParams;


### PR DESCRIPTION
Add `Debug::Tracer tracer` stack variable to main so that TraceMessageBus works

Signed-off-by: rgba16f <82187279+rgba16f@users.noreply.github.com>