### PR TITLE
Fix vulkan Validation error as part of updating to the latest lib

### DIFF
--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1716,6 +1716,12 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::CreateSceneForRPISample()
     {
+        // set pipeline MSAA samples
+        AZ_Assert(IsValidNumMSAASamples(m_numMsaaSamples), "Invalid MSAA sample setting");
+        const bool isNonMsaaPipeline = (m_numMsaaSamples == 1);
+        const char* supervariantName = isNonMsaaPipeline ? AZ::RPI::NoMsaaSupervariantName : "";
+        AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(AZ::Name(supervariantName));
+
         // Create and register a scene with all available feature processors
         RPI::SceneDescriptor sceneDesc;
         sceneDesc.m_nameId = AZ::Name("RPI");
@@ -1735,12 +1741,8 @@ namespace AtomSampleViewer
 
         // Register scene to RPI system so it will be processed/rendered per tick
         RPI::RPISystemInterface::Get()->RegisterScene(m_rpiScene);
-
-        // set pipeline MSAA samples
-        AZ_Assert(IsValidNumMSAASamples(m_numMsaaSamples), "Invalid MSAA sample setting");
-        const bool isNonMsaaPipeline = (m_numMsaaSamples == 1);
-        const char* supervariantName = isNonMsaaPipeline ? AZ::RPI::NoMsaaSupervariantName : "";
-        AZ::RPI::ShaderSystemInterface::Get()->SetSupervariantName(AZ::Name(supervariantName));
+        
+        
 
         auto* xrSystem = AZ::RHI::RHISystemInterface::Get()->GetXRSystem();
         const bool createDefaultRenderPipeline = !xrSystem || xrSystem->IsDefaultRenderPipelineNeeded();


### PR DESCRIPTION
- There was a mismatch between the shader msaa super variant and the Render target sample count. Addressing that fixed the following Vk error
`<16:36:09> [Error] (vkDebugMessage) - [ERROR][Validation] Validation Error: [ VUID-RuntimeSpirv-samples-08726 ] Object 0: handle = 0xbfd2530000000a6d, name = DiffuseProbeGridRender_PassSrg, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0xdba6a50a | vkCmdDrawIndexed: Descriptor set VkDescriptorSet 0xbfd2530000000a6d[DiffuseProbeGridRender_PassSrg] in binding #1 index 0 requires bound image to have multiple samples, but got VK_SAMPLE_COUNT_1_BIT. The Vulkan spec states: If an OpTypeImage has an MS operand 1, its bound image must not have been created with VkImageCreateInfo::samples as VK_SAMPLE_COUNT_1_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-RuntimeSpirv-samples-08726)
`

Related linked PRs
Core engine - https://github.com/o3de/o3de/pull/16625
3p package - https://github.com/o3de/3p-package-source/pull/212