### PR TITLE
Material Canvas: Remove invalid display mapper enum option

### DIFF
--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -292,7 +292,7 @@ namespace AtomSampleViewer
     void TonemappingExampleComponent::UpdateCapturePassHierarchy()
     {
         AZ_Assert(static_cast<Render::DisplayMapperOperationType>(m_displayMapperConfiguration.m_operationType)
-            != Render::DisplayMapperOperationType::Invalid, "Invalid display mapper operation mode");
+            <= Render::DisplayMapperOperationType::Reinhard, "Invalid display mapper operation mode");
         AZStd::array<AZStd::string, 5> displayMapperPasses = {
             "AcesOutputTransform",
             "AcesLutPass",
@@ -342,7 +342,7 @@ namespace AtomSampleViewer
     const char* TonemappingExampleComponent::GetDisplayMapperOperationTypeLabel() const
     {
         AZ_Assert(static_cast<Render::DisplayMapperOperationType>(m_displayMapperConfiguration.m_operationType)
-            != Render::DisplayMapperOperationType::Invalid, "Invalid display mapper operation mode");
+            <= Render::DisplayMapperOperationType::Reinhard, "Invalid display mapper operation mode");
         const char* displayMapperOperationTypeLabels[] =
         {
             "ACES",


### PR DESCRIPTION
Removing invalid display mapper enum options so that it's not selectable from drop downs.

Resolves #14896

Relates to https://github.com/o3de/o3de/pull/14950