### PR TITLE
Linux: Fixed new Warning As Error from very old code:

### DIFF
--- a/Gem/Code/Source/Performance/HighInstanceExampleComponent.h
+++ b/Gem/Code/Source/Performance/HighInstanceExampleComponent.h
@@ -136,7 +136,6 @@ namespace AtomSampleViewer
 
         AZStd::vector<AZStd::string> m_expandedModelList; // has models that are more expensive on the gpu
         AZStd::vector<AZStd::string> m_simpleModelList; // Aims to keep the test cpu bottlenecked by using trivial geometry such as a cube
-        size_t m_lastPinnedModelCount = 0;
 
         float m_originalFarClipDistance;
         bool m_updateTransformEnabled = false;


### PR DESCRIPTION
```
In file included from /mnt/data/GIT/o3de/AtomSampleViewer/Gem/Code/Source/Performance/HighInstanceExampleComponent.cpp:9:
/mnt/data/GIT/o3de/AtomSampleViewer/Gem/Code/Source/Performance/HighInstanceExampleComponent.h:139:16: error: private field 'm_lastPinnedModelCount' is not used [-Werror,-Wunused-private-field]
        size_t m_lastPinnedModelCount = 0;
               ^
1 error generated.
```

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>