### PR TITLE
Restore Standalone target

### DIFF
--- a/project.json
+++ b/project.json
@@ -14,7 +14,8 @@
     "icon_path": "preview.png",
     "engine": "o3de",
     "external_subdirectories": [
-        "Gem"
+        "Gem",
+        "Standalone"
     ],
     "gem_names": [
         "Maestro",


### PR DESCRIPTION
The AtomSampleViewerStandalone target was removed in a previous change,  this adds it back.
Fixes https://github.com/o3de/o3de-atom-sampleviewer/issues/600

Tested by configuring and building the target, and verifying it appeared in Visual Studio