### PR TITLE
Fix DispatchRaysItem arguments after changes in O3DE

### DIFF
--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -226,9 +226,9 @@ namespace AZ
             };
 
             RHI::DispatchRaysItem dispatchRaysItem;
-            dispatchRaysItem.m_width = targetImageSize.m_width;
-            dispatchRaysItem.m_height = targetImageSize.m_height;
-            dispatchRaysItem.m_depth = 1;
+            dispatchRaysItem.m_arguments.m_direct.m_width = targetImageSize.m_width;
+            dispatchRaysItem.m_arguments.m_direct.m_height = targetImageSize.m_height;
+            dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
             dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState.get();
             dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable.get();
             dispatchRaysItem.m_shaderResourceGroupCount = 1;

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -598,9 +598,9 @@ namespace AtomSampleViewer
             };
 
             RHI::DispatchRaysItem dispatchRaysItem;
-            dispatchRaysItem.m_width = m_imageWidth;
-            dispatchRaysItem.m_height = m_imageHeight;
-            dispatchRaysItem.m_depth = 1;
+            dispatchRaysItem.m_arguments.m_direct.m_width = m_imageWidth;
+            dispatchRaysItem.m_arguments.m_direct.m_height = m_imageHeight;
+            dispatchRaysItem.m_arguments.m_direct.m_depth = 1;
             dispatchRaysItem.m_rayTracingPipelineState = m_rayTracingPipelineState.get();
             dispatchRaysItem.m_rayTracingShaderTable = m_rayTracingShaderTable.get();
             dispatchRaysItem.m_shaderResourceGroupCount = RHI::ArraySize(shaderResourceGroups);


### PR DESCRIPTION
After the pull request https://github.com/o3de/o3de/pull/12009 is merged, AtomSampleViewer also needs to be changed to be conform to the changed API in `RHI::DispatchRaysItem`.
