### PR TITLE
Making changes to allow gems to create and register sample components in ASV

### DIFF
--- a/Gem/Code/Source/Automation/ScriptManager.cpp
+++ b/Gem/Code/Source/Automation/ScriptManager.cpp
@@ -39,20 +39,23 @@
 
 namespace AtomSampleViewer
 {
-    ScriptManager* ScriptManager::s_instance = nullptr;
-
     ScriptManager::ScriptManager()
         : m_scriptBrowser("@user@/lua_script_browser.xml")
     {
     }
 
+    ScriptManager* ScriptManager::GetInstance()
+    {
+        static ScriptManager* s_instance = nullptr;
+        if (!s_instance)
+        {
+            AtomSampleViewer::SampleComponentSingletonRequestBus::BroadcastResult(s_instance, &AtomSampleViewer::SampleComponentSingletonRequestBus::Events::GetScriptManagerInstance);
+        }
+        return s_instance;
+    }
+
     void ScriptManager::Activate()
     {
-        AZ_Assert(s_instance == nullptr, "ScriptManager is already activated");
-        s_instance = this;
-
-        ScriptableImGui::Create();
-
         m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
         m_sriptBehaviorContext = AZStd::make_unique<AZ::BehaviorContext>();
         ReflectScriptContext(m_sriptBehaviorContext.get());
@@ -73,11 +76,9 @@ namespace AtomSampleViewer
 
     void ScriptManager::Deactivate()
     {
-        s_instance = nullptr;
         m_scriptContext = nullptr;
         m_sriptBehaviorContext = nullptr;
         m_scriptBrowser.Deactivate();
-        ScriptableImGui::Destory();
         m_imageComparisonOptions.Deactivate();
         ScriptRunnerRequestBus::Handler::BusDisconnect();
         ScriptRepeaterRequestBus::Handler::BusDisconnect();
@@ -933,6 +934,8 @@ namespace AtomSampleViewer
 
     void ScriptManager::ExecuteScript(const AZStd::string& scriptFilePath)
     {
+        ScriptManager* s_instance = GetInstance();
+
         AZ::Data::Asset<AZ::ScriptAsset> scriptAsset = AZ::RPI::AssetUtils::LoadAssetByProductPath<AZ::ScriptAsset>(scriptFilePath.c_str());
         if (!scriptAsset)
         {
@@ -956,7 +959,7 @@ namespace AtomSampleViewer
         // Execute(script) will add commands to the m_scriptOperations. These should be considered part of their own test script, for reporting purposes.
         s_instance->m_scriptOperations.push([scriptFilePath]()
             {
-                s_instance->m_scriptReporter.PushScript(scriptFilePath);
+                GetInstance()->m_scriptReporter.PushScript(scriptFilePath);
             }
         );
 
@@ -982,8 +985,8 @@ namespace AtomSampleViewer
         s_instance->m_scriptOperations.push([]()
             {
                 // We don't call m_scriptReporter.PopScript() yet because some cleanup needs to happen in TickScript() on the next frame.
-                AZ_Assert(!s_instance->m_shouldPopScript, "m_shouldPopScript is already true");
-                s_instance->m_shouldPopScript = true;
+                AZ_Assert(!GetInstance()->m_shouldPopScript, "m_shouldPopScript is already true");
+                GetInstance()->m_shouldPopScript = true;
             }
         );
     }
@@ -1134,8 +1137,7 @@ namespace AtomSampleViewer
         {
             ReportScriptError(message.c_str());
         };
-
-        s_instance->m_scriptOperations.push(AZStd::move(func));
+        GetInstance()->m_scriptOperations.push(AZStd::move(func));
     }
 
     void ScriptManager::Script_Warning(const AZStd::string& message)
@@ -1144,8 +1146,7 @@ namespace AtomSampleViewer
         {
             ReportScriptWarning(message.c_str());
         };
-
-        s_instance->m_scriptOperations.push(AZStd::move(func));
+        GetInstance()->m_scriptOperations.push(AZStd::move(func));
     }
 
     void ScriptManager::Script_Print(const AZStd::string& message [[maybe_unused]])
@@ -1156,7 +1157,7 @@ namespace AtomSampleViewer
             AZ_TracePrintf("Automation", "Script: %s\n", message.c_str());
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(func));
+        GetInstance()->m_scriptOperations.push(AZStd::move(func));
 #endif
     }
 
