### PR TITLE
Add Unified alias for upcoming Multiplayer UnifiedLauncher changes

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -50,6 +50,7 @@ ly_add_target(
 # if enabled, AtomSampleViewer is used by the Client and ServerLauncher
 ly_create_alias(NAME AtomSampleViewer.Clients  NAMESPACE Gem TARGETS Gem::AtomSampleViewer)
 ly_create_alias(NAME AtomSampleViewer.Servers  NAMESPACE Gem TARGETS Gem::AtomSampleViewer)
+ly_create_alias(NAME AtomSampleViewer.Unified  NAMESPACE Gem TARGETS Gem::AtomSampleViewer)
 
 if(PAL_TRAIT_BUILD_HOST_TOOLS)
 


### PR DESCRIPTION
This change accommodates the addition of the UnifiedLauncher proposed in https://github.com/o3de/o3de/pull/12344. The intention is to submit this after the linked change is submitted.

Signed-off-by: puvvadar <puvvadar@amazon.com>