### PR TITLE
Fixes to get MaterialHotReloadTest working on Linux.

### DIFF
--- a/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
+++ b/Gem/Code/Source/MaterialHotReloadTestComponent.cpp
@@ -258,7 +258,7 @@ namespace AtomSampleViewer
 
     AzFramework::AssetSystem::AssetStatus MaterialHotReloadTestComponent::GetTestAssetStatus(const char* tempSourceFile) const
     {
-        AZStd::string filePath = AZStd::string("materials/hotreloadtest/temp/") + tempSourceFile;
+        AZStd::string filePath = AZStd::string("Materials/HotReloadTest/Temp/") + tempSourceFile;
 
         AzFramework::AssetSystem::AssetStatus status = AzFramework::AssetSystem::AssetStatus::AssetStatus_Unknown;
         AzFramework::AssetSystemRequestBus::BroadcastResult(status, &AzFramework::AssetSystem::AssetSystemRequests::GetAssetStatusSearchType,

--- a/Materials/HotReloadTest/TestData/AZSL_HorizontalPattern.txt
+++ b/Materials/HotReloadTest/TestData/AZSL_HorizontalPattern.txt
@@ -6,7 +6,7 @@
  */
 
 #include <viewsrg.srgi>
-#include <Atom/Features/PBR/ForwardPassSrg.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 

--- a/Materials/HotReloadTest/TestData/AZSL_VerticalPattern.txt
+++ b/Materials/HotReloadTest/TestData/AZSL_VerticalPattern.txt
@@ -6,7 +6,7 @@
  */
 
 #include <viewsrg.srgi>
-#include <Atom/Features/PBR/ForwardPassSrg.azsli>
+#include <Atom/Features/Pipeline/Forward/ForwardPassSrg.azsli>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 

--- a/Standalone/Platform/Linux/AtomSampleViewerApplication_linux.cpp
+++ b/Standalone/Platform/Linux/AtomSampleViewerApplication_linux.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AtomSampleViewerApplication.h>
+
+namespace AtomSampleViewer
+{
+    const bool AtomSampleViewerApplication::s_connectToAssetProcessor = true;
+
+    void AtomSampleViewerApplication::SetupConsoleHandlerRoutine()
+    {
+    }
+} // namespace AtomSampleViewer

--- a/Standalone/Platform/Linux/platform_linux_files.cmake
+++ b/Standalone/Platform/Linux/platform_linux_files.cmake
@@ -7,6 +7,6 @@
 #
 
 set(FILES
-    ../Common/AtomSampleViewerApplication_common.cpp
+    AtomSampleViewerApplication_linux.cpp
     main_linux.cpp
 )


### PR DESCRIPTION
Made sure path casing matches the actual file.
Fixed an incorrect include path in the AZSL files (it looks like it was broken at 6fb0adf3d8f1802b7308d7e41fbdf001e1527bcb, I'm not sure how it wasn't noticed earlier). Most importantly, linux wasn't setting s_connectToAssetProcessor to true. MaterialHotReloadTest needs the connection to query the asset status.

Fixes https://github.com/o3de/o3de-atom-sampleviewer/issues/524 

Signed-off-by: santorac <55155825+santorac@users.noreply.github.com>