### PR TITLE
Added option to customize the image diff tool

### DIFF
--- a/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
+++ b/Gem/Code/Source/Platform/Linux/Utils_Linux.cpp
@@ -20,10 +20,14 @@ namespace AtomSampleViewer
             return true;
         }
 
-        bool RunDiffTool(const AZStd::string& filePathA, const AZStd::string& filePathB)
+        AZStd::string GetDefaultDiffToolPath_Impl()
+        {
+            return AZStd::string("/usr/bin/bcompare");
+        }
+
+        bool RunDiffTool_Impl(const AZStd::string& diffToolPath, const AZStd::string& filePathA, const AZStd::string& filePathB)
         {
             bool result = true;
-            AZStd::string executablePath = "/usr/bin/bcompare";
 
             // Fork a process to run Beyond Compare app
             pid_t childPid = fork();
@@ -31,15 +35,15 @@ namespace AtomSampleViewer
             if (childPid == 0)
             {
                 // In child process
-                char* args[] = { const_cast<char*>(executablePath.c_str()), const_cast<char*>(filePathA.c_str()),
+                char* args[] = { const_cast<char*>(diffToolPath.c_str()), const_cast<char*>(filePathA.c_str()),
                                  const_cast<char*>(filePathB.c_str()), static_cast<char*>(0) };
-                execv(executablePath.c_str(), args);
+                execv(diffToolPath.c_str(), args);
 
                 AZ_Error(
                     "RunDiffTool", false,
                     "RunDiffTool: Unable to launch Beyond Compare %s : errno = %s . Make sure you have installed Beyond Compare command "
                     "line tools.",
-                    executablePath.c_str(), strerror(errno));
+                    diffToolPath.c_str(), strerror(errno));
 
                 _exit(errno);
             }

--- a/Gem/Code/Source/Platform/Mac/Utils_Mac.cpp
+++ b/Gem/Code/Source/Platform/Mac/Utils_Mac.cpp
@@ -21,21 +21,25 @@ namespace AtomSampleViewer
             return true;
         }
 
-        bool RunDiffTool(const AZStd::string& filePathA, const AZStd::string& filePathB)
+        AZStd::string GetDefaultDiffToolPath_Impl()
+        {
+            return AZStd::string("/usr/local/bin/bcompare");
+        }
+
+        bool RunDiffTool_Impl(const AZStd::string& diffToolPath, const AZStd::string& filePathA, const AZStd::string& filePathB)
         {
             bool result = true;
-            AZStd::string executablePath = "/usr/local/bin/bcompare";
-           
+
             //Fork a process to run Beyond Compare app
             pid_t childPid = fork();
-            
+
             if (childPid == 0)
             {
                 //In child process
-                char* args[] = { const_cast<char*>(executablePath.c_str()), const_cast<char*>(filePathA.c_str()), const_cast<char*>(filePathB.c_str()), static_cast<char*>(0)};
-                execv(executablePath.c_str(), args);
-                
-                AZ_TracePrintf("RunDiffTool", "RunDiffTool: Unable to launch Beyond Compare %s : errno = %s . Make sure you have installed Beyond Compare command line tools.", executablePath.c_str(), strerror(errno));
+                char* args[] = { const_cast<char*>(diffToolPath.c_str()), const_cast<char*>(filePathA.c_str()), const_cast<char*>(filePathB.c_str()), static_cast<char*>(0)};
+                execv(diffToolPath.c_str(), args);
+
+                AZ_TracePrintf("RunDiffTool", "RunDiffTool: Unable to launch Beyond Compare %s : errno = %s . Make sure you have installed Beyond Compare command line tools.", diffToolPath.c_str(), strerror(errno));
                 std::cerr << strerror(errno) << std::endl;
 
                 _exit(errno);

--- a/Gem/Code/Source/Platform/Windows/Utils_Windows.cpp
+++ b/Gem/Code/Source/Platform/Windows/Utils_Windows.cpp
@@ -18,11 +18,17 @@ namespace AtomSampleViewer
             return true;
         }
 
-        bool RunDiffTool(const AZStd::string& filePathA, const AZStd::string& filePathB)
+        AZStd::string GetDefaultDiffToolPath_Impl()
+        {
+            return AZStd::string("C:\\Program Files\\Beyond Compare 4\\BCompare.exe");
+        }
+
+        bool RunDiffTool_Impl(const AZStd::string& diffToolPath, const AZStd::string& filePathA, const AZStd::string& filePathB)
         {
             bool result = false;
 
-            AZStd::wstring exeW = L"C:\\Program Files\\Beyond Compare 4\\BCompare.exe";
+            AZStd::wstring exeW;
+            AZStd::to_wstring(exeW, diffToolPath.c_str());
             AZStd::wstring filePathAW;
             AZStd::to_wstring(filePathAW, filePathA.c_str());
             AZStd::wstring filePathBW;

--- a/Gem/Code/Source/Utils/Utils.h
+++ b/Gem/Code/Source/Utils/Utils.h
@@ -66,7 +66,13 @@ namespace AtomSampleViewer
 
         void ReportScriptableAction(const char* formatStr, ...);
 
+        // Discovers, from the settings registry, the path to the diff tool and invokes
+        // the per-platform RunDiffTool_Impl.
         bool RunDiffTool(const AZStd::string& filePathA, const AZStd::string& filePathB);
+
+        // Customized per platform
+        AZStd::string GetDefaultDiffToolPath_Impl();
+        bool RunDiffTool_Impl(const AZStd::string& diffToolPath, const AZStd::string& filePathA, const AZStd::string& filePathB);
 
         AZ::Data::Instance<AZ::RPI::StreamingImage> GetSolidColorCubemap(uint32_t color);
 


### PR DESCRIPTION
Added option to customize the image diff tool executable via settings registry key:
`O3DE/External/DiffTool`

If the registry key is not defined then
it will default to the previously hardcoded platform defaults.

Validated this functionality by using WinMerge, and added this to my
.o3de/Registry/bootstrap.setreg:  
```json
{
    ... 
    "O3DE" : {
        "External": {
            "DiffTool": "C:/Program Files/WinMerge/WinMergeU.exe"
        }
    }
}
```