### PR TITLE
EyeMaterial Test fixes

### DIFF
--- a/Gem/Code/Source/EyeMaterialExampleComponent.cpp
+++ b/Gem/Code/Source/EyeMaterialExampleComponent.cpp
@@ -21,7 +21,7 @@ namespace AtomSampleViewer
 {
     static const char* MeshPath = "objects/eye.fbx.azmodel";
     static const char* MaterialPath = "materials/eye/001_EyeBasic.azmaterial";
-    static const float DefaultCameraHeading = 40.0f;
+    static const float DefaultCameraHeadingDegrees = 129.6f;
     static const float DefaultCameraDistance = 2.0f;
     
     static const char* IrisColorName = "iris.baseColor.color";
@@ -104,7 +104,9 @@ namespace AtomSampleViewer
             &AZ::Debug::CameraControllerRequestBus::Events::Enable,
             azrtti_typeid<AZ::Debug::ArcBallControllerComponent>());
         AZ::Debug::ArcBallControllerRequestBus::Event(GetCameraEntityId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetDistance, DefaultCameraDistance);
-        AZ::Debug::ArcBallControllerRequestBus::Event(GetCameraEntityId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetHeading, DefaultCameraHeading);
+        const float headingRadians = AZ::DegToRad(DefaultCameraHeadingDegrees);
+        AZ::Debug::ArcBallControllerRequestBus::Event(
+            GetCameraEntityId(), &AZ::Debug::ArcBallControllerRequestBus::Events::SetHeading, headingRadians);
 
         // Lighting
         m_defaultIbl.Init(m_scene);

--- a/Materials/Eye/001_EyeBasic.material
+++ b/Materials/Eye/001_EyeBasic.material
@@ -2,8 +2,9 @@
     "materialType": "Materials/Types/Eye.materialtype",
     "materialTypeVersion": 1,
     "propertyValues": {
-        "eye.innerEyeIOR": 1.2000000476837158,
-        "eye.irisDepth": 0.46000000834465027,
+        "eye.innerEyeIOR": 1.336,
+        "eye.irisDepth": 0.401,
+		"eye.irisRadius": 0.042,
         "iris.baseColor.color": [
             0.503395140171051,
             0.7551079392433167,

--- a/Materials/Eye/001_EyeBasic.material
+++ b/Materials/Eye/001_EyeBasic.material
@@ -3,8 +3,8 @@
     "materialTypeVersion": 1,
     "propertyValues": {
         "eye.innerEyeIOR": 1.336,
-        "eye.irisDepth": 0.401,
-		"eye.irisRadius": 0.042,
+        "eye.irisDepth": 0.406,
+		"eye.irisRadius": 0.19,
         "iris.baseColor.color": [
             0.503395140171051,
             0.7551079392433167,

--- a/Materials/Eye/001_EyeBasic.material
+++ b/Materials/Eye/001_EyeBasic.material
@@ -3,8 +3,8 @@
     "materialTypeVersion": 1,
     "propertyValues": {
         "eye.innerEyeIOR": 1.336,
-        "eye.irisDepth": 0.406,
-		"eye.irisRadius": 0.19,
+        "eye.irisDepth": 0.403,
+		"eye.irisRadius": 0.2,
         "iris.baseColor.color": [
             0.503395140171051,
             0.7551079392433167,

--- a/scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
+++ b/scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8ab3b38f10ff32f15922587b904304838d731ab3baac28053e3b7c5e778c3d74
-size 396409
+oid sha256:dc1a01ccaf865d50656f4b923a10de62f375567a78d42c9df6c95edcbe19cbc3
+size 382399

--- a/scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
+++ b/scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc1a01ccaf865d50656f4b923a10de62f375567a78d42c9df6c95edcbe19cbc3
-size 382399
+oid sha256:7beacfe0944fd1db8c64affaea279180400a1663182e5082ac03b25245e463ca
+size 379487

--- a/scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
+++ b/scripts/ExpectedScreenshots/EyeMaterial/screenshot_eye.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7beacfe0944fd1db8c64affaea279180400a1663182e5082ac03b25245e463ca
-size 379487
+oid sha256:52c1d18bb74eb733a34b847d4aa177923dd50214651804ed407fbb67c740cba2
+size 381237

--- a/scripts/EyeMaterialRotate.bv.lua
+++ b/scripts/EyeMaterialRotate.bv.lua
@@ -1,0 +1,44 @@
+----------------------------------------------------------------------------------------------------
+--
+-- Copyright (c) Contributors to the Open 3D Engine Project.
+-- For complete copyright and license terms please see the LICENSE at the root of this distribution.
+--
+-- SPDX-License-Identifier: Apache-2.0 OR MIT
+--
+--
+--
+----------------------------------------------------------------------------------------------------
+
+--[[
+    This is not a formal automation test. Instead, it is a helper/utility
+    script that can be used to automatically change the Heading angle of the
+    ArcBall camera, and being able to appreciate the Eye mesh being
+    rendered with the Eye material from different angles.
+
+    In particular, it was used to capture videos of the original Eye shader vs
+    the updated version.
+]]
+
+-- Animates the Heading angle of the ArcBall camera starting from @startHeadingDegrees
+-- until it reaches @stopHeadingDegrees in @numSteps. At each step (delta angle) it waits
+-- @waitTimePerStepSeconds seconds before changing to the next angle.
+function MyAnimateCamera(startHeadingDegrees, stopHeadingDegrees, numSteps, waitTimePerStepSeconds)
+    local headingDegrees = startHeadingDegrees
+    local deltaDegrees = (stopHeadingDegrees - startHeadingDegrees) / numSteps
+    local stepCount = numSteps+1
+    for step=1, stepCount  do
+        ArcBallCameraController_SetHeading(DegToRad(headingDegrees));
+        IdleSeconds(waitTimePerStepSeconds);
+        headingDegrees = headingDegrees + deltaDegrees
+    end
+end
+
+OpenSample('Features/EyeMaterial')
+-- in 18 steps of 10 degrees each, rotate the camera
+-- from 90 degrees  to 270 degrees. at each step it will wait
+-- 1 second.
+MyAnimateCamera(90.0, 270.0, 18, 1.0)
+
+-- Here are two examples of leaving the camera at a particular angle.
+-- MyAnimateCamera(129.6, 129.6, 1, 1.0)
+-- MyAnimateCamera(90.0, 90.0, 1, 1.0)


### PR DESCRIPTION
Updates screenshot and other minor fixes to the EyeMaterialTest. In particular changed the InnerEye IOR (Index of Refraction) to 1.336 which approximates reality, instead of the old 1.2.

This PR is contingent on this PR for the main engine: https://github.com/o3de/o3de/pull/16939
![image](https://github.com/o3de/o3de-atom-sampleviewer/assets/66021303/762ae3eb-f51d-48ba-8435-5f4957b10cb2)


Here are some video of before and after results.

**New Version:**  
https://github.com/o3de/o3de-atom-sampleviewer/assets/66021303/1a345896-236c-442f-a58d-b1a0560d86ee


  
**Previous Version**:  
https://github.com/o3de/o3de-atom-sampleviewer/assets/66021303/4607e595-42fb-48af-a928-e814d8360946
  