@@ -1176,8 +1177,6 @@ namespace AtomSampleViewer
     {
         auto operation = [sampleName]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
             if (sampleName.empty())
             {
                 SampleComponentManagerRequestBus::Broadcast(&SampleComponentManagerRequests::Reset);
@@ -1194,13 +1193,13 @@ namespace AtomSampleViewer
                     // They need 1 frame to activate, 1 frame to start ticking, and 1 frame to guarantee
                     // that a sample OnTick occurs before a ScriptManager::OnTick. We schedule
                     // a few extra just in case.
-                    AZ_Assert(s_instance->m_scriptIdleFrames == 0, "m_scriptIdleFrames is being stomped");
-                    s_instance->m_scriptIdleFrames = 6;
+                    AZ_Assert(GetInstance()->m_scriptIdleFrames == 0, "m_scriptIdleFrames is being stomped");
+                    GetInstance()->m_scriptIdleFrames = 6;
                 }
             }
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_ShowTool(const AZStd::string& toolName, bool enable)
@@ -1213,68 +1212,60 @@ namespace AtomSampleViewer
             AZ_Warning("ScriptManager", foundTool, "Can't find [%s] tool", toolName.c_str());
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_RunScript(const AZStd::string& scriptFilePath)
     {
         // Unlike other Script_ callback functions, we process immediately instead of pushing onto the m_scriptOperations queue.
         // This function is special because running the script is what adds more commands onto the m_scriptOperations queue.
-        s_instance->ExecuteScript(scriptFilePath);
+        GetInstance()->ExecuteScript(scriptFilePath);
     }
 
     void ScriptManager::Script_IdleFrames(int numFrames)
     {
         auto operation = [numFrames]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
-            AZ_Assert(s_instance->m_scriptIdleFrames == 0, "m_scriptIdleFrames is being stomped");
-            s_instance->m_scriptIdleFrames = numFrames;
+            AZ_Assert(GetInstance()->m_scriptIdleFrames == 0, "m_scriptIdleFrames is being stomped");
+            GetInstance()->m_scriptIdleFrames = numFrames;
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_IdleSeconds(float numSeconds)
     {
         auto operation = [numSeconds]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
-            s_instance->m_scriptIdleSeconds = numSeconds;
+            GetInstance()->m_scriptIdleSeconds = numSeconds;
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_LockFrameTime(float seconds)
     {
         auto operation = [seconds]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
             AZ::TimeUs us = AZ::SecondsToTimeUs(seconds);
             
             AZ::CVarFixedString commandString = AZ::CVarFixedString::format("t_simulationTickDeltaOverride %" PRId64, static_cast<int64_t>(us));
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(commandString.c_str());
-            s_instance->m_frameTimeIsLocked = true;
+            GetInstance()->m_frameTimeIsLocked = true;
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_UnlockFrameTime()
     {
         auto operation = []()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand("t_simulationTickDeltaOverride 0");
-            s_instance->m_frameTimeIsLocked = false;
+            GetInstance()->m_frameTimeIsLocked = false;
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_SetImguiValue(AZ::ScriptDataContext& dc)
@@ -1306,7 +1297,7 @@ namespace AtomSampleViewer
                 ScriptableImGui::SetBool(fieldNameString, value);
             };
 
-            s_instance->m_scriptOperations.push(AZStd::move(func));
+            GetInstance()->m_scriptOperations.push(AZStd::move(func));
         }
         else if (dc.IsNumber(1))
         {
@@ -1318,7 +1309,7 @@ namespace AtomSampleViewer
                 ScriptableImGui::SetNumber(fieldNameString, value);
             };
 
-            s_instance->m_scriptOperations.push(AZStd::move(func));
+            GetInstance()->m_scriptOperations.push(AZStd::move(func));
         }
         else if (dc.IsString(1))
         {
@@ -1332,7 +1323,7 @@ namespace AtomSampleViewer
                 ScriptableImGui::SetString(fieldNameString, valueString);
             };
 
-            s_instance->m_scriptOperations.push(AZStd::move(func));
+            GetInstance()->m_scriptOperations.push(AZStd::move(func));
         }
         else if (dc.IsClass<AZ::Vector3>(1))
         {
@@ -1344,7 +1335,7 @@ namespace AtomSampleViewer
                 ScriptableImGui::SetVector(fieldNameString, value);
             };
 
-            s_instance->m_scriptOperations.push(AZStd::move(func));
+            GetInstance()->m_scriptOperations.push(AZStd::move(func));
         }
         else if (dc.IsClass<AZ::Vector2>(1))
         {
@@ -1356,7 +1347,7 @@ namespace AtomSampleViewer
                 ScriptableImGui::SetVector(fieldNameString, value);
             };
 
-            s_instance->m_scriptOperations.push(AZStd::move(func));
+            GetInstance()->m_scriptOperations.push(AZStd::move(func));
         }
     }
 
@@ -1372,11 +1363,11 @@ namespace AtomSampleViewer
             }
             else
             {
-                s_instance->ReportScriptError("ResizeViewport() is not supported on this platform");
+                GetInstance()->ReportScriptError("ResizeViewport() is not supported on this platform");
             }
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_ExecuteConsoleCommand(const AZStd::string& command)
@@ -1386,7 +1377,7 @@ namespace AtomSampleViewer
             AZ::Interface<AZ::IConsole>::Get()->PerformCommand(command.c_str());
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::SetShowImGui(bool show)
@@ -1407,10 +1398,10 @@ namespace AtomSampleViewer
     {
         auto operation = [show]()
         {
-            s_instance->SetShowImGui(show);
+            GetInstance()->SetShowImGui(show);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     bool ScriptManager::PrepareForScreenCapture(const AZStd::string& imageName)
@@ -1437,6 +1428,7 @@ namespace AtomSampleViewer
             return false;
         }
 
+        ScriptManager* s_instance = GetInstance();
         s_instance->m_scriptReporter.AddScreenshotTest(imageName);
 
         s_instance->m_isCapturePending = true;
@@ -1453,7 +1445,7 @@ namespace AtomSampleViewer
                 &AZ::Render::FrameCaptureTestRequestBus::Events::SetScreenshotFolder, screenshotFolder);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_SetTestEnvPath(const AZStd::string& envPath)
@@ -1464,7 +1456,7 @@ namespace AtomSampleViewer
                 &AZ::Render::FrameCaptureTestRequestBus::Events::SetTestEnvPath, envPath);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_SetOfficialBaselineImageFolder(const AZStd::string& baselineFolder)
@@ -1475,7 +1467,7 @@ namespace AtomSampleViewer
                 &AZ::Render::FrameCaptureTestRequestBus::Events::SetOfficialBaselineImageFolder, baselineFolder);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_SetLocalBaselineImageFolder(const AZStd::string& baselineFolder)
@@ -1486,17 +1478,17 @@ namespace AtomSampleViewer
                 &AZ::Render::FrameCaptureTestRequestBus::Events::SetLocalBaselineImageFolder, baselineFolder);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_SelectImageComparisonToleranceLevel(const AZStd::string& presetName)
     {
         auto operation = [presetName]()
         {
-            s_instance->m_imageComparisonOptions.SelectToleranceLevel(presetName);
+            GetInstance()->m_imageComparisonOptions.SelectToleranceLevel(presetName);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_CaptureScreenshot(const AZStd::string& imageName)
@@ -1505,6 +1497,8 @@ namespace AtomSampleViewer
 
         auto operation = [imageName]()
         {
+            ScriptManager* s_instance = GetInstance();
+
             // Note this will pause the script until the capture is complete
             if (PrepareForScreenCapture(imageName))
             {
@@ -1544,16 +1538,17 @@ namespace AtomSampleViewer
             }
         };
 
+        ScriptManager* s_instance = GetInstance();
         s_instance->m_scriptOperations.push(AZStd::move(operation));
         s_instance->m_scriptOperations.push([]()
             {
-                s_instance->m_scriptReporter.CheckLatestScreenshot(s_instance->m_imageComparisonOptions.GetCurrentToleranceLevel());
+                GetInstance()->m_scriptReporter.CheckLatestScreenshot(GetInstance()->m_imageComparisonOptions.GetCurrentToleranceLevel());
             });
 
         // restore imgui show/hide
         s_instance->m_scriptOperations.push([]()
             {
-                s_instance->SetShowImGui(s_instance->m_prevShowImGui);
+                GetInstance()->SetShowImGui(GetInstance()->m_prevShowImGui);
             });
 
     }
@@ -1564,6 +1559,8 @@ namespace AtomSampleViewer
 
         auto operation = [imageName]()
         {
+            ScriptManager* s_instance = GetInstance();
+
             // Note this will pause the script until the capture is complete
             if (PrepareForScreenCapture(imageName))
             {
@@ -1603,16 +1600,18 @@ namespace AtomSampleViewer
             }
         };
 
+        ScriptManager* s_instance = GetInstance();
+
         s_instance->m_scriptOperations.push(AZStd::move(operation));
         s_instance->m_scriptOperations.push([]()
             {
-                s_instance->m_scriptReporter.CheckLatestScreenshot(s_instance->m_imageComparisonOptions.GetCurrentToleranceLevel());
+                GetInstance()->m_scriptReporter.CheckLatestScreenshot(GetInstance()->m_imageComparisonOptions.GetCurrentToleranceLevel());
             });
 
         // restore imgui show/hide
         s_instance->m_scriptOperations.push([]()
             {
-                s_instance->SetShowImGui(s_instance->m_prevShowImGui);
+                GetInstance()->SetShowImGui(GetInstance()->m_prevShowImGui);
             });
     }
 
@@ -1620,6 +1619,8 @@ namespace AtomSampleViewer
     {
         auto operation = [imageName]()
         {
+            ScriptManager* s_instance = GetInstance();
+
             // Note this will pause the script until the capture is complete
             if (PrepareForScreenCapture(imageName))
             {
@@ -1659,10 +1660,11 @@ namespace AtomSampleViewer
             }
         };
 
+        ScriptManager* s_instance = GetInstance();
         s_instance->m_scriptOperations.push(AZStd::move(operation));
         s_instance->m_scriptOperations.push([]()
             {
-                s_instance->m_scriptReporter.CheckLatestScreenshot(s_instance->m_imageComparisonOptions.GetCurrentToleranceLevel());
+                GetInstance()->m_scriptReporter.CheckLatestScreenshot(GetInstance()->m_imageComparisonOptions.GetCurrentToleranceLevel());
             });
     }
 
@@ -1743,6 +1745,8 @@ namespace AtomSampleViewer
 
         auto operation = [passHierarchy, slot, imageName, readbackOption]()
         {
+            ScriptManager* s_instance = GetInstance();
+
             // Note this will pause the script until the capture is complete
             if (PrepareForScreenCapture(imageName))
             {
@@ -1783,10 +1787,10 @@ namespace AtomSampleViewer
             }
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
-        s_instance->m_scriptOperations.push([]()
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push([]()
             {
-                s_instance->m_scriptReporter.CheckLatestScreenshot(s_instance->m_imageComparisonOptions.GetCurrentToleranceLevel());
+                GetInstance()->m_scriptReporter.CheckLatestScreenshot(GetInstance()->m_imageComparisonOptions.GetCurrentToleranceLevel());
             });
     }
 
@@ -1853,14 +1857,14 @@ namespace AtomSampleViewer
 
         auto operation = [outputFilePath]()
         {
-            s_instance->m_isCapturePending = true;
-            s_instance->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
-            s_instance->PauseScript();
+            GetInstance()->m_isCapturePending = true;
+            GetInstance()->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
+            GetInstance()->PauseScript();
 
             AZ::Render::ProfilingCaptureRequestBus::Broadcast(&AZ::Render::ProfilingCaptureRequestBus::Events::CapturePassTimestamp, outputFilePath);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_CaptureCpuFrameTime(AZ::ScriptDataContext& dc)
@@ -1874,14 +1878,14 @@ namespace AtomSampleViewer
 
         auto operation = [outputFilePath]()
         {
-            s_instance->m_isCapturePending = true;
-            s_instance->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
-            s_instance->PauseScript();
+            GetInstance()->m_isCapturePending = true;
+            GetInstance()->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
+            GetInstance()->PauseScript();
 
             AZ::Render::ProfilingCaptureRequestBus::Broadcast(&AZ::Render::ProfilingCaptureRequestBus::Events::CaptureCpuFrameTime, outputFilePath);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_CapturePassPipelineStatistics(AZ::ScriptDataContext& dc)
@@ -1895,14 +1899,14 @@ namespace AtomSampleViewer
 
         auto operation = [outputFilePath]()
         {
-            s_instance->m_isCapturePending = true;
-            s_instance->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
-            s_instance->PauseScript();
+            GetInstance()->m_isCapturePending = true;
+            GetInstance()->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
+            GetInstance()->PauseScript();
 
             AZ::Render::ProfilingCaptureRequestBus::Broadcast(&AZ::Render::ProfilingCaptureRequestBus::Events::CapturePassPipelineStatistics, outputFilePath);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_CaptureCpuProfilingStatistics(AZ::ScriptDataContext& dc)
@@ -1916,9 +1920,9 @@ namespace AtomSampleViewer
 
         auto operation = [outputFilePath]()
         {
-            s_instance->m_isCapturePending = true;
-            s_instance->AZ::Debug::ProfilerNotificationBus::Handler::BusConnect();
-            s_instance->PauseScript();
+            GetInstance()->m_isCapturePending = true;
+            GetInstance()->AZ::Debug::ProfilerNotificationBus::Handler::BusConnect();
+            GetInstance()->PauseScript();
 
             if (auto profilerSystem = AZ::Debug::ProfilerSystemInterface::Get(); profilerSystem)
             {
@@ -1926,7 +1930,7 @@ namespace AtomSampleViewer
             }
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_CaptureBenchmarkMetadata(AZ::ScriptDataContext& dc)
@@ -1954,14 +1958,14 @@ namespace AtomSampleViewer
 
         auto operation = [benchmarkName, outputFilePath]()
         {
-            s_instance->m_isCapturePending = true;
-            s_instance->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
-            s_instance->PauseScript();
+            GetInstance()->m_isCapturePending = true;
+            GetInstance()->AZ::Render::ProfilingCaptureNotificationBus::Handler::BusConnect();
+            GetInstance()->PauseScript();
 
             AZ::Render::ProfilingCaptureRequestBus::Broadcast(&AZ::Render::ProfilingCaptureRequestBus::Events::CaptureBenchmarkMetadata, benchmarkName, outputFilePath);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     bool ScriptManager::ValidateProfilingCaptureScripContexts(AZ::ScriptDataContext& dc, AZStd::string& outputFilePath)
@@ -2005,12 +2009,12 @@ namespace AtomSampleViewer
 
     int ScriptManager::Script_GetRandomTestSeed()
     {
-        return s_instance->m_testSuiteRunConfig.m_randomSeed;
+        return GetInstance()->m_testSuiteRunConfig.m_randomSeed;
     }
 
     void ScriptManager::CheckArcBallControllerHandler()
     {
-        if (0 == AZ::Debug::ArcBallControllerRequestBus::GetNumOfEventHandlers(s_instance->m_cameraEntity->GetId()))
+        if (0 == AZ::Debug::ArcBallControllerRequestBus::GetNumOfEventHandlers(GetInstance()->m_cameraEntity->GetId()))
         {
             ReportScriptError("There is no handler for ArcBallControllerRequestBus for the camera entity.");
         }
@@ -2018,7 +2022,7 @@ namespace AtomSampleViewer
 
     void ScriptManager::CheckNoClipControllerHandler()
     {
-        if (0 == AZ::Debug::NoClipControllerRequestBus::GetNumOfEventHandlers(s_instance->m_cameraEntity->GetId()))
+        if (0 == AZ::Debug::NoClipControllerRequestBus::GetNumOfEventHandlers(GetInstance()->m_cameraEntity->GetId()))
         {
             ReportScriptError("There is no handler for NoClipControllerRequestBus for the camera entity.");
         }
@@ -2028,119 +2032,109 @@ namespace AtomSampleViewer
     {
         auto operation = [center]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckArcBallControllerHandler();
-            AZ::Debug::ArcBallControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetCenter, center);
+            AZ::Debug::ArcBallControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetCenter, center);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_ArcBallCameraController_SetPan(AZ::Vector3 pan)
     {
         auto operation = [pan]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckArcBallControllerHandler();
-            AZ::Debug::ArcBallControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetPan, pan);
+            AZ::Debug::ArcBallControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetPan, pan);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_ArcBallCameraController_SetDistance(float distance)
     {
         auto operation = [distance]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckArcBallControllerHandler();
-            AZ::Debug::ArcBallControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetDistance, distance);
+            AZ::Debug::ArcBallControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetDistance, distance);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_ArcBallCameraController_SetHeading(float heading)
     {
         auto operation = [heading]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckArcBallControllerHandler();
-            AZ::Debug::ArcBallControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetHeading, heading);
+            AZ::Debug::ArcBallControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetHeading, heading);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_ArcBallCameraController_SetPitch(float pitch)
     {
         auto operation = [pitch]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckArcBallControllerHandler();
-            AZ::Debug::ArcBallControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetPitch, pitch);
+            AZ::Debug::ArcBallControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetPitch, pitch);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_NoClipCameraController_SetPosition(AZ::Vector3 position)
     {
         auto operation = [position]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckNoClipControllerHandler();
-            AZ::Debug::NoClipControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetPosition, position);
+            AZ::Debug::NoClipControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetPosition, position);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_NoClipCameraController_SetHeading(float heading)
     {
         auto operation = [heading]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckNoClipControllerHandler();
-            AZ::Debug::NoClipControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetHeading, heading);
+            AZ::Debug::NoClipControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetHeading, heading);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_NoClipCameraController_SetPitch(float pitch)
     {
         auto operation = [pitch]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckNoClipControllerHandler();
-            AZ::Debug::NoClipControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetPitch, pitch);
+            AZ::Debug::NoClipControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetPitch, pitch);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_NoClipCameraController_SetFov(float fov)
     {
         auto operation = [fov]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
             CheckNoClipControllerHandler();
-            AZ::Debug::NoClipControllerRequestBus::Event(s_instance->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetFov, fov);
+            AZ::Debug::NoClipControllerRequestBus::Event(GetInstance()->m_cameraEntity->GetId(), &AZ::Debug::NoClipControllerRequestBus::Events::SetFov, fov);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_AssetTracking_Start()
     {
         auto operation = []()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-            s_instance->m_assetStatusTracker.StartTracking();
+            GetInstance()->m_assetStatusTracker.StartTracking();
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
 
@@ -2148,36 +2142,33 @@ namespace AtomSampleViewer
     {
         auto operation = [sourceAssetPath, expectedCount]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-            s_instance->m_assetStatusTracker.ExpectAsset(sourceAssetPath, expectedCount);
+            GetInstance()->m_assetStatusTracker.ExpectAsset(sourceAssetPath, expectedCount);
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_AssetTracking_IdleUntilExpectedAssetsFinish(float timeout)
     {
         auto operation = [timeout]()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
 
-            AZ_Assert(!s_instance->m_waitForAssetTracker, "It shouldn't be possible to run the next command until m_waitForAssetTracker is false");
+            AZ_Assert(!GetInstance()->m_waitForAssetTracker, "It shouldn't be possible to run the next command until m_waitForAssetTracker is false");
 
-            s_instance->m_waitForAssetTracker = true;
-            s_instance->m_assetTrackingTimeout = timeout;
+            GetInstance()->m_waitForAssetTracker = true;
+            GetInstance()->m_assetTrackingTimeout = timeout;
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 
     void ScriptManager::Script_AssetTracking_Stop()
     {
         auto operation = []()
         {
-            AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-            s_instance->m_assetStatusTracker.StopTracking();
+            GetInstance()->m_assetStatusTracker.StopTracking();
         };
 
-        s_instance->m_scriptOperations.push(AZStd::move(operation));
+        GetInstance()->m_scriptOperations.push(AZStd::move(operation));
     }
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/Automation/ScriptManager.h
+++ b/Gem/Code/Source/Automation/ScriptManager.h
@@ -69,6 +69,8 @@ namespace AtomSampleViewer
 
         void RunMainTestSuite(const AZStd::string& suiteFilePath, bool exitOnTestEnd, int randomSeed);
 
+        static ScriptManager* GetInstance();
+
     private:
         static constexpr const char* FullSuiteScriptFilepath = "scripts/_fulltestsuite_.bv.luac";
 
@@ -352,7 +354,5 @@ namespace AtomSampleViewer
 
         bool m_prevShowImGui = true;
         bool m_showImGui = true;
-
-        static ScriptManager* s_instance;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/Automation/ScriptableImGui.cpp
+++ b/Gem/Code/Source/Automation/ScriptableImGui.cpp
@@ -11,27 +11,23 @@
 #include <AzFramework/StringFunc/StringFunc.h>
 #include <Utils/Utils.h>
 
+#include <SampleComponentManagerBus.h>
+
 namespace AtomSampleViewer
 {
-    ScriptableImGui* ScriptableImGui::s_instance = nullptr;
-
-    void ScriptableImGui::Create()
+    ScriptableImGui* ScriptableImGui::GetInstance()
     {
-        AZ_Assert(s_instance == nullptr, "instance already called");
-        s_instance = aznew ScriptableImGui();
-    }
-
-    void ScriptableImGui::Destory()
-    {
-        AZ_Assert(s_instance != nullptr, "instance is null");
-        delete s_instance;
-        s_instance = nullptr;
+        static ScriptableImGui* s_instance = nullptr;
+        if (!s_instance)
+        {
+            AtomSampleViewer::SampleComponentSingletonRequestBus::BroadcastResult(s_instance, &AtomSampleViewer::SampleComponentSingletonRequestBus::Events::GetScriptableImGuiInstance);
+        }
+        return s_instance;
     }
 
     void ScriptableImGui::CheckAllActionsConsumed()
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
+        ScriptableImGui* s_instance = GetInstance();
         AZ_Error("Automation", s_instance->m_scriptedActions.empty(), "Not all scripted ImGui actions were consumed");
         for (auto iter : s_instance->m_scriptedActions)
         {
@@ -43,31 +39,27 @@ namespace AtomSampleViewer
 
     void ScriptableImGui::ClearActions()
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_scriptedActions.clear();
         s_instance->m_nameContextStack.clear();
     }
 
     void ScriptableImGui::PushNameContext(const AZStd::string& nameContext)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_nameContextStack.push_back(nameContext);
     }
 
     void ScriptableImGui::PopNameContext()
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
+        ScriptableImGui* s_instance = GetInstance();
         AZ_Assert(!s_instance->m_nameContextStack.empty(), "Called PopNameContext too many times");
         s_instance->m_nameContextStack.pop_back();
     }
 
     ScriptableImGui::ActionItem ScriptableImGui::FindAndRemoveAction(const AZStd::string& pathToImGuiItem)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
+        ScriptableImGui* s_instance = GetInstance();
         auto iter = s_instance->m_scriptedActions.find(pathToImGuiItem);
         if (iter != s_instance->m_scriptedActions.end())
         {
@@ -81,6 +73,7 @@ namespace AtomSampleViewer
 
     AZStd::string ScriptableImGui::MakeFullPath(const AZStd::string& forLabel)
     {
+        ScriptableImGui* s_instance = GetInstance();
         static constexpr char Delimiter[] = "/";
 
         AZStd::string fullPath;
@@ -101,31 +94,31 @@ namespace AtomSampleViewer
 
     void ScriptableImGui::SetBool(const AZStd::string& pathToImGuiItem, bool value)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_scriptedActions[pathToImGuiItem] = value;
     }
 
     void ScriptableImGui::SetNumber(const AZStd::string& pathToImGuiItem, float value)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_scriptedActions[pathToImGuiItem] = value;
     }
 
     void ScriptableImGui::SetVector(const AZStd::string& pathToImGuiItem, const AZ::Vector2& value)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_scriptedActions[pathToImGuiItem] = value;
     }
 
     void ScriptableImGui::SetVector(const AZStd::string& pathToImGuiItem, const AZ::Vector3& value)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_scriptedActions[pathToImGuiItem] = value;
     }
 
     void ScriptableImGui::SetString(const AZStd::string& pathToImGuiItem, const AZStd::string& value)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
+        ScriptableImGui* s_instance = GetInstance();
         s_instance->m_scriptedActions[pathToImGuiItem] = value;
     }
 
@@ -498,8 +491,6 @@ namespace AtomSampleViewer
 
     bool ScriptableImGui::TreeNodeEx(const char* label, ImGuiSelectableFlags flags)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
-
         if (ImGui::TreeNodeEx(label, flags))
         {
             PushNameContext(label);
@@ -517,7 +508,7 @@ namespace AtomSampleViewer
 
     bool ScriptableImGui::BeginCombo(const char* label, const char* preview_value, ImGuiComboFlags flags)
     {
-        AZ_DEBUG_STATIC_MEMEBER(instance, s_instance);
+        ScriptableImGui* s_instance = GetInstance();
 
         const AZStd::string pathToImGuiItem = MakeFullPath(label);
 
@@ -541,6 +532,7 @@ namespace AtomSampleViewer
 
     void ScriptableImGui::EndCombo()
     {
+        ScriptableImGui* s_instance = GetInstance();
         if (s_instance->m_isInScriptedComboPopup)
         {
             s_instance->m_isInScriptedComboPopup = false;

--- a/Gem/Code/Source/Automation/ScriptableImGui.h
+++ b/Gem/Code/Source/Automation/ScriptableImGui.h
@@ -42,6 +42,8 @@ namespace AtomSampleViewer
             ~ScopedNameContext() { ScriptableImGui::PopNameContext(); }
         };
 
+        static ScriptableImGui* GetInstance();
+
         //! This can be used to add some context around the ImGui labels that are exposed to the script system.
         //! Each call to PushNameContext() will add a prefix the ImGui labels to form the script field IDs.
         //! For example, the following will result in a script field ID of "A/B/MyButton" instead of just "MyButton".
@@ -97,9 +99,6 @@ namespace AtomSampleViewer
         /////////////////////////////////////////////////////////////////////////////////////////////////
         // Private API for ScriptManager to call...
 
-        static void Create();
-        static void Destory();
-
         //! Call this every frame to report errors when scripted actions aren't consumed through ImGui API function calls.
         //! This usually indicates that a script is trying to manipulate ImGui elements that don't exist.
         static void CheckAllActionsConsumed();
@@ -152,8 +151,6 @@ namespace AtomSampleViewer
         ActionMap m_scriptedActions;
 
         bool m_isInScriptedComboPopup = false;
-
-        static ScriptableImGui* s_instance;
     };
 
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -52,35 +52,10 @@ namespace AtomSampleViewer
 {
     class ScriptManager;
 
-    enum class SamplePipelineType : uint32_t
-    {
-        RHI = 0,
-        RPI
-    };
-
-    class SampleEntry
-    {
-    public:
-        AZStd::string m_parentMenuName;
-        AZStd::string m_sampleName;
-        // m_parentMenuName/m_sampleName
-        AZStd::string m_fullName;
-        AZ::Uuid m_sampleUuid;
-        AZStd::function<bool()> m_isSupportedFunc;
-        SamplePipelineType m_pipelineType = SamplePipelineType::RHI;
-        AZ::ComponentDescriptor* m_componentDescriptor;
-        AZStd::string m_contentWarning;
-        AZStd::string m_contentWarningTitle;
-
-        bool operator==(const SampleEntry& other)
-        {
-            return other.m_sampleName == m_sampleName && other.m_parentMenuName == m_parentMenuName;
-        }
-    };
-
     class SampleComponentManager final
         : public AZ::Component
         , public SampleComponentManagerRequestBus::Handler
+        , public SampleComponentSingletonRequestBus::Handler
         , public AZ::TickBus::Handler
         , public AzFramework::InputChannelEventListener
         , public AZ::Render::FrameCaptureNotificationBus::Handler
@@ -94,6 +69,7 @@ namespace AtomSampleViewer
         static void Reflect(AZ::ReflectContext* context);
 
         static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+        static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided);
         static void GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent);
 
         static AZStd::vector<SampleEntry> GetSamples();
@@ -106,9 +82,6 @@ namespace AtomSampleViewer
         void Deactivate() override;
 
     private:
-
-        void RegisterSampleComponent(const SampleEntry& sample);
-
         // AZ::TickBus::Handler
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
@@ -161,6 +134,11 @@ namespace AtomSampleViewer
         int16_t GetNumMSAASamples() override;
         void SetDefaultNumMSAASamples(int16_t defaultNumMsaaSamples) override;
         int16_t GetDefaultNumMSAASamples() override;
+
+        // SampleComponentSingletonRequestBus overrides
+        void RegisterSampleComponent(const SampleEntry& sample) override;
+        ScriptManager* GetScriptManagerInstance() override;
+        ScriptableImGui* GetScriptableImGuiInstance() override;
 
         void ResetNumMSAASamples() override;
         void ResetRPIScene() override;
@@ -260,6 +238,7 @@ namespace AtomSampleViewer
         AZStd::string m_frameCaptureFilePath;
 
         AZStd::unique_ptr<ScriptManager> m_scriptManager;
+        AZStd::unique_ptr<ScriptableImGui> m_scriptableImGui;
 
         AZStd::shared_ptr<AZ::RPI::WindowContext> m_windowContext;
 

--- a/Gem/Code/Source/SampleComponentManagerBus.h
+++ b/Gem/Code/Source/SampleComponentManagerBus.h
@@ -12,6 +12,56 @@
 
 namespace AtomSampleViewer
 {
+    enum class SamplePipelineType : uint32_t
+    {
+        RHI = 0,
+        RPI
+    };
+
+    class SampleEntry
+    {
+    public:
+        AZStd::string m_parentMenuName;
+        AZStd::string m_sampleName;
+        // m_parentMenuName/m_sampleName
+        AZStd::string m_fullName;
+        AZ::Uuid m_sampleUuid;
+        AZStd::function<bool()> m_isSupportedFunc;
+        SamplePipelineType m_pipelineType = SamplePipelineType::RHI;
+        AZ::ComponentDescriptor* m_componentDescriptor;
+        AZStd::string m_contentWarning;
+        AZStd::string m_contentWarningTitle;
+
+        bool operator==(const SampleEntry& other)
+        {
+            return other.m_sampleName == m_sampleName && other.m_parentMenuName == m_parentMenuName;
+        }
+    };
+
+    template <typename T>
+    static SampleEntry NewSample(SamplePipelineType type, const char* menuName, const AZStd::string& name)
+    {
+        SampleEntry entry;
+        entry.m_sampleName = name;
+        entry.m_sampleUuid = azrtti_typeid<T>();
+        entry.m_pipelineType = type;
+        entry.m_componentDescriptor = T::CreateDescriptor();
+        entry.m_parentMenuName = menuName;
+        entry.m_fullName = entry.m_parentMenuName + '/' + entry.m_sampleName;
+        entry.m_contentWarning = T::ContentWarning;
+        entry.m_contentWarningTitle = T::ContentWarningTitle;
+
+        return entry;
+    }
+
+    template <typename T>
+    static SampleEntry NewSample(SamplePipelineType type, const char* menuName, const AZStd::string& name, AZStd::function<bool()> isSupportedFunction)
+    {
+        SampleEntry entry = NewSample<T>(type, menuName, name);
+        entry.m_isSupportedFunc = isSupportedFunction;
+        return entry;
+    }
+
     class SampleComponentManagerRequests
         : public AZ::EBusTraits
     {
@@ -68,6 +118,21 @@ namespace AtomSampleViewer
         virtual void EnableXrPipelines(bool value) = 0;
     };
     using SampleComponentManagerRequestBus = AZ::EBus<SampleComponentManagerRequests>;
+
+    class ScriptManager;
+    class ScriptableImGui;
+
+    class SampleComponentSingletonRequests
+        : public AZ::EBusTraits
+    {
+    public:
+
+        virtual ScriptManager* GetScriptManagerInstance() = 0;
+        virtual ScriptableImGui* GetScriptableImGuiInstance() = 0;
+        virtual void RegisterSampleComponent(const SampleEntry& sample) = 0;
+    };
+    using SampleComponentSingletonRequestBus = AZ::EBus<SampleComponentSingletonRequests>;
+
 
     class SampleComponentManagerNotifications
         : public AZ::EBusTraits


### PR DESCRIPTION
Made changes to allow gems to create and register their own samples. This required the following changes:
1. Remove static ScriptManager and static ScriptableImGui instances from their respective .cpp as these static global variables were not playing nicely across gems. Replaced them instead with GetInstance() functions, which has a static pointer that it initializes through a bus call if it's not already set. 
2. Created a new SampleComponentSingletonRequests bus to initialize the static pointers above through the SampleComponentManager.
3. In this new bus, added a function for registering sample components so that gems can register their samples with the SampleComponentManager. This function is in this new bus and not in the SampleComponentManagerRequestBus because that bus does not get hooked up during the activate function but later during the SampleComponentManager::ActivateInternal() function, which doesn't guarantee order dependency with gem system components that depend on the SampleComponentManagerService

Test: can successfully create new ASV sample using custom gem.