### PR TITLE
AcquirePipelineState null checks should check initialization state (ASV)

### DIFF
--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -333,7 +333,7 @@ namespace AtomSampleViewer
             pipelineStateDescriptor.m_inputStreamLayout.Finalize();
 
             pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!pipelineState)
+            if (!pipelineState || !pipelineState->IsInitialized())
             {
                 AZ_Error("Render", false, "Failed to acquire default pipeline state for shader %s", shaderFilepath);
             }

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -291,7 +291,7 @@ namespace AtomSampleViewer
 
         auto& pipeline = m_pipelineStates[static_cast<uint32_t>(type)];
         pipeline = m_shader->AcquirePipelineState(pipelineStateDescriptor);
-        if (!pipeline)
+        if (!pipeline || !pipeline->IsInitialized())
         {
             AZ_Error(AlphaToCoverage::SampleName, false, "Failed to acquire default pipeline state for shader '%s'", AlphaToCoverage::ShaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -326,7 +326,7 @@ namespace AtomSampleViewer
                 }
 
                 m_terrainPipelineStates[ShadowScope] = shader->AcquirePipelineState(pipelineDesc);
-                if (!m_terrainPipelineStates[ShadowScope])
+                if (!m_terrainPipelineStates[ShadowScope] || !m_terrainPipelineStates[ShadowScope]->IsInitialized())
                 {
                     AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for shadow shader");
                     return;
@@ -344,7 +344,7 @@ namespace AtomSampleViewer
                     0);
 
                 m_modelPipelineStates[ShadowScope] = shader->AcquirePipelineState(pipelineDesc);
-                if (!m_modelPipelineStates[ShadowScope])
+                if (!m_modelPipelineStates[ShadowScope] || !m_modelPipelineStates[ShadowScope]->IsInitialized())
                 {
                     AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for shader");
                     return;
@@ -386,7 +386,7 @@ namespace AtomSampleViewer
                 }
 
                 m_terrainPipelineStates[ForwardScope] = shader->AcquirePipelineState(pipelineDesc);
-                if (!m_terrainPipelineStates[ForwardScope])
+                if (!m_terrainPipelineStates[ForwardScope] || !m_terrainPipelineStates[ForwardScope]->IsInitialized())
                 {
                     AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for shadow shader");
                     return;
@@ -404,7 +404,7 @@ namespace AtomSampleViewer
                     0);
 
                 m_modelPipelineStates[ForwardScope] = shader->AcquirePipelineState(pipelineDesc);
-                if (!m_modelPipelineStates[ForwardScope])
+                if (!m_modelPipelineStates[ForwardScope] || !m_modelPipelineStates[ForwardScope]->IsInitialized())
                 {
                     AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for shader");
                     return;
@@ -446,7 +446,7 @@ namespace AtomSampleViewer
             }
 
             m_copyTexturePipelineState = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_copyTexturePipelineState)
+            if (!m_copyTexturePipelineState || !m_copyTexturePipelineState->IsInitialized())
             {
                 AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for copy texture");
                 return;
@@ -481,7 +481,7 @@ namespace AtomSampleViewer
             }
 
             m_luminancePipelineState = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_luminancePipelineState)
+            if (!m_luminancePipelineState || !m_luminancePipelineState->IsInitialized())
             {
                 AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for luminance map");
                 return;
@@ -495,7 +495,7 @@ namespace AtomSampleViewer
             shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
 
             m_luminanceReducePipelineState = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_luminanceReducePipelineState)
+            if (!m_luminanceReducePipelineState || !m_luminanceReducePipelineState->IsInitialized())
             {
                 AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for luminance reduce");
                 return;
@@ -509,7 +509,7 @@ namespace AtomSampleViewer
             shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
 
             m_tonemappingPipelineState = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_tonemappingPipelineState)
+            if (!m_tonemappingPipelineState || !m_tonemappingPipelineState->IsInitialized())
             {
                 AZ_Error(AsyncCompute::sampleName, false, "Failed to acquire default pipeline state for tonemapping");
                 return;

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -444,7 +444,7 @@ namespace AtomSampleViewer
                 pipelineStateDescriptor.m_renderStates.m_depthStencilState.m_depth.m_enable = true;
 
                 m_pipelineState = m_shader->AcquirePipelineState(pipelineStateDescriptor);
-                AZ_Assert(m_pipelineState, "Failed to acquire default pipeline state for shader");
+                AZ_Assert(m_pipelineState && m_pipelineState->IsInitialized(), "Failed to acquire default pipeline state for shader");
             }
         }
 

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -179,7 +179,7 @@ namespace AtomSampleViewer
         }
 
         m_dispatchPipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_dispatchPipelineState)
