### PR TITLE
Various Fixes to ASV

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -6,7 +6,7 @@
 #
 #
 
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Source/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}")
 
 ly_add_target(
     NAME AtomSampleViewer.Lib.Static STATIC

--- a/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
+++ b/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
@@ -75,7 +75,7 @@ namespace AtomSampleViewer
 
         Data::AssetId modelAssetId;
         Data::AssetCatalogRequestBus::BroadcastResult(
-            modelAssetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, Products::ModelFilePath, nullptr, false);
+            modelAssetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, Products::ModelFilePath, AZ::Uuid::CreateNull(), false);
         AZ_Assert(modelAssetId.IsValid(), "Failed to get model asset id: %s", Products::ModelFilePath);
         m_modelAsset.Create(modelAssetId);
 

--- a/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
@@ -164,7 +164,7 @@ namespace AtomSampleViewer
         ScriptRunnerRequestBus::Broadcast(&ScriptRunnerRequests::PauseScriptWithTimeout, LongTimeout);
 
         Data::AssetId modelAssetId;
-        Data::AssetCatalogRequestBus::BroadcastResult(modelAssetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, Products::ModelFilePath, nullptr, false);
+        Data::AssetCatalogRequestBus::BroadcastResult(modelAssetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, Products::ModelFilePath, AZ::Uuid::CreateNull(), false);
         AZ_Assert(modelAssetId.IsValid(), "Failed to get model asset id: %s", Products::ModelFilePath);
         m_modelAsset.Create(modelAssetId);
 
@@ -290,7 +290,7 @@ namespace AtomSampleViewer
     Data::AssetId MaterialHotReloadTestComponent::GetAssetId(const char* productFilePath)
     {
         Data::AssetId assetId;
-        Data::AssetCatalogRequestBus::BroadcastResult(assetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, productFilePath, nullptr, false);
+        Data::AssetCatalogRequestBus::BroadcastResult(assetId, &Data::AssetCatalogRequestBus::Events::GetAssetIdByPath, productFilePath, AZ::Uuid::CreateNull(), false);
         return assetId;
     }
 

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -312,7 +312,7 @@ namespace AtomSampleViewer
 
         // Release the probe
         m_reflectionProbeFeatureProcessor->RemoveReflectionProbe(m_reflectionProbeHandle);
-        m_reflectionProbeHandle = nullptr;
+        m_reflectionProbeHandle = {};
 
         // Release all meshes
         for (auto& shaderBallMeshHandle : m_shaderBallMeshHandles)

--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -39,7 +39,7 @@ namespace AtomSampleViewer
         using PointLightHandle = AZ::Render::PointLightFeatureProcessorInterface::LightHandle;
         using DiskLightHandle = AZ::Render::DiskLightFeatureProcessorInterface::LightHandle;
         using DirectionalLightHandle = AZ::Render::DirectionalLightFeatureProcessorInterface::LightHandle;
-        using ReflectinoProbeHandle = AZ::Render::ReflectionProbeHandle;
+        using ReflectionProbeHandle = AZ::Render::ReflectionProbeHandle;
 
         static constexpr uint32_t ShaderBallCount = 12u;
 
@@ -93,7 +93,7 @@ namespace AtomSampleViewer
         PointLightHandle m_pointLightHandle;
         DiskLightHandle m_diskLightHandle;
         DirectionalLightHandle m_directionalLightHandle;
-        ReflectinoProbeHandle m_reflectionProbeHandle;
+        ReflectionProbeHandle m_reflectionProbeHandle;
 
         MultiSceneExampleComponent* m_parent = nullptr;
         const AZ::Vector3 m_cameraOffset{ 0.0f, -4.0f, 2.0f };

--- a/Standalone/CMakeLists.txt
+++ b/Standalone/CMakeLists.txt
@@ -6,8 +6,7 @@
 #
 #
 
-
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}")
 
 include(${pal_dir}/atomsampleviewer_traits_${PAL_PLATFORM_NAME_LOWERCASE}.cmake)
 


### PR DESCRIPTION
- Replaced deprecated CMake PAL functions with current version (gets rid of cmake warnings).
- Fixed uses of Uuid based on recent changes in o3de.
- Fixed spelling of a type.