### PR TITLE
Remove OpenXR VRS image initialization

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -567,7 +567,6 @@ namespace AtomSampleViewer
 
         m_windowContext = nullptr;
         m_brdfTexture.reset();
-        m_xrVrsTexture.reset();
 
         ReleaseRHIScene();
         ReleaseRPIScene();
@@ -1770,17 +1769,6 @@ namespace AtomSampleViewer
 
         if (xrSystem)
         {
-            RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-            if (RHI::CheckBitsAll(device->GetFeatures().m_shadingRateTypeMask, RHI::ShadingRateTypeFlags::PerRegion) && !m_xrVrsTexture)
-            {
-                auto* xrRPISystem = AZ::RPI::RPISystemInterface::Get()->GetXRSystem();
-                // Need to fill the contents of the Variable shade rating image.
-                const AZStd::shared_ptr<const RPI::PassTemplate> forwardTemplate =
-                    RPI::PassSystemInterface::Get()->GetPassTemplate(Name("MultiViewForwardPassTemplate"));
-
-                m_xrVrsTexture = xrRPISystem->InitPassFoveatedAttachment(*forwardTemplate);
-            }
-
             RPI::RenderPipelineDescriptor xrPipelineDesc;
             xrPipelineDesc.m_mainViewTagName = "MainCamera";
             xrPipelineDesc.m_renderSettings.m_multisampleState.m_samples = static_cast<uint16_t>(m_numMsaaSamples);

--- a/Gem/Code/Source/SampleComponentManager.h
+++ b/Gem/Code/Source/SampleComponentManager.h
@@ -182,7 +182,6 @@ namespace AtomSampleViewer
         AZ::Entity* m_cameraEntity = nullptr;
 
         AZ::Data::Instance<AZ::RPI::AttachmentImage> m_brdfTexture;
-        AZ::Data::Instance<AZ::RPI::AttachmentImage> m_xrVrsTexture;
 
         int32_t m_selectedSampleIndex = -1;
 


### PR DESCRIPTION
Remove OpenXR VRS image initialization because it's done in the gem now.

O3de changes here https://github.com/o3de/o3de/pull/16617
OpenXR Gem changes here https://github.com/o3de/o3de-extras/pull/479

Tested withe the Features/OpenXR sample on Quest2 link and native mode.