### PR TITLE
Add AZ_CLASS_ALLOCATOR macro to AtomSampleViewerApplication

### DIFF
--- a/Standalone/Platform/Common/AtomSampleViewerApplication.h
+++ b/Standalone/Platform/Common/AtomSampleViewerApplication.h
@@ -28,6 +28,7 @@ namespace AtomSampleViewer
         , public SampleComponentManagerNotificationBus::Handler
     {
     public:
+        AZ_CLASS_ALLOCATOR(AtomSampleViewerApplication, AZ::SystemAllocator)
         AtomSampleViewerApplication();
         AtomSampleViewerApplication(int* argc, char*** argv);
         ~AtomSampleViewerApplication() override;


### PR DESCRIPTION
This brings AtomSampleViewer to be compatible with https://github.com/o3de/o3de/pull/14030.

Signed-off-by: Chris Burel <burelc@amazon.com>