### PR TITLE
Enabling custom MSAA points in ASV to not break screenshots

### DIFF
--- a/Passes/MainRenderPipeline.azasset
+++ b/Passes/MainRenderPipeline.azasset
@@ -1,0 +1,44 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "RenderPipelineDescriptor",
+    "ClassData": {
+        "Name": "MainPipeline",
+        "MainViewTag": "MainCamera",
+        "RootPassTemplate": "MainPipeline",
+        "AllowModification": true,
+        "RenderSettings": {
+            "MultisampleState": {
+                "samples": 2,
+                "customPositionsCount": 16,
+                "customPositions": [
+                    // First sample is dead center of the pixel for accurate resolve -> non-MSAA depth
+                    // When we resolve MSAA depth to non-MSAA depth, we just pick this first sample
+                    // Being at the center of the pixel makes SSAO and world space reprojection more accurate
+                    { "x":  8,   "y":  8 },
+
+                    // Second sample is top-left corner so that samples from neighboring pixels can be used for
+                    // Quincux anti-aliasing techniques
+                    { "x":  0,   "y":  0 },
+                    
+                    { "x":  7,   "y": 15 },
+                    { "x": 15,   "y":  7 },
+                    
+                    { "x":  8,   "y":  0 },
+                    { "x":  0,   "y":  8 },
+                    { "x":  4,   "y": 11 },
+                    { "x": 11,   "y":  4 },
+                    
+                    { "x":  0,   "y": 15 },
+                    { "x": 15,   "y":  0 },
+                    { "x": 15,   "y": 15 },
+                    { "x":  3,   "y":  3 },
+                    { "x":  4,   "y":  7 },
+                    { "x":  7,   "y":  4 },
+                    { "x": 10,   "y": 13 },
+                    { "x": 13,   "y": 10 }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Enabling custom MSAA points in ASV to not break screenshots when I disable custom msaa samples in the main pipeline

Signed-off-by: antonmic <56370189+antonmic@users.noreply.github.com>