### PR TITLE
Updated the AtomSampleViewer project to reference the new `Atom_TestData` gem

### DIFF
--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -26,4 +26,5 @@ set(ENABLED_GEMS
     DiffuseProbeGrid
     XR
     OpenXRVk
+    Atom_TestData
 )

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Animated.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Animated.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_animated.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_animated.materialtype",
     "materialTypeVersion": 3,
     "propertyValues": {
         "settings.amplitude": 0.009999999776482582,

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Basic.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Basic.material
@@ -1,12 +1,12 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_basic.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_basic.materialtype",
     "materialTypeVersion": 3,
     "propertyValues": {
         "baseColor.textureMap": "@gemroot:Atom_Feature_Common@/Assets/Textures/Default/default_basecolor.tif",
-        "metallic.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/checker8x8_512.png",
+        "metallic.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/checker8x8_512.png",
         "normal.textureMap": "@gemroot:Atom_Feature_Common@/Assets/Textures/Default/default_normal.tif",
         "roughness.lowerBound": 0.10999999940395355,
-        "roughness.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/checker8x8_gray_512.png",
+        "roughness.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/checker8x8_gray_512.png",
         "roughness.upperBound": 0.8899999856948853,
         "specularF0.factor": 0.4399999976158142,
         "uv.rotateDegrees": 45.0

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Empty.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Empty.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_empty.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_empty.materialtype",
     "materialTypeVersion": 3,
     "propertyValues": {
     }

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
     "materialTypeVersion": 3,
     "propertyValues": {
         "anisotropy.anisotropyAngle": 0.6399999856948853,
@@ -7,14 +7,14 @@
         "anisotropy.factor": 0.949999988079071,
         "baseColor.factor": 0.7599999904632568,
         "baseColor.textureBlendMode": "Lerp",
-        "baseColor.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/cc0/Concrete019_1K_Color.jpg",
-        "detailLayerGroup.baseColorDetailMap": "@gemroot:Atom@/TestData/TestData/Textures/cc0/Concrete019_1K_Color.jpg",
+        "baseColor.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/cc0/Concrete019_1K_Color.jpg",
+        "detailLayerGroup.baseColorDetailMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/cc0/Concrete019_1K_Color.jpg",
         "detailLayerGroup.detailUV.offsetV": 0.9200000166893005,
         "detailLayerGroup.detailUV.scale": 2.0,
         "detailLayerGroup.enableBaseColor": true,
         "detailLayerGroup.enableDetailLayer": true,
         "detailLayerGroup.enableNormals": true,
-        "detailLayerGroup.normalDetailMap": "@gemroot:Atom@/TestData/TestData/Textures/cc0/Concrete019_1K_Normal.jpg",
+        "detailLayerGroup.normalDetailMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/cc0/Concrete019_1K_Normal.jpg",
         "subsurfaceScattering.enableSubsurfaceScattering": true
     }
 }

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_Cutout.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_Cutout.material
@@ -1,11 +1,11 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Enhanced.material",
     "propertyValues": {
         "general.doubleSided": true,
         "opacity.alphaSource": "Split",
         "opacity.mode": "Cutout",
-        "opacity.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/checker8x8_512.png"
+        "opacity.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/checker8x8_512.png"
     }
 }

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_PDO.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_PDO.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Enhanced.material",
     "propertyValues": {
@@ -8,7 +8,7 @@
         "parallax.offset": 0.03799999877810478,
         "parallax.pdo": true,
         "parallax.quality": "Medium",
-        "parallax.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/cc0/Concrete019_1K_Displacement.jpg",
+        "parallax.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/cc0/Concrete019_1K_Displacement.jpg",
         "subsurfaceScattering.enableSubsurfaceScattering": false
     }
 }

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_TintedTransparent.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_TintedTransparent.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Enhanced.material",
     "propertyValues": {

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_Transparent.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Enhanced_Transparent.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_enhanced.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Enhanced.material",
     "propertyValues": {

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard.material
@@ -1,10 +1,10 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
     "materialTypeVersion": 3,
     "propertyValues": {
         "baseColor.textureMap": "@engroot@/Gems/AtomContent/Sponza/Assets/Textures/bricks_1k_basecolor.png",
         "clearCoat.enable": true,
-        "clearCoat.influenceMap": "@gemroot:Atom@/TestData/TestData/Textures/checker8x8_512.png",
+        "clearCoat.influenceMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/checker8x8_512.png",
         "clearCoat.roughness": 0.10999999940395355,
         "emissive.color": [
             1.0,
@@ -14,7 +14,7 @@
         ],
         "emissive.enable": true,
         "emissive.intensity": 1.2599999904632568,
-        "emissive.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/checker8x8_gray_512.png",
+        "emissive.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/checker8x8_gray_512.png",
         "normal.textureMap": "@engroot@/Gems/AtomContent/Sponza/Assets/Textures/bricks_1k_normal.jpg",
         "occlusion.diffuseTextureMap": "@engroot@/Gems/AtomContent/Sponza/Assets/Textures/bricks_1k_ao.png",
         "occlusion.specularTextureMap": "@engroot@/Gems/AtomContent/Sponza/Assets/Textures/bricks_1k_ao.png",

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_Cutout.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_Cutout.material
@@ -1,11 +1,11 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Standard.material",
     "propertyValues": {
         "general.doubleSided": true,
         "opacity.alphaSource": "Split",
         "opacity.mode": "Cutout",
-        "opacity.textureMap": "@gemroot:Atom@/TestData/TestData/Textures/checker8x8_512.png"
+        "opacity.textureMap": "@gemroot:Atom_TestData@/Assets/TestData/Textures/checker8x8_512.png"
     }
 }

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_PDO.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_PDO.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Standard.material",
     "propertyValues": {

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_TintedTransparent.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_TintedTransparent.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Standard.material",
     "propertyValues": {

--- a/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_Transparent.material
+++ b/Materials/MaterialPipelineTest/MaterialPipelineTest_Standard_Transparent.material
@@ -1,5 +1,5 @@
 {
-    "materialType": "@gemroot:Atom@/TestData/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
+    "materialType": "@gemroot:Atom_TestData@/Assets/TestData/Materials/Types/materialpipelinetest_standard.materialtype",
     "materialTypeVersion": 3,
     "parentMaterial": "MaterialPipelineTest_Standard.material",
     "propertyValues": {

--- a/Registry/assetprocessor_settings.setreg
+++ b/Registry/assetprocessor_settings.setreg
@@ -17,11 +17,6 @@
                     "recursive": 1,
                     "order": 3
                 },
-                "ScanFolder AtomTestData": {
-                    "watch": "@GEMROOT:Atom@/TestData",
-                    "recursive": 1,
-                    "order": 1000
-                },
                 "RC cgf": {
                     "ignore": true
                 },


### PR DESCRIPTION
The TestData folder in the Atom Gem folder has been moved to the AtomContent folder and turned into an Asset Only Gem.

depends o3de/o3de#14205

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>