### PR TITLE
Move StreamingImage sample's render the images to 2dpass instead of forward pass

### DIFF
--- a/Shaders/StreamingImageExample/Image3d.azsl
+++ b/Shaders/StreamingImageExample/Image3d.azsl
@@ -6,7 +6,8 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/Features/ColorManagement/TransformColor.azsli>
 
 ShaderResourceGroup ImageSrg : SRG_PerDraw
 {
@@ -33,8 +34,6 @@ struct VSOutput
 struct PSOutput
 {
     float4 m_color : SV_Target0;
-    float4 m_specular : SV_Target1;
-    float4 m_scatterDistance : SV_Target2;
 };
 
 VSOutput MainVS(VSInput vsInput)
@@ -63,10 +62,9 @@ PSOutput MainPS(VSOutput psInput)
     uint numberOfLevels;
     ImageSrg::m_texture3D.GetDimensions(0, width, height, depth, numberOfLevels);
 
-    OUT.m_color = ImageSrg::m_texture3D.Load(int4(width * psInput.m_uv.x, height * psInput.m_uv.y, psInput.slice, 0));
+    float3 texColor = ImageSrg::m_texture3D.Load(int4(width * psInput.m_uv.x, height * psInput.m_uv.y, psInput.slice, 0)).xyz;
+    OUT.m_color = float4(TransformColor(texColor, ColorSpaceId::LinearSRGB, ColorSpaceId::SRGB), 1.0);
     
-    OUT.m_specular = float4(0,0,0,1);
-    OUT.m_scatterDistance = float4(0,0,0,0);
     return OUT;
 }
 

--- a/Shaders/StreamingImageExample/Image3d.shader
+++ b/Shaders/StreamingImageExample/Image3d.shader
@@ -5,7 +5,7 @@
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }
     },
 
-    "DrawList" : "forward",
+    "DrawList" : "2dpass",
 
     "ProgramSettings":
     {

--- a/Shaders/StreamingImageExample/ImageMips.azsl
+++ b/Shaders/StreamingImageExample/ImageMips.azsl
@@ -83,7 +83,7 @@ PSOutput MainPS(VSOutput psInput)
     }
     else
     {
-		float3 texColor = ImageMipsSrg::m_texture.SampleLevel(ImageMipsSrg::m_sampler, psInput.m_uvlod.xy, psInput.m_uvlod.z).xyz;
+        float3 texColor = ImageMipsSrg::m_texture.SampleLevel(ImageMipsSrg::m_sampler, psInput.m_uvlod.xy, psInput.m_uvlod.z).xyz;
         OUT.m_color = float4(TransformColor(texColor, ColorSpaceId::LinearSRGB, ColorSpaceId::SRGB), 1.0);
     }
     return OUT;

--- a/Shaders/StreamingImageExample/ImageMips.azsl
+++ b/Shaders/StreamingImageExample/ImageMips.azsl
@@ -6,7 +6,8 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/Features/ColorManagement/TransformColor.azsli>
 
 ShaderResourceGroup ImageMipsSrg : SRG_PerDraw
 {
@@ -18,6 +19,8 @@ ShaderResourceGroup ImageMipsSrg : SRG_PerDraw
     Sampler m_sampler
     {
         MaxAnisotropy = 16;
+        MinFilter = Linear;
+        MagFilter = Linear;
         AddressU = Wrap;
         AddressV = Wrap;
         AddressW = Wrap;
@@ -39,8 +42,6 @@ struct VSOutput
 struct PSOutput
 {
     float4 m_color : SV_Target0;
-    float4 m_specular : SV_Target1;
-    float4 m_scatterDistance : SV_Target2;
 };
 
 VSOutput MainVS(VSInput vsInput)
@@ -78,14 +79,13 @@ PSOutput MainPS(VSOutput psInput)
     PSOutput OUT;
     if (psInput.m_uvlod.z < 0)
     {
-         OUT.m_color = float4(1.0, 1.0, 1.0, 1.0);
+        OUT.m_color = float4(1.0, 1.0, 1.0, 1.0);
     }
     else
     {
-         OUT.m_color = ImageMipsSrg::m_texture.SampleLevel(ImageMipsSrg::m_sampler, psInput.m_uvlod.xy, psInput.m_uvlod.z);
+		float3 texColor = ImageMipsSrg::m_texture.SampleLevel(ImageMipsSrg::m_sampler, psInput.m_uvlod.xy, psInput.m_uvlod.z).xyz;
+        OUT.m_color = float4(TransformColor(texColor, ColorSpaceId::LinearSRGB, ColorSpaceId::SRGB), 1.0);
     }
-    OUT.m_specular = float4(0,0,0,1);
-    OUT.m_scatterDistance = float4(0,0,0,0);
     return OUT;
 }
 

--- a/Shaders/StreamingImageExample/ImageMips.shader
+++ b/Shaders/StreamingImageExample/ImageMips.shader
@@ -5,7 +5,7 @@
         "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }
     },
 
-    "DrawList" : "forward",
+    "DrawList" : "2dpass",
 
     "ProgramSettings":
     {

--- a/scripts/ExpectedScreenshots/StreamingImage/HotReloading.png
+++ b/scripts/ExpectedScreenshots/StreamingImage/HotReloading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c58cfb1b20c07df14f477617576418f552ff259c701f8d4f92eecf868777fcab
-size 417046
+oid sha256:3cfd0fcee2ea7e7516a60c5d49b8efe35451e809470dff8f744f529d85c7c87e
+size 438537

--- a/scripts/ExpectedScreenshots/StreamingImage/Streaming2dImages.png
+++ b/scripts/ExpectedScreenshots/StreamingImage/Streaming2dImages.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:793817b205eea350db69390981d5f8e7b191c1462e65c9cbd9ca8f2b7f118287
-size 417046
+oid sha256:bd8ec243546731e387bd2915c6dc8a6aa1a3fe31e3a17f3cb4e60cf850fc3415
+size 438550

--- a/scripts/ExpectedScreenshots/StreamingImage/Streaming3dImage.png
+++ b/scripts/ExpectedScreenshots/StreamingImage/Streaming3dImage.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06ee38c78238350fab1efcdcd0b7b97fcbbf0dd352c4999eba957e883d1bb698
-size 146751
+oid sha256:5331071066fb9b1845a729bc7568294d77a9ac56ed4ff6d2e0bf5dba4bc19bca
+size 150732


### PR DESCRIPTION
The LowEndPipeline and the other pipelines don't have forward pass (a pass with 'forward' drawlistTag). This cause issue for StreamingImage sample which renders the images using 'forward' DrawListTag.

The PR changed the shader files to use 2dpass DrawListTag which it would render to 2DPass. And all the render pipelines include this pass. 

Also updated the shader so it renders in sRGB colorspace since the 2D pass is after display mapping. The screenshots are updated to show textures with its originally color.