### PR TITLE
Added test result diff support on Linux

### DIFF
--- a/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
@@ -7,6 +7,8 @@
  */
 #include <Utils/Utils.h>
 
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <AzCore/PlatformIncl.h>
 
 namespace AtomSampleViewer
@@ -20,7 +22,43 @@ namespace AtomSampleViewer
 
         bool RunDiffTool(const AZStd::string& filePathA, const AZStd::string& filePathB)
         {
-            return false;
+            bool result = true;
+            AZStd::string executablePath = "/usr/bin/bcompare";
+
+            // Fork a process to run Beyond Compare app
+            pid_t childPid = fork();
+
+            if (childPid == 0)
+            {
+                // In child process
+                char* args[] = { const_cast<char*>(executablePath.c_str()), const_cast<char*>(filePathA.c_str()),
+                                 const_cast<char*>(filePathB.c_str()), static_cast<char*>(0) };
+                execv(executablePath.c_str(), args);
+
+                AZ_Error(
+                    "RunDiffTool", false,
+                    "RunDiffTool: Unable to launch Beyond Compare %s : errno = %s . Make sure you have installed Beyond Compare command "
+                    "line tools.",
+                    executablePath.c_str(), strerror(errno));
+
+                _exit(errno);
+            }
+            else if (childPid > 0)
+            {
+                // In parent process
+                int status;
+                pid_t result = waitpid(childPid, &status, WNOHANG);
+                if (result == -1)
+                {
+                    result = false;
+                }
+            }
+            else
+            {
+                result = false;
+            }
+
+            return result;
         }
     } // namespace Utils
 } // namespace AtomSampleViewer


### PR DESCRIPTION
with Beyond Compare (aka bcompare)

bcompare is already assumed to be installed
on MacOS and Windows.

In the future we can make a PySide based
tool that leverages applications like
idiff: https://manpages.ubuntu.com/manpages/jammy/en/man1/idiff.1.html and have a fully open source alternative for all
major Host OSes supported by O3DE.

Signed-off-by: galibzon <66021303+galibzon@users.noreply.github.com>