### PR TITLE
Fix for GHI-611 : dynamicmaterialtest crashes

### DIFF
--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -65,6 +65,7 @@ VSOutput MainVS(VSInput IN, uint instanceId : SV_InstanceID)
     OUT.m_normal = IN.m_normal;
     OUT.m_tangent = IN.m_tangent;
     OUT.m_uv = IN.m_uv;
+    OUT.m_instanceId = instanceId;
     return OUT;
 }
 


### PR DESCRIPTION
Set m_instanceId in VsOutput for EmissiveMaterial.azsl, otherwise there is invalid pipeline state because the pixel shader reads an attribute that is never written to in the vertex shader.