### PR TITLE
Updating the AtomSampleViewerSystemComponent to use a duration_cast.

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -110,7 +110,7 @@ namespace AtomSampleViewer
         AZ::ComponentApplicationBus::Broadcast(&AZ::ComponentApplicationBus::Events::QueryApplicationType, appType);
         if (appType.IsValid() && !appType.IsEditor())
         {
-            // AtomSampleViewer SampleComponentManager creates and manages its own scene and render pipelines. 
+            // AtomSampleViewer SampleComponentManager creates and manages its own scene and render pipelines.
             // We disable the creation of default scene in BootStrapSystemComponent
             AZ::Render::Bootstrap::DefaultWindowBus::Broadcast(&AZ::Render::Bootstrap::DefaultWindowBus::Events::SetCreateDefaultScene, false);
         }
@@ -207,7 +207,7 @@ namespace AtomSampleViewer
 
         if (!m_testsLogged)
         {
-            AZStd::chrono::duration<float> elapsedTime = HighResTimer::now() - m_timestamp;
+            auto elapsedTime = AZStd::chrono::duration_cast<AZStd::chrono::duration<float>>(HighResTimer::now() - m_timestamp);
 
             if (m_frameCount == 1)
             {


### PR DESCRIPTION
As a dependency of the following change still in [PR](https://github.com/o3de/o3de/blame/f49f16db458deda09eb58e5af4c270ba741e24b1/Code/Framework/AzCore/AzCore/std/chrono/chrono.h#L21-L23) updating AZstd::chrono:: namespace to alias the std::chrono:: library, an `AZStd::chrono::duration_cast` has been added when assigning to an `AZStd::chrono::duration` which would result in precision lost.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>