### PR TITLE
Fix compilation bug introduced by O3DE PR #16269

### DIFF
--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -24,7 +24,7 @@ namespace AtomSampleViewer
     RHISamplePass::RHISamplePass(const AZ::RPI::PassDescriptor& descriptor)
         : AZ::RPI::RenderPass(descriptor)
     {
-        m_flags.m_hasPipelineViewTag = true;
+        m_flags.m_bindViewSrg = true;
         m_pipelineViewTag = "MainCamera";
     }
 


### PR DESCRIPTION
Fix compilation bug introduced by PR:
https://github.com/o3de/o3de/pull/16269

The bug was:
C:/GIT/o3de/AtomSampleViewer/Gem/Code/Source/RHI/BasicRHIComponent.cpp(27,17): error C2039: 'm_hasPipelineViewTag': is not a member of 'AZ::RPI::Pass::<unnamed-type-m_flags>'