### PR TITLE
Fix for PR17022 in O3DE

### DIFF
--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -459,7 +459,8 @@ namespace AtomSampleViewer
 
             commandList->BuildBottomLevelAccelerationStructure(*m_triangleRayTracingBlas);
             commandList->BuildBottomLevelAccelerationStructure(*m_rectangleRayTracingBlas);
-            commandList->BuildTopLevelAccelerationStructure(*m_rayTracingTlas, {});
+            commandList->BuildTopLevelAccelerationStructure(
+                *m_rayTracingTlas, { m_triangleRayTracingBlas.get(), m_rectangleRayTracingBlas.get() });
         };
 
         m_scopeProducers.emplace_back(


### PR DESCRIPTION
Fixes an API change introduced by the O3DE [PR17022](https://github.com/o3de/o3de/pull/17022).
This PR will not build before the O3DE PR is not merged.