### PR TITLE
Adding casts that were removed in the last pr

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1757,7 +1757,7 @@ namespace AtomSampleViewer
             pipelineDesc.m_materialPipelineTag = GetMaterialPipelineName();
             pipelineDesc.m_mainViewTagName = "MainCamera";
             pipelineDesc.m_allowModification = true;
-            pipelineDesc.m_renderSettings.m_multisampleState.m_samples = m_numMsaaSamples;
+            pipelineDesc.m_renderSettings.m_multisampleState.m_samples = static_cast<uint16_t>(m_numMsaaSamples);
 
             m_renderPipeline = RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext.get());
             m_rpiScene->AddRenderPipeline(m_renderPipeline);
@@ -1786,7 +1786,7 @@ namespace AtomSampleViewer
 
             RPI::RenderPipelineDescriptor xrPipelineDesc;
             xrPipelineDesc.m_mainViewTagName = "MainCamera";
-            xrPipelineDesc.m_renderSettings.m_multisampleState.m_samples = m_numMsaaSamples;
+            xrPipelineDesc.m_renderSettings.m_multisampleState.m_samples = static_cast<uint16_t>(m_numMsaaSamples);
 
             // Build the pipeline for left eye
             xrPipelineDesc.m_name = "RPISamplePipelineXRLeft";


### PR DESCRIPTION
The types are in fact different (uint16_t vs int16_t) which could cause warning on other platforms.