### PR TITLE
Update ASV screenshots to fix failures.

### DIFF
--- a/Scripts/ExpectedScreenshots/CullingAndLod/screenshot_1.png
+++ b/Scripts/ExpectedScreenshots/CullingAndLod/screenshot_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:776711afde141b1af32e6b6ed0110b02af1178a77de98f3854245b200ca37e96
-size 93562
+oid sha256:edc17bda01574c8698fbe52f29f8860491100f549cbfcea30d8cc69f807f3dac
+size 93447

--- a/Scripts/ExpectedScreenshots/Shadow/point_lights.png
+++ b/Scripts/ExpectedScreenshots/Shadow/point_lights.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58a15ae7f9f0c2915fc6eb810b760c037aa032141afbd7be27625aa6de0ab5c6
-size 303561
+oid sha256:7384590635cf022ebfd2a0485648a064ebebf5f2a95cfb012c398eee569b8d22
+size 303578

--- a/Scripts/ExpectedScreenshots/Shadow/spot_initial.png
+++ b/Scripts/ExpectedScreenshots/Shadow/spot_initial.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86f2f833623e9038420b9c50ca61fdfe69e19f3b29211b924f11d334e0b36d48
-size 240542
+oid sha256:eb7b841256c6f5cd9c3035edf8236354c0bc322bd9116b7f7f8ae5f3a4716c9f
+size 240788

--- a/Scripts/ExpectedScreenshots/Shadow/spot_shadowmap_size.png
+++ b/Scripts/ExpectedScreenshots/Shadow/spot_shadowmap_size.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:879d186c00ba960974b300ffeae16a3e102e7a6b90355c3a73264d8adc1f8c5a
-size 240798
+oid sha256:bee3ed7280975d8ceb7e200f5afcaa0e9a107ffeb56902d4e36e6f5494ba78ff
+size 241200

--- a/Scripts/ExpectedScreenshots/StandardPBR/015_subsurfacescattering_transmission_thin.png
+++ b/Scripts/ExpectedScreenshots/StandardPBR/015_subsurfacescattering_transmission_thin.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1ae64bc1a9f86fc0e4f0e794b1983e2d7685a9cefe0e5174a9115550ebad5168
-size 662933
+oid sha256:ab96a407acdb2c361c1d8442b6e1f93931842515190c9f3a55de006b3ab78c78
+size 650099


### PR DESCRIPTION
Signed-off-by: jiaweig <51759646+jiaweig-amzn@users.noreply.github.com>

Those are screenshot failures that only have a little pixel difference.

![screenshot_1_diff](https://user-images.githubusercontent.com/51759646/200421339-8117a317-e1d0-43c5-aeca-8db7961b3f1b.JPG)
![spot_initial_diff](https://user-images.githubusercontent.com/51759646/200421344-6e1e011f-e195-4e00-8c45-a25dd1dc65d0.JPG)
![spot_lights_diff](https://user-images.githubusercontent.com/51759646/200421346-f15881c5-3d8d-4487-a5b4-f84410551680.JPG)
![spot_shadowmap_size](https://user-images.githubusercontent.com/51759646/200421347-fdce62e8-f47a-4c9f-8043-d1329e54c460.JPG)
![015_subsurfacescattering_transmission_thin](https://user-images.githubusercontent.com/51759646/200421349-3d01bfe8-d0ca-444f-868c-d8530bf2cf78.JPG)
