### PR TITLE
Fixed Mesh sample's low-end pipeline toggle.

### DIFF
--- a/Gem/Code/Source/MeshExampleComponent.cpp
+++ b/Gem/Code/Source/MeshExampleComponent.cpp
@@ -101,6 +101,7 @@ namespace AtomSampleViewer
     void MeshExampleComponent::ActivateLowEndPipeline()
     {
         m_originalPipeline = m_scene->GetDefaultRenderPipeline();
+        m_lowEndPipeline->GetRootPass()->SetEnabled(true); // PassSystem::RemoveRenderPipeline was calling SetEnabled(false)
         m_scene->AddRenderPipeline(m_lowEndPipeline);
         m_lowEndPipeline->SetDefaultView(m_originalPipeline->GetDefaultView());
         m_scene->RemoveRenderPipeline(m_originalPipeline->GetId());
@@ -112,6 +113,7 @@ namespace AtomSampleViewer
     {
         m_imguiScope = {}; // restores previous ImGui context.
 
+        m_originalPipeline->GetRootPass()->SetEnabled(true); // PassSystem::RemoveRenderPipeline was calling SetEnabled(false)
         m_scene->AddRenderPipeline(m_originalPipeline);
         m_scene->RemoveRenderPipeline(m_lowEndPipeline->GetId());
     }

--- a/Scripts/ExpectedScreenshots/LowEndPipeline/004_metalmap.png
+++ b/Scripts/ExpectedScreenshots/LowEndPipeline/004_metalmap.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b8614e43a65b9f2169c82365c4ec8770985e439047a05f7a3bbcc4ba8818c6c
+size 593590

--- a/Scripts/ExpectedScreenshots/LowEndPipeline/009_opacity_blended.png
+++ b/Scripts/ExpectedScreenshots/LowEndPipeline/009_opacity_blended.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2e4f6632444f86d0ce4c904bbee93495dd44bbb459b3d0f402ede75e19876a5
+size 1091623

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -224,3 +224,24 @@ g_testMaterialsFolder = 'testdata/materials/autobrick/'
 
 GenerateMaterialScreenshot('Level C', 'Brick', {model=g_cubeModel})
 GenerateMaterialScreenshot('Level D', 'Tile', {model=g_cubeModel})
+
+----------------------------------------------------------------------
+-- Low End Pipeline...
+
+SetImguiValue('Use Low End Pipeline', true)
+
+-- Toggle a couple extra times to test a specific issue where the render pipelines would become disabled.
+IdleFrames(2) 
+SetImguiValue('Use Low End Pipeline', false)
+IdleFrames(2) 
+SetImguiValue('Use Low End Pipeline', true)
+IdleFrames(2) 
+
+g_testMaterialsFolder = 'testdata/materials/standardpbrtestcases/'
+g_testCaseFolder = 'LowEndPipeline'
+Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder .. g_testCaseFolder))
+
+-- We're not really getting full coverage here, but just some cursory regression tests to make sure the low-end pipeline doesn't break.
+GenerateMaterialScreenshot('Level E', '004_MetalMap')
+GenerateMaterialScreenshot('Level F', '009_Opacity_Blended', {lighting="Neutral Urban", model=g_beveledCubeModel})
+


### PR DESCRIPTION
PassSystem::RemoveRenderPipeline was calling SetEnabled(false) so just made sure to enable the pipeline again each time the setting is toggled. I'll open a task to hopefully remove the SetEnabled(false) call from RemoveRenderPipeline, it seems unnecessary.

See https://github.com/o3de/o3de-atom-sampleviewer/issues/519 

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>

Full test suite only reported known issues:
![image](https://user-images.githubusercontent.com/55155825/192087809-3d367a18-6f6d-4434-949c-b2cb121718d7.png)
