### PR TITLE
Added a Regression Test For The Material Pipeline System

### DIFF
--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Animated.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Animated.material
@@ -1,0 +1,16 @@
+{
+    "materialType": "@projectroot@/Cache/Intermediate Assets/testdata/materials/types/materialpipelinetest_animated_generated.materialtype",
+    "materialTypeVersion": 3,
+    "propertyValues": {
+        "settings.amplitude": 0.009999999776482582,
+        "settings.animationSpeed": 2.0,
+        "settings.color": [
+            1.0,
+            0.20444037020206451,
+            0.20444037020206451,
+            1.0
+        ],
+        "settings.frequency": 5.0,
+        "settings.roughness": 0.8600000143051147
+    }
+}

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Basic.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Basic.material
@@ -1,0 +1,12 @@
+{
+    "materialType": "@projectroot@/Cache/Intermediate Assets/testdata/materials/types/materialpipelinetest_basic_generated.materialtype",
+    "materialTypeVersion": 3,
+    "propertyValues": {
+        "settings.color": [
+            1.0,
+            0.20444037020206451,
+            0.20444037020206451,
+            1.0
+        ]
+    }
+}

--- a/Registry/material_pipelines.setreg
+++ b/Registry/material_pipelines.setreg
@@ -1,0 +1,12 @@
+{
+    "O3DE": {
+        "Atom": {
+            "RPI": {
+                "MaterialPipelineFiles": [
+                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/MainPipeline/MainPipeline.materialpipeline",
+                    "@gemroot:Atom_Feature_Common@/Assets/Materials/Pipelines/LowEndPipeline/LowEndPipeline.materialpipeline"
+                ]
+            }
+        }
+    }
+}

--- a/Scripts/ExpectedScreenshots/MaterialPipelineSystem/materialpipelinetest_basic_lowendpipeline.png
+++ b/Scripts/ExpectedScreenshots/MaterialPipelineSystem/materialpipelinetest_basic_lowendpipeline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2fab8dc6a9cf7215f77840a6178a07209171e72cce238f5e4065113e60186a3a
+size 453005

--- a/Scripts/ExpectedScreenshots/MaterialPipelineSystem/materialpipelinetest_basic_mainpipeline.png
+++ b/Scripts/ExpectedScreenshots/MaterialPipelineSystem/materialpipelinetest_basic_mainpipeline.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26d0e5a3191c12a06138baa57c823f4a72de254db9b3a5dcddd0c22632abc46f
+size 551485

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -252,7 +252,7 @@ GenerateMaterialScreenshot('Level F', '009_Opacity_Blended', {lighting="Neutral 
 -- These tests are temporary, specifically for regression testing the new material pipeline system while it is in development.
 -- Once the core material types like StandardPBR are ported to use material pipelines, we can remove these test cases.
 
-g_testMaterialsFolder = 'testdata/materials/materialpipelinetest/'
+g_testMaterialsFolder = 'materials/materialpipelinetest/'
 g_testCaseFolder = 'MaterialPipelineSystem'
 Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder .. g_testCaseFolder))
 

--- a/Scripts/MaterialScreenshotTests.bv.lua
+++ b/Scripts/MaterialScreenshotTests.bv.lua
@@ -245,3 +245,22 @@ Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder .. g_te
 GenerateMaterialScreenshot('Level E', '004_MetalMap')
 GenerateMaterialScreenshot('Level F', '009_Opacity_Blended', {lighting="Neutral Urban", model=g_beveledCubeModel})
 
+
+----------------------------------------------------------------------
+-- Material Pipeline Abstraction...
+
+-- These tests are temporary, specifically for regression testing the new material pipeline system while it is in development.
+-- Once the core material types like StandardPBR are ported to use material pipelines, we can remove these test cases.
+
+g_testMaterialsFolder = 'testdata/materials/materialpipelinetest/'
+g_testCaseFolder = 'MaterialPipelineSystem'
+Print('Saving screenshots to ' .. NormalizePath(g_screenshotOutputFolder .. g_testCaseFolder))
+
+SetImguiValue('Use Low End Pipeline', false)
+IdleFrames(2) 
+GenerateMaterialScreenshot('Level E', 'MaterialPipelineTest_Basic', {screenshotFilename="MaterialPipelineTest_Basic_MainPipeline"})
+
+SetImguiValue('Use Low End Pipeline', true)
+IdleFrames(2) 
+GenerateMaterialScreenshot('Level E', 'MaterialPipelineTest_Basic', {screenshotFilename="MaterialPipelineTest_Basic_LowEndPipeline"})
+


### PR DESCRIPTION
Added a new setreg file to override the material pipeline list, enabling LowEndPipeline.
Added a simple regression test case for using the same material in both MainPipeline and LowEndPipeline.

See https://github.com/o3de/o3de/pull/12717
