### PR TITLE
Build fixes for chrono library changes 

### DIFF
--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -11,7 +11,6 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/std/containers/array.h>
-#include <AzCore/std/chrono/clocks.h>
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
@@ -92,7 +91,7 @@ namespace AtomSampleViewer
 
         void SetQueryType(QueryType type);
         void DrawSampleSettings();
-        
+
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_quadInputAssemblyBuffer;
 

--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -22,6 +22,7 @@
 #include <AzCore/Serialization/Utils.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/std/sort.h>
+#include <AzCore/std/time.h>
 
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzFramework/Components/TransformComponent.h>
@@ -183,7 +184,7 @@ namespace AtomSampleViewer
 
         // If there are any assets that haven't finished loading yet, and thus haven't been disconnected, disconnect now.
         AZ::Data::AssetBus::MultiHandler::BusDisconnect();
-        
+
         m_defaultIbl.Reset();
 
         m_skyboxFeatureProcessor->Enable(false);
@@ -594,7 +595,7 @@ namespace AtomSampleViewer
         if (ImGui::Begin("Results"))
         {
             ImGui::Columns(2);
-            
+
             ImGui::Text("Load");
             ImGui::NextColumn();
             ImGui::Text("Run");

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -24,6 +24,7 @@
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/SystemFile.h>
+#include <AzCore/std/time.h>
 #include <AzCore/Utils/Utils.h>
 
 #include <AzFramework/API/ApplicationAPI.h>
@@ -53,7 +54,7 @@ namespace AtomSampleViewer
             Data::Asset<AZ::RPI::ShaderAsset>& shaderAsset,
             RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout>& srgLayout,
             RHI::ConstPtr<RHI::PipelineState>& pipelineState,
-            RHI::DrawListTag& drawListTag, 
+            RHI::DrawListTag& drawListTag,
             RPI::Scene* scene)
         {
             // Since the shader is using SV_VertexID and SV_InstanceID as VS input, we won't need to have vertex buffer.


### PR DESCRIPTION
Adding missing includes for time.h in SponzaBenchmarkComponent.cpp and StreamingImageExampleComponent.cpp and removing include for clocks.h from QueryExampleExampleComponent.h as part of the chrono changes from PR https://github.com/o3de/o3de/pull/11983

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>