+        if (!m_dispatchPipelineState || !m_dispatchPipelineState->IsInitialized())
         {
             AZ_Error(s_computeExampleName, false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;
@@ -214,7 +214,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_drawPipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_drawPipelineState)
+        if (!m_drawPipelineState || !m_drawPipelineState->IsInitialized())
         {
             AZ_Error(s_computeExampleName, false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -177,7 +177,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_pipelineState)
+            if (!m_pipelineState || !m_pipelineState->IsInitialized())
             {
                 AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", copyQueueShaderFilePath);
                 return;

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -158,7 +158,7 @@ namespace AtomSampleViewer
         pipelineDesc.m_renderStates.m_blendState.m_targets[0].m_blendOp = RHI::BlendOp::Add;
 
         m_pipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineState)
+        if (!m_pipelineState || !m_pipelineState->IsInitialized())
         {
             AZ_Error(s_dualSourceBlendingName, false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -268,7 +268,7 @@ namespace AtomSampleViewer
             drawPipelineStateDescriptor.m_renderStates.m_depthStencilState = AZ::RHI::DepthStencilState::CreateDepth();
 
             m_drawPipelineState = shader->AcquirePipelineState(drawPipelineStateDescriptor);
-            if (!m_drawPipelineState)
+            if (!m_drawPipelineState || !m_drawPipelineState->IsInitialized())
             {
                 AZ_Error(IndirectRendering::SampleName, false, "Failed to acquire default pipeline state for shader '%s'", IndirectDrawShaderFilePath);
                 return;
@@ -297,7 +297,7 @@ namespace AtomSampleViewer
             shader->GetVariant(m_indirectDispatchShaderVariantStableId).ConfigurePipelineState(computePipelineStateDescriptor);
 
             m_cullPipelineState = shader->AcquirePipelineState(computePipelineStateDescriptor);
-            if (!m_cullPipelineState)
+            if (!m_cullPipelineState || !m_cullPipelineState->IsInitialized())
             {
                 AZ_Error(IndirectRendering::SampleName, false, "Failed to acquire default pipeline state for shader '%s'", IndirectDispatchShaderFilePath);
                 return;

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
@@ -187,7 +187,7 @@ namespace AtomSampleViewer
         }
 
         m_dispatchPipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_dispatchPipelineState)
+        if (!m_dispatchPipelineState || !m_dispatchPipelineState->IsInitialized())
         {
             AZ_Error(InputAssembly::SampleName, false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;
@@ -218,7 +218,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_drawPipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_drawPipelineState)
+        if (!m_drawPipelineState || !m_drawPipelineState->IsInitialized())
         {
             AZ_Error(InputAssembly::SampleName, false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -120,7 +120,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_pipelineStates[0] = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineStates[0])
+        if (!m_pipelineStates[0] || !m_pipelineStates[0]->IsInitialized())
         {
             AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", MRTTargetShaderFilePath);
             return;
@@ -154,7 +154,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_pipelineStates[1] = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineStates[1])
+        if (!m_pipelineStates[1] || !m_pipelineStates[1]->IsInitialized())
         {
             AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", MRTScreenShaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -270,7 +270,7 @@ namespace AtomSampleViewer
 
         auto& pipeline = m_pipelineStates[static_cast<uint32_t>(type)];
         pipeline = m_triangleShader->AcquirePipelineState(pipelineStateDescriptor);
-        if (!pipeline)
+        if (!pipeline || !pipeline->IsInitialized())
         {
             AZ_Error(SampleName, false, "Failed to acquire default pipeline state for shader '%s'", TriangeShaderFilePath);
             return;
@@ -402,7 +402,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_customResolveMSAAPipelineState = m_customMSAAResolveShader->AcquirePipelineState(pipelineStateDescriptor);
-        if (!m_customResolveMSAAPipelineState)
+        if (!m_customResolveMSAAPipelineState || !m_customResolveMSAAPipelineState->IsInitialized())
         {
             AZ_Error(SampleName, false, "Failed to acquire default pipeline state for shader '%s'", CustomResolveShaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -293,7 +293,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_pipelineState)
+            if (!m_pipelineState || !m_pipelineState->IsInitialized())
             {
                 AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", triangeShaderFilePath);
                 return;

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -233,7 +233,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_pipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineState)
+        if (!m_pipelineState || !m_pipelineState->IsInitialized())
         {
             AZ_Error("MultiThreadComponent", false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -332,7 +332,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_pipelineStates[0] = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineStates[0])
+        if (!m_pipelineStates[0] || !m_pipelineStates[0]->IsInitialized())
         {
             AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", depthShaderFilePath);
             return;
@@ -369,7 +369,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_pipelineStates[1] = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineStates[1])
+        if (!m_pipelineStates[1] || !m_pipelineStates[1]->IsInitialized())
         {
             AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", shadowShaderFilePath);
             return;

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -243,7 +243,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to create draw render attachment layout");
 
         m_drawPipelineState = drawShader->AcquirePipelineState(pipelineDesc);
-        AZ_Assert(m_drawPipelineState, "Failed to acquire draw pipeline state");
+        AZ_Assert(m_drawPipelineState && m_drawPipelineState->IsInitialized(), "Failed to acquire draw pipeline state");
 
         m_drawSRG = CreateShaderResourceGroup(drawShader, "BufferSrg", RayTracingExampleName);
     }
@@ -290,7 +290,7 @@ namespace AtomSampleViewer
 
         // global pipeline state and srg
         m_globalPipelineState = m_rayGenerationShader->AcquirePipelineState(rayGenerationShaderDescriptor);
-        AZ_Assert(m_globalPipelineState, "Failed to acquire ray tracing global pipeline state");
+        AZ_Assert(m_globalPipelineState && m_globalPipelineState->IsInitialized(), "Failed to acquire ray tracing global pipeline state");
         m_globalSrg = CreateShaderResourceGroup(m_rayGenerationShader, "RayTracingGlobalSrg", RayTracingExampleName);
 
         // build the ray tracing pipeline state descriptor

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -179,7 +179,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_demoPipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_demoPipelineState)
+            if (!m_demoPipelineState || !m_demoPipelineState->IsInitialized())
             {
                 AZ_Error(SHExampleComponent::sampleName, false, "Failed to acquire default pipeline state for shader '%s'", SHExampleComponent::demoShaderFilePath);
                 return;
@@ -223,7 +223,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_renderPipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_renderPipelineState)
+            if (!m_renderPipelineState || !m_renderPipelineState->IsInitialized())
             {
                 AZ_Error(SHExampleComponent::sampleName, false, "Failed to acquire default pipeline state for shader '%s'", SHExampleComponent::demoShaderFilePath);
                 return;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -265,7 +265,7 @@ namespace AtomSampleViewer
 
                 pipelineDesc.m_renderStates.m_rasterState.m_cullMode = modelData.m_modelType == ModelType_Plane ? RHI::CullMode::None : RHI::CullMode::Back;
                 modelData.m_pipelineState = shader->AcquirePipelineState(pipelineDesc);
-                if (!modelData.m_pipelineState)
+                if (!modelData.m_pipelineState || !modelData.m_pipelineState->IsInitialized())
                 {
                     AZ_Error(SubpassInputExample::SampleName, false, "Failed to acquire default pipeline state for shader");
                     return;
@@ -291,7 +291,7 @@ namespace AtomSampleViewer
 
             // Composition Pipeline
             m_compositionPipeline = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_compositionPipeline)
+            if (!m_compositionPipeline || !m_compositionPipeline->IsInitialized())
             {
                 AZ_Error(SubpassInputExample::SampleName, false, "Failed to acquire composition pipeline state for shader");
                 return;

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -162,7 +162,7 @@ namespace AtomSampleViewer
             pipelineStateDescriptor.m_inputStreamLayout.SetTopology(AZ::RHI::PrimitiveTopology::TriangleStrip);
             pipelineStateDescriptor.m_inputStreamLayout.Finalize();
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_pipelineState)
+            if (!m_pipelineState || !m_pipelineState->IsInitialized())
             {
                 AZ_Error("Render", false, "Failed to acquire default pipeline state for shader %s", texture3dShaderFilePath);
             }

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -121,7 +121,9 @@ namespace AtomSampleViewer
             AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_pipelineState = m_shader->AcquirePipelineState(pipelineStateDescriptor);
-            AZ_Error(InternalTA::SampleName, m_pipelineState, "Failed for the appropriate acquire default pipeline state for shader '%s'", InternalTA::ShaderFilePath);
+            AZ_Error(
+                InternalTA::SampleName, m_pipelineState && m_pipelineState->IsInitialized(),
+                "Failed for the appropriate acquire default pipeline state for shader '%s'", InternalTA::ShaderFilePath);
         }
 
         // Setup input buffer stream

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -147,7 +147,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_pipelineState)
+            if (!m_pipelineState || !m_pipelineState->IsInitialized())
             {
                 AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", triangeShaderFilePath);
                 return;

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -145,7 +145,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_pipelineState)
+            if (!m_pipelineState || !m_pipelineState->IsInitialized())
             {
                 AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", triangeShaderFilePath);
                 return;

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -206,7 +206,9 @@ namespace AtomSampleViewer
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
 
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            AZ_Assert(m_pipelineState, "Failed to acquire default pipeline state for shader '%s'", triangeShaderFilePath);
+            AZ_Assert(
+                m_pipelineState && m_pipelineState->IsInitialized(), "Failed to acquire default pipeline state for shader '%s'",
+                triangeShaderFilePath);
 
             m_shaderResourceGroup = CreateShaderResourceGroup(shader, "TriangleSrg", s_trianglesConstantBufferExampleName);
         }

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
@@ -370,7 +370,7 @@ namespace AtomSampleViewer
             pipelineDesc.m_inputStreamLayout = m_inputStreamLayout;
 
             m_modelPipelineState[0] = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_modelPipelineState[0])
+            if (!m_modelPipelineState[0] || !m_modelPipelineState[0]->IsInitialized())
             {
                 AZ_Error(VariableRateShading::SampleName, false, "Failed to acquire default pipeline state for shader");
                 return;
@@ -386,7 +386,7 @@ namespace AtomSampleViewer
             pipelineDesc.m_renderAttachmentConfiguration.m_renderAttachmentLayout = rateRenderAttachmentLayout;
 
             m_modelPipelineState[1] = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_modelPipelineState[1])
+            if (!m_modelPipelineState[1] || !m_modelPipelineState[1]->IsInitialized())
             {
                 AZ_Error(VariableRateShading::SampleName, false, "Failed to acquire default pipeline state for shader");
                 return;
@@ -399,7 +399,7 @@ namespace AtomSampleViewer
             shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId).ConfigurePipelineState(pipelineDesc);
 
             m_computePipelineState = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_computePipelineState)
+            if (!m_computePipelineState || !m_computePipelineState->IsInitialized())
             {
                 AZ_Error(VariableRateShading::SampleName, false, "Failed to acquire default pipeline state for compute");
                 return;
@@ -432,7 +432,7 @@ namespace AtomSampleViewer
             targetBlendState.m_blendOp = RHI::BlendOp::Add;
 
             m_imagePipelineState = shader->AcquirePipelineState(pipelineDesc);
-            if (!m_imagePipelineState)
+            if (!m_imagePipelineState || !m_imagePipelineState->IsInitialized())
             {
                 AZ_Error(VariableRateShading::SampleName, false, "Failed to acquire default pipeline state for shader");
                 return;

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -268,7 +268,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == AZ::RHI::ResultCode::Success, "Failed to create render attachment layout");
 
         m_pipelineState = shader->AcquirePipelineState(pipelineDesc);
-        if (!m_pipelineState)
+        if (!m_pipelineState || !m_pipelineState->IsInitialized())
         {
             AZ_Error("XRExampleComponent", false, "Failed to acquire default pipeline state for shader '%s'", shaderFilePath);
             return;

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -124,7 +124,7 @@ namespace AtomSampleViewer
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
             m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!m_pipelineState)
+            if (!m_pipelineState || !m_pipelineState->IsInitialized())
             {
                 AZ_Error("Render", false, "Failed to acquire default pipeline state for shader %s", shaderFilepath);
             }

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -82,7 +82,7 @@ namespace AtomSampleViewer
             pipelineStateDescriptor.m_inputStreamLayout.Finalize();
 
             pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!pipelineState)
+            if (!pipelineState || !pipelineState->IsInitialized())
             {
                 AZ_Error("Render", false, "Failed to acquire default pipeline state for shader %s", shaderFilepath);
             }

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -232,7 +232,7 @@ namespace AtomSampleViewer
             pipelineStateDescriptor.m_inputStreamLayout.Finalize();
 
             pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
-            if (!pipelineState)
+            if (!pipelineState || !pipelineState->IsInitialized())
             {
                 AZ_Error("Render", false, "Failed to acquire default pipeline state for shader %s", shaderFilepath);
             }


### PR DESCRIPTION
## What does this PR do?

Calls to Shader::AcquirePipelineState should check if IsInitialized == true, not just check for null, because if the pipeline state fails to compile it will return a non-null value that is uninitialized.

## How was this PR tested?
Ran ASV tests and the editor.