### PR TITLE
New AutomatedNightlyTestSuite for ASV AR.

### DIFF
--- a/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
+++ b/Standalone/PythonTests/Automated/benchmark_runner_periodic_suite.py
@@ -11,7 +11,6 @@ import subprocess
 import pytest
 
 import ly_test_tools.environment.process_utils as process_utils
-import ly_test_tools.launchers.platforms.base
 from ly_test_tools.benchmark.data_aggregator import BenchmarkDataAggregator
 
 logger = logging.getLogger(__name__)
@@ -23,7 +22,7 @@ class AtomSampleViewerException(Exception):
 
 
 @pytest.mark.parametrize('launcher_platform', ['windows'])
-@pytest.mark.parametrize("project", ["AtomSampleViewer"])
+@pytest.mark.parametrize("project", ["o3de-atom-sampleviewer"])
 @pytest.mark.parametrize('rhi', ['dx12', 'vulkan'])
 @pytest.mark.usefixtures("clean_atomsampleviewer_logs", "atomsampleviewer_log_monitor")
 class TestPerformanceBenchmarksPeriodicSuite:
@@ -52,5 +51,5 @@ class TestPerformanceBenchmarksPeriodicSuite:
 
             aggregator = BenchmarkDataAggregator(workspace, logger, 'periodic')
             aggregator.upload_metrics(rhi)
-        except ly_test_tools.log.log_monitor.LogMonitorException as e:
+        except atomsampleviewer_log_monitor.log_monitor.LogMonitorException as e:
             raise AtomSampleViewerException(f'Data capturing did not complete in time for RHI {rhi}, got error: {e}')

--- a/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
+++ b/Standalone/PythonTests/Automated/test_AtomSampleViewer_main_suite.py
@@ -11,7 +11,6 @@ import subprocess
 import pytest
 
 import ly_test_tools.environment.process_utils as process_utils
-import ly_test_tools.launchers.platforms.base
 
 logger = logging.getLogger(__name__)
 
@@ -22,14 +21,14 @@ class AtomSampleViewerException(Exception):
 
 
 @pytest.mark.parametrize('launcher_platform', ['windows'])
-@pytest.mark.parametrize("project", ["AtomSampleViewer"])
+@pytest.mark.parametrize("project", ["o3de-atom-sampleviewer"])
 @pytest.mark.parametrize('rhi', ['dx12', 'vulkan'])
 @pytest.mark.usefixtures("clean_atomsampleviewer_logs", "atomsampleviewer_log_monitor")
 class TestAutomationMainSuite:
 
     def test_AutomatedReviewTestSuite(self, request, workspace, launcher_platform, rhi, atomsampleviewer_log_monitor):
         # Script call setup.
-        test_script = '_FullTestSuite_.bv.lua'
+        test_script = '_AutomatedNightlyTestSuite_.bv.lua'
         test_script_path = os.path.join(workspace.paths.project(), 'scripts', test_script)
         if not os.path.exists(test_script_path):
             raise AtomSampleViewerException(f'Test script does not exist in path: {test_script_path}')
@@ -53,7 +52,7 @@ class TestAutomationMainSuite:
                                 "Traceback (most recent call last):"]
             atomsampleviewer_log_monitor.monitor_log_for_lines(
                 unexpected_lines=unexpected_lines, halt_on_unexpected=True, timeout=400)
-        except ly_test_tools.log.log_monitor.LogMonitorException as e:
+        except atomsampleviewer_log_monitor.LogMonitorException as e:
             expected_screenshots_path = os.path.join(
                 workspace.paths.project(), "scripts", "ExpectedScreenshots")
             test_screenshots_path = os.path.join(

--- a/Standalone/PythonTests/conftest.py
+++ b/Standalone/PythonTests/conftest.py
@@ -13,8 +13,8 @@ import types
 
 import pytest
 
-import ly_test_tools.builtin.helpers as helpers
 import ly_test_tools.environment.file_system as file_system
+import ly_test_tools.launchers.platforms.base
 import ly_test_tools.log.log_monitor
 
 logger = logging.getLogger(__name__)

--- a/scripts/_FullTestSuite_.bv.lua
+++ b/scripts/_FullTestSuite_.bv.lua
@@ -72,6 +72,7 @@ tests= {
     RunScriptWrapper('scripts/ReadbackTest.bv.luac'),
     RunScriptWrapper('scripts/depthoffieldtest.bv.luac'),
     RunScriptWrapper('scripts/exposuretest.bv.luac'),
+    RunScriptWrapper('scripts/shaderreloadsoaktest.bv.luac'),
 
     --Fast checking for the samples which don't have a test. Samples should be removed from this list once they have their own tests
 


### PR DESCRIPTION
Changes:
- Adds the new `_AutomatedNightlyTestSuite_.bv.lua` test file which targets specific reliable tests for use with ASV AR.
- It also adds the `ShaderReloadSoakTest` to the `_FullTestSuite_.bv.lua` test file as requested in the original internal JIRA request (can't link here). The intent is that `ShaderReloadSoakTest` and `MaterialHotReloadTest ` are not part of this new `_AutomatedNightlyTestSuite_.bv.lua` test file but remain as part of the `_FullTestSuite_.bv.lua` test file.

Some important notes about this PR:
- Currently there is a blocker that prevents the merging of this code until it is fixed. This blocker is also causing our current ASV AR setup for the development branch to fail until it is fixed: https://github.com/o3de/o3de-atom-sampleviewer/pull/616
- This will be taken out of Draft PR mode once that fix is merged and the stabilization branch its merged to is then merged to the development branch.
- I did a pseudo test of this code by replacing the `AtomSampleViewerStandalone.exe` with `AtomSampleViewer.GameLauncher.exe` and it mostly worked, other than the CLI args. So, in theory, this code should run as expected once the issue with the AtomSampleViewerStandalone target is resolved.