### PR TITLE
Use the BindlessSrg in the BindlessPrototype sample

### DIFF
--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -126,6 +126,8 @@ namespace AtomSampleViewer
             AZ::RHI::ShaderInputNameIndex m_objecHandleIndex = "m_perObjectHandle";
             AZ::RHI::ShaderInputNameIndex m_materialHandleIndex = "m_materialHandle";
             AZ::RHI::ShaderInputNameIndex m_lightHandleIndex = "m_lightHandle";
+            AZ::RHI::ShaderInputNameIndex m_uvBufferHandleIndex = "m_uvBufferIndex";
+            AZ::RHI::ShaderInputNameIndex m_uvBufferByteOffsetHandleIndex = "m_uvBufferByteOffset";
 
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_perSubMeshSrg;
 
@@ -133,6 +135,9 @@ namespace AtomSampleViewer
             AZ::RPI::ModelLod::StreamBufferViewList bufferStreamViewArray;
 
             AZ::Matrix4x4 m_modelMatrix;
+
+            uint32_t m_uvBufferIndex = 0;
+            uint32_t m_uvBufferByteOffset = 0;
         };
 
     public:

--- a/Shaders/RHI/BindlessPrototype.azsl
+++ b/Shaders/RHI/BindlessPrototype.azsl
@@ -108,7 +108,6 @@ VertexOutput MainVS(VertexInput vsInput)
     OUT.m_position = mul(worldToClipMatrix, worldPosition);
     OUT.m_uv =
         asfloat(Bindless::GetByteAddressBuffer(HandleSrg::m_uvBufferIndex).Load2(HandleSrg::m_uvBufferByteOffset + vsInput.m_vertexId * 8));
-    // OUT.m_uv = vsInput.m_uv;
     OUT.m_normal = normalize(vsInput.m_normal);
 
     return OUT;

--- a/Shaders/RHI/BindlessPrototype.azsl
+++ b/Shaders/RHI/BindlessPrototype.azsl
@@ -61,6 +61,9 @@ ShaderResourceGroup HandleSrg : PerSubMesh
     uint m_perObjectHandle;
     uint m_materialHandle;
     uint m_lightHandle;
+
+    uint m_uvBufferIndex;
+    uint m_uvBufferByteOffset;
 };
 
 struct VertexInput
@@ -70,6 +73,7 @@ struct VertexInput
     float3 m_tangent : TANGENT;
     float3 m_bitangent : BITANGENT;
     float2 m_uv : UV0;
+    uint m_vertexId : SV_VertexID;
 };
 
 struct VertexOutput
@@ -102,7 +106,9 @@ VertexOutput MainVS(VertexInput vsInput)
 
     const float4 worldPosition = mul(perObject.m_localToWorldMatrix,  float4(vsInput.m_position, 1.0));
     OUT.m_position = mul(worldToClipMatrix, worldPosition);
-    OUT.m_uv = vsInput.m_uv;
+    OUT.m_uv =
+        asfloat(Bindless::GetByteAddressBuffer(HandleSrg::m_uvBufferIndex).Load2(HandleSrg::m_uvBufferByteOffset + vsInput.m_vertexId * 8));
+    // OUT.m_uv = vsInput.m_uv;
     OUT.m_normal = normalize(vsInput.m_normal);
 
     return OUT;

--- a/Shaders/RHI/BindlessPrototypeSrg.azsli
+++ b/Shaders/RHI/BindlessPrototypeSrg.azsli
@@ -35,6 +35,8 @@ ShaderResourceGroupSemantic NonBindlessTextureSemanticId
     FrequencyId = 3;
 };
 
+#include <Atom/Features/Bindless.azsli>
+
 ShaderResourceGroup FloatBufferSrg : FloatBufferSemanticId
 {
     StructuredBuffer<FloatBuffer> m_floatBuffer;


### PR DESCRIPTION
This PR introduces the BindlessSRG to the Bindless Protoype.
It's main purpose is to show off the problems described in this issue: https://github.com/o3de/o3de/issues/16305

We don't use the UV coordinates from the Input Assembly, but load them from the UV coordinate buffer, using the BindlessSRG.
This does work for Vulkan, but does not fully work in DX12.

DX12:
![dx12](https://github.com/o3de/o3de-atom-sampleviewer/assets/120572403/16b81f65-4505-4ca8-8523-19f31fb31478)

Vulkan:
![vulkan](https://github.com/o3de/o3de-atom-sampleviewer/assets/120572403/8b728430-f627-443d-b7a4-e0c4e0ba6071)

The texture is missing in parts of the models in the DX12 image, due to the UV coordinates being zero.

Note: I only tested this in the 2305 pass, and rebased it to development, as the development branch does produce a compiler error in `SampleComponentManagerBus.h` for me.
