### PR TITLE
Clean up mesh feature processor to set materials and event handlers in descriptor before acquire

### DIFF
--- a/Gem/Code/Source/AreaLightExampleComponent.cpp
+++ b/Gem/Code/Source/AreaLightExampleComponent.cpp
@@ -209,13 +209,13 @@ namespace AtomSampleViewer
             {
                 if (!meshHandle.IsValid())
                 {
-                    meshHandle = m_meshFeatureProcessor->AcquireMesh(MeshHandleDescriptor{ modelAsset }, m_materialInstances.at(i));
+                    meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor(modelAsset, m_materialInstances.at(i)));
                 }
                 else if (m_modelAsset.GetId() != modelAsset.GetId())
                 {
                     // Valid mesh handle, but wrong asset. Release and reacquire.
                     m_meshFeatureProcessor->ReleaseMesh(meshHandle);
-                    meshHandle = m_meshFeatureProcessor->AcquireMesh(MeshHandleDescriptor{ modelAsset }, m_materialInstances.at(i));
+                    meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor(modelAsset, m_materialInstances.at(i)));
                 }
 
                 AZ::Transform transform = AZ::Transform::CreateIdentity();

--- a/Gem/Code/Source/AssetLoadTestComponent.cpp
+++ b/Gem/Code/Source/AssetLoadTestComponent.cpp
@@ -179,7 +179,7 @@ namespace AtomSampleViewer
             if (instanceData.m_materialAssetId.IsValid())
             {
                 AZ::Data::Asset<RPI::MaterialAsset> materialAsset;
-                materialAsset.Create(instanceData.m_materialAssetId);
+                materialAsset.Create(instanceData.m_materialAssetId, true);
                 materialInstance = AZ::RPI::Material::FindOrCreate(materialAsset);
 
                 // cache the material when its loaded
@@ -188,10 +188,10 @@ namespace AtomSampleViewer
 
             if (instanceData.m_modelAssetId.IsValid())
             {
-                AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;
-                modelAsset.Create(instanceData.m_modelAssetId);
-
-                instanceData.m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, materialInstance);
+                AZ::Render::MeshHandleDescriptor descriptor;
+                descriptor.m_modelAsset.Create(instanceData.m_modelAssetId, true);
+                descriptor.m_customMaterials[AZ::Render::DefaultCustomMaterialId].m_material = materialInstance;
+                instanceData.m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
                 GetMeshFeatureProcessor()->SetTransform(instanceData.m_meshHandle, instanceData.m_transform);
             }
         }

--- a/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
+++ b/Gem/Code/Source/BakedShaderVariantExampleComponent.cpp
@@ -88,7 +88,8 @@ namespace AtomSampleViewer
 
         Transform meshTransform =
             Transform::CreateFromQuaternion(Quaternion::CreateFromAxisAngle(Vector3::CreateAxisX(), -AZ::Constants::HalfPi));
-        m_meshHandle = m_meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor{ m_modelAsset }, m_material);
+
+        m_meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor(m_modelAsset, m_material));
         m_meshFeatureProcessor->SetTransform(m_meshHandle, meshTransform);
 
         AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(AZ::Name(ATOMSAMPLEVIEWER_TRAIT_BAKED_SHADERVARIANT_SAMPLE_PASS_NAME), 

--- a/Gem/Code/Source/CheckerboardExampleComponent.cpp
+++ b/Gem/Code/Source/CheckerboardExampleComponent.cpp
@@ -44,12 +44,14 @@ namespace AtomSampleViewer
     void CheckerboardExampleComponent::Activate()
     {
         AZ::RPI::AssetUtils::TraceLevel traceLevel = AZ::RPI::AssetUtils::TraceLevel::Assert;
-        auto meshAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/shaderball_simple.fbx.azmodel", traceLevel);
+        auto modelAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/shaderball_simple.fbx.azmodel", traceLevel);
         auto materialAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::MaterialAsset>(DefaultPbrMaterialPath, traceLevel);
         auto materialInstance = AZ::RPI::Material::FindOrCreate(materialAsset);
 
         m_meshFeatureProcessor = m_scene->GetFeatureProcessor<AZ::Render::MeshFeatureProcessorInterface>();
-        m_meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor{ meshAsset }, materialInstance);
+
+        m_meshHandle = m_meshFeatureProcessor->AcquireMesh(AZ::Render::MeshHandleDescriptor(modelAsset, materialInstance));
+
         m_meshFeatureProcessor->SetTransform(m_meshHandle, AZ::Transform::CreateIdentity());
 
         AZ::Debug::CameraControllerRequestBus::Event(

--- a/Gem/Code/Source/CullingAndLodExampleComponent.cpp
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.cpp
@@ -185,14 +185,14 @@ namespace AtomSampleViewer
         {
             for (uint32_t y = 0; y < numAlongYAxis; ++y)
             {
-                auto meshHandle = meshFP->AcquireMesh(Render::MeshHandleDescriptor{ objectModelAsset }, material);
+                auto meshHandle = meshFP->AcquireMesh(Render::MeshHandleDescriptor(objectModelAsset, material));
                 Transform modelToWorld = Transform::CreateTranslation(Vector3(x * spacing, y * spacing, 2.0f));
                 meshFP->SetTransform(meshHandle, modelToWorld);
                 m_meshHandles.push_back(AZStd::move(meshHandle));
             }
         }
 
-        auto planeMeshHandle = meshFP->AcquireMesh(Render::MeshHandleDescriptor{ planeModelAsset }, material);
+        auto planeMeshHandle = meshFP->AcquireMesh(Render::MeshHandleDescriptor(planeModelAsset, material));
         Vector3 planeNonUniformScale(numAlongXAxis * spacing, numAlongYAxis * spacing, 1.0f);
         Transform planeModelToWorld = Transform::CreateTranslation(Vector3(0.5f * numAlongXAxis * spacing, 0.5f * numAlongYAxis * spacing, 0.0f));
         meshFP->SetTransform(planeMeshHandle, planeModelToWorld, planeNonUniformScale);

--- a/Gem/Code/Source/CullingAndLodExampleComponent.h
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.h
@@ -100,7 +100,7 @@ namespace AtomSampleViewer
 
         // models
         AZStd::vector<AZ::Render::MeshFeatureProcessorInterface::MeshHandle> m_meshHandles;
-        AZStd::vector<AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler> m_modelChangedHandlers;
+        AZStd::vector<AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler> m_modelChangedHandlers;
 
         // GUI
         ImGuiSidebar m_imguiSidebar;

--- a/Gem/Code/Source/DecalExampleComponent.cpp
+++ b/Gem/Code/Source/DecalExampleComponent.cpp
@@ -79,7 +79,7 @@ namespace AtomSampleViewer
     {
         const auto meshAsset = m_assetLoadManager.GetAsset<AZ::RPI::ModelAsset>(TargetMeshName);
         const auto materialAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::MaterialAsset>(TargetMaterialName, AZ::RPI::AssetUtils::TraceLevel::Assert);
-        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ meshAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(meshAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
         ScaleObjectToFitDecals();
     }
 

--- a/Gem/Code/Source/DepthOfFieldExampleComponent.cpp
+++ b/Gem/Code/Source/DepthOfFieldExampleComponent.cpp
@@ -192,7 +192,7 @@ namespace AtomSampleViewer
 
         for (MeshHandle& meshHandle : m_meshHandles)
         {
-            meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor{ m_bunnyModelAsset }, materialInstance);
+            meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor(m_bunnyModelAsset, materialInstance));
 
             auto transform = AZ::Transform::CreateTranslation(translation);
             transform *= scaleTransform;

--- a/Gem/Code/Source/DiffuseGIExampleComponent.cpp
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.cpp
@@ -231,9 +231,9 @@ namespace AtomSampleViewer
             transform.SetTranslation(-5.0f, 0.0f, 0.0f);
             transform *= AZ::Transform::CreateRotationY(AZ::Constants::HalfPi);
             AZ::Vector3 nonUniformScale(10.05f, 10.05f, 1.0f);
-            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::LeftWall)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_planeModelAsset },
-                AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_leftWallColor)));
+            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::LeftWall)] =
+                GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(
+                    m_planeModelAsset, AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_leftWallColor))));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::LeftWall)], transform, nonUniformScale);
         }
@@ -245,9 +245,9 @@ namespace AtomSampleViewer
             transform.SetTranslation(5.0f, 0.0f, 0.0f);
             transform *= AZ::Transform::CreateRotationY(-AZ::Constants::HalfPi);
             AZ::Vector3 nonUniformScale(10.05f, 10.05f, 1.0f);
-            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::RightWall)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_planeModelAsset },
-                AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_rightWallColor)));
+            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::RightWall)] =
+                GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(
+                    m_planeModelAsset, AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_rightWallColor))));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::RightWall)], transform, nonUniformScale);
         }
@@ -259,9 +259,9 @@ namespace AtomSampleViewer
             transform.SetTranslation(0.0f, 5.0f, 0.0f);
             transform *= AZ::Transform::CreateRotationX(AZ::Constants::HalfPi);
             AZ::Vector3 nonUniformScale(10.05f, 10.05f, 1.0f);
-            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::BackWall)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_planeModelAsset },
-                AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_backWallColor)));
+            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::BackWall)] =
+                GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(
+                    m_planeModelAsset, AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_backWallColor))));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::BackWall)], transform, nonUniformScale);
         }
@@ -273,9 +273,9 @@ namespace AtomSampleViewer
             transform.SetTranslation(0.0f, 0.0f, 5.0f);
             transform *= AZ::Transform::CreateRotationX(AZ::Constants::Pi);
             AZ::Vector3 nonUniformScale(10.05f, 10.05f, 1.0f);
-            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::Ceiling)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_planeModelAsset },
-                AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_ceilingColor)));
+            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::Ceiling)] =
+                GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(
+                    m_planeModelAsset, AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_ceilingColor))));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::Ceiling)], transform, nonUniformScale);
         }
@@ -286,9 +286,9 @@ namespace AtomSampleViewer
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             transform.SetTranslation(0.0f, 0.0f, -5.0f);
             AZ::Vector3 nonUniformScale(10.05f, 10.05f, 1.0f);
-            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::Floor)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_planeModelAsset },
-                AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_floorColor)));
+            m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::Floor)] =
+                GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(
+                    m_planeModelAsset, AZ::RPI::Material::FindOrCreate(GetCornellBoxMaterialAsset(m_floorColor))));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::Floor)], transform, nonUniformScale);
         }
@@ -300,7 +300,7 @@ namespace AtomSampleViewer
             transform *= AZ::Transform::CreateRotationZ(AZ::Constants::HalfPi * 0.2f);
             AZ::Vector3 nonUniformScale(3.0f, 3.0f, 6.0f);
             m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::LargeBox)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_cubeModelAsset }, AZ::RPI::Material::FindOrCreate(m_whiteMaterialAsset));
+                AZ::Render::MeshHandleDescriptor(m_cubeModelAsset, AZ::RPI::Material::FindOrCreate(m_whiteMaterialAsset)));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::LargeBox)], transform, nonUniformScale);
         }
@@ -312,7 +312,7 @@ namespace AtomSampleViewer
             transform *= AZ::Transform::CreateRotationZ(-AZ::Constants::HalfPi * 0.2f);
             AZ::Vector3 nonUniformScale(3.0f, 3.0f, 3.0f);
             m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::SmallBox)] = GetMeshFeatureProcessor()->AcquireMesh(
-                AZ::Render::MeshHandleDescriptor{ m_cubeModelAsset }, AZ::RPI::Material::FindOrCreate(m_whiteMaterialAsset));
+                AZ::Render::MeshHandleDescriptor(m_cubeModelAsset, AZ::RPI::Material::FindOrCreate(m_whiteMaterialAsset)));
             GetMeshFeatureProcessor()->SetTransform(
                 m_meshHandles[aznumeric_cast<uint32_t>(CornellBoxMeshes::SmallBox)], transform, nonUniformScale);
         }
@@ -377,7 +377,8 @@ namespace AtomSampleViewer
         m_meshHandles.resize(aznumeric_cast<uint32_t>(SponzaMeshes::Count));
 
         AZ::Transform transform = AZ::Transform::CreateIdentity();
-        m_meshHandles[aznumeric_cast<uint32_t>(SponzaMeshes::Inside)] = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_sponzaModelAsset });
+        m_meshHandles[aznumeric_cast<uint32_t>(SponzaMeshes::Inside)] =
+            GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(m_sponzaModelAsset));
         GetMeshFeatureProcessor()->SetTransform(m_meshHandles[aznumeric_cast<uint32_t>(SponzaMeshes::Inside)], transform);
         
         m_directionalLightPitch = AZ::DegToRad(-65.0f);

--- a/Gem/Code/Source/DynamicMaterialTestComponent.cpp
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.cpp
@@ -95,26 +95,17 @@ namespace AtomSampleViewer
         AZ::Data::Asset<AZ::RPI::MaterialAsset>& materialAsset = m_materialConfigs[m_currentMaterialConfig].m_materialAsset;
         AZ::Data::Instance<AZ::RPI::Material> material = Material::Create(materialAsset);
          
-        Render::MeshHandleDescriptor meshDescriptor;
-        meshDescriptor.m_modelAsset = m_modelAsset;
+        Render::MeshHandleDescriptor meshDescriptor(m_modelAsset, material);
         meshDescriptor.m_isRayTracingEnabled = false;
-        auto meshHandle = GetMeshFeatureProcessor()->AcquireMesh(meshDescriptor, material);
+        meshDescriptor.m_modelChangedEventHandler =
+            AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler{ [this](const AZ::Data::Instance<AZ::RPI::Model>& /*model*/)
+                                                                          {
+                                                                              m_loadedMeshCounter++;
+                                                                          } };
+
+        auto meshHandle = GetMeshFeatureProcessor()->AcquireMesh(meshDescriptor);
         GetMeshFeatureProcessor()->SetTransform(meshHandle, transform);
 
-        Data::Instance<RPI::Model> model = GetMeshFeatureProcessor()->GetModel(meshHandle);
-        if (model)
-        {
-            m_loadedMeshCounter++;
-        }
-        else
-        {
-            m_meshLoadEventHandlers.push_back(AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler
-                {
-                    [this](AZ::Data::Instance<AZ::RPI::Model> model) { m_loadedMeshCounter++; }
-                });
-            GetMeshFeatureProcessor()->ConnectModelChangeEventHandler(meshHandle, m_meshLoadEventHandlers.back());
-        }
-        
         m_meshHandles.push_back(AZStd::move(meshHandle));
         m_materials.push_back(material);
     }
@@ -130,7 +121,6 @@ namespace AtomSampleViewer
 
         m_loadedMeshCounter = 0;
         m_waitingForMeshes = false;
-        m_meshLoadEventHandlers.clear();
     }
 
     void DynamicMaterialTestComponent::InitMaterialConfigs()

--- a/Gem/Code/Source/DynamicMaterialTestComponent.h
+++ b/Gem/Code/Source/DynamicMaterialTestComponent.h
@@ -76,8 +76,6 @@ namespace AtomSampleViewer
 
         bool m_waitingForMeshes = false;
         uint32_t m_loadedMeshCounter = 0;
-        AZStd::vector<AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler> m_meshLoadEventHandlers;
-
         float m_currentTime = 0.0f;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/ExposureExampleComponent.cpp
+++ b/Gem/Code/Source/ExposureExampleComponent.cpp
@@ -113,23 +113,23 @@ namespace AtomSampleViewer
         using namespace AZ;
 
         const char* sponzaPath = "objects/sponza.fbx.azmodel";
-        Data::Asset<RPI::ModelAsset> modelAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(sponzaPath, RPI::AssetUtils::TraceLevel::Assert);
-        Data::Asset<RPI::MaterialAsset> materialAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath, RPI::AssetUtils::TraceLevel::Assert);
-        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+        Data::Asset<RPI::ModelAsset> modelAsset =
+            RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(sponzaPath, RPI::AssetUtils::TraceLevel::Assert);
+        Data::Asset<RPI::MaterialAsset> materialAsset =
+            RPI::AssetUtils::GetAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath, RPI::AssetUtils::TraceLevel::Assert);
 
+        Render::MeshHandleDescriptor descriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset));
+        descriptor.m_modelChangedEventHandler =
+            AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler{ [this](const AZ::Data::Instance<AZ::RPI::Model>& model)
+                                                                          {
+                                                                              OnModelReady(model);
+                                                                          } };
+
+        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
+ 
         // rotate the entity 180 degrees about Z (the vertical axis)
         // This makes it consistent with how it was positioned in the world when the world was Y-up.
         GetMeshFeatureProcessor()->SetTransform(m_meshHandle, Transform::CreateRotationZ(AZ::Constants::Pi));
-
-        Data::Instance<RPI::Model> model = GetMeshFeatureProcessor()->GetModel(m_meshHandle);
-        if (model)
-        {
-            OnModelReady(model);
-        }
-        else
-        {
-            GetMeshFeatureProcessor()->ConnectModelChangeEventHandler(m_meshHandle, m_meshChangedHandler);
-        }
 
         SetupLights();
     }

--- a/Gem/Code/Source/ExposureExampleComponent.h
+++ b/Gem/Code/Source/ExposureExampleComponent.h
@@ -73,10 +73,7 @@ namespace AtomSampleViewer
 
         // model
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
-        AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_meshChangedHandler
-        {
-            [&](AZ::Data::Instance<AZ::RPI::Model> model) { OnModelReady(model); }
-        };
+
         bool m_sponzaAssetLoaded = false;
 
         // feature processors

--- a/Gem/Code/Source/EyeMaterialExampleComponent.cpp
+++ b/Gem/Code/Source/EyeMaterialExampleComponent.cpp
@@ -92,7 +92,7 @@ namespace AtomSampleViewer
     void EyeMaterialExampleComponent::LoadMesh(AZ::Transform transform)
     {
         m_materialInstance = AZ::RPI::Material::Create(m_materialAsset);
-        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_modelAsset }, m_materialInstance);
+        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(m_modelAsset, m_materialInstance));
         GetMeshFeatureProcessor()->SetTransform(m_meshHandle, transform);
     }
 

--- a/Gem/Code/Source/LightCullingExampleComponent.cpp
+++ b/Gem/Code/Source/LightCullingExampleComponent.cpp
@@ -204,7 +204,6 @@ namespace AtomSampleViewer
 
     void LightCullingExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
     {
-        m_meshChangedHandler.Disconnect();
         m_worldModelAssetLoaded = true;
         m_worldModelAABB = model->GetModelAsset()->GetAabb();
 
@@ -755,22 +754,19 @@ namespace AtomSampleViewer
 
     void LightCullingExampleComponent::CreateOpaqueModels()
     {
-        Data::Asset<RPI::ModelAsset> modelAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(WorldModelName, RPI::AssetUtils::TraceLevel::Assert);
+        Data::Asset<RPI::ModelAsset> modelAsset =
+            RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(WorldModelName, RPI::AssetUtils::TraceLevel::Assert);
 
-        auto meshFeatureProcessor = GetMeshFeatureProcessor();
+        Render::MeshHandleDescriptor descriptor(modelAsset);
+        descriptor.m_modelChangedEventHandler =
+            AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler{ [this](const AZ::Data::Instance<AZ::RPI::Model>& model)
+                                                                          {
+                                                                              OnModelReady(model);
+                                                                          } };
 
-        m_meshHandle = meshFeatureProcessor->AcquireMesh(MeshHandleDescriptor{ modelAsset });
-        meshFeatureProcessor->SetTransform(m_meshHandle, Transform::CreateIdentity());
-        Data::Instance<RPI::Model> model = meshFeatureProcessor->GetModel(m_meshHandle);
-        // Loading in the world will probably take a while and I want to grab the AABB afterwards, so hook it up to a a ModelChangeEventHandler
-        if (model)
-        {
-            OnModelReady(model);
-        }
-        else
-        {
-            meshFeatureProcessor->ConnectModelChangeEventHandler(m_meshHandle, m_meshChangedHandler);
-        }
+        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
+
+        GetMeshFeatureProcessor()->SetTransform(m_meshHandle, Transform::CreateIdentity());
     }
 
     void LightCullingExampleComponent::CreateTransparentModels()
@@ -787,7 +783,8 @@ namespace AtomSampleViewer
 
         for (const AZ::Vector3& position : TransparentModelPositions)
         {
-            AZ::Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = GetMeshFeatureProcessor()->AcquireMesh(MeshHandleDescriptor{ transparentModelAsset }, materialInstance);
+            AZ::Render::MeshFeatureProcessorInterface::MeshHandle meshHandle =
+                GetMeshFeatureProcessor()->AcquireMesh(MeshHandleDescriptor(transparentModelAsset, materialInstance));
             GetMeshFeatureProcessor()->SetTransform(meshHandle, Transform::CreateTranslation(position));
             m_transparentMeshHandles.push_back(std::move(meshHandle));
         }

--- a/Gem/Code/Source/LightCullingExampleComponent.h
+++ b/Gem/Code/Source/LightCullingExampleComponent.h
@@ -190,10 +190,7 @@ namespace AtomSampleViewer
         float m_originalFarClipDistance = 0.f;
 
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
-        AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_meshChangedHandler
-        {
-            [&](AZ::Data::Instance<AZ::RPI::Model> model) { OnModelReady(model); }
-        };
+
         bool m_worldModelAssetLoaded = false;
 
         AZ::Aabb m_worldModelAABB;

--- a/Gem/Code/Source/MSAA_RPI_ExampleComponent.h
+++ b/Gem/Code/Source/MSAA_RPI_ExampleComponent.h
@@ -63,13 +63,6 @@ namespace AtomSampleViewer
         // sample mesh
         int m_modelType = 0;
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
-        AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_meshChangedHandler
-        {
-            [&](AZ::Data::Instance<AZ::RPI::Model> model)
-            {
-                OnModelReady(model);
-            }
-        };
 
         // original render pipeline when the sample was started
         AZ::RPI::RenderPipelinePtr m_originalPipeline;

--- a/Gem/Code/Source/MeshExampleComponent.h
+++ b/Gem/Code/Source/MeshExampleComponent.h
@@ -101,8 +101,6 @@ namespace AtomSampleViewer
         static const uint32_t CameraControllerCount = static_cast<uint32_t>(CameraControllerType::Count);
         static const char* CameraControllerNameTable[CameraControllerCount];
         CameraControllerType m_currentCameraControllerType = CameraControllerType::ArcBall;
-
-        AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_changedHandler;
         
         static constexpr float ArcballRadiusMinModifier = 0.01f;
         static constexpr float ArcballRadiusMaxModifier = 4.0f;

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
@@ -110,10 +110,10 @@ namespace AtomSampleViewer
             RPI::AssetUtils::TraceLevel::Assert);
         auto floorAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::ModelAsset>(CubeModelFilePath,
             RPI::AssetUtils::TraceLevel::Assert);
-        m_floorMeshHandle = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor{ floorAsset }, material);
+        m_floorMeshHandle = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor(floorAsset, material));
         for (uint32_t bunnyIndex = 0; bunnyIndex < BunnyCount; bunnyIndex++)
         {
-            m_bunnyMeshHandles[bunnyIndex] = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor{ bunnyAsset }, material);
+            m_bunnyMeshHandles[bunnyIndex] = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor(bunnyAsset, material));
         }
 
         const Vector3 floorNonUniformScale{ 12.f, 12.f, 0.1f };

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -132,43 +132,38 @@ namespace AtomSampleViewer
         m_postProcessFeatureProcessor = m_scene->GetFeatureProcessor<Render::PostProcessFeatureProcessorInterface>();
 
         // Helper function to load meshes
-        const auto LoadMesh = [this](const char* modelPath) -> Render::MeshFeatureProcessorInterface::MeshHandle
+        auto LoadMesh = [this](
+                            const char* modelPath,
+                            const ModelChangedHandler& modelChangedHandler) -> Render::MeshFeatureProcessorInterface::MeshHandle
         {
             AZ_Assert(m_meshFeatureProcessor, "Cannot find mesh feature processor on scene");
 
-            auto meshAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(modelPath, RPI::AssetUtils::TraceLevel::Assert);            
-            auto materialAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath,
-                RPI::AssetUtils::TraceLevel::Assert);
+            auto meshAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::ModelAsset>(modelPath, RPI::AssetUtils::TraceLevel::Assert);
+            auto materialAsset =
+                RPI::AssetUtils::LoadAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath, RPI::AssetUtils::TraceLevel::Assert);
             auto material = AZ::RPI::Material::FindOrCreate(materialAsset);
-            Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = m_meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor{ meshAsset }, material);
 
+            Render::MeshHandleDescriptor descriptor(meshAsset, material);
+            descriptor.m_modelChangedEventHandler = modelChangedHandler;
+            Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = m_meshFeatureProcessor->AcquireMesh(descriptor);
             return meshHandle;
         };
 
         // Create the ShaderBalls
         {
-            for (uint32_t i = 0u; i < ShaderBallCount; i++)
+            m_shaderBallMeshHandles.resize(ShaderBallCount);
+            for (uint32_t i = 0u; i < ShaderBallCount; ++i)
             {
-                m_shaderBallMeshHandles.push_back(LoadMesh(ShaderBallModelFilePath));
-                auto updateShaderBallTransform = [this, i](Data::Instance<RPI::Model> model)
-                {
-                    const Aabb& aabb = model->GetModelAsset()->GetAabb();
-                    const Vector3 translation{ 0.0f, -aabb.GetMin().GetZ() * aznumeric_cast<float>(i), -aabb.GetMin().GetY() };
-                    const auto transform = Transform::CreateTranslation(translation);
-                    m_meshFeatureProcessor->SetTransform(m_shaderBallMeshHandles[i], transform);
-                };
-
-                // If the model is available already, set the tranform immediately, else utilize the EBus::Event feature
-                Data::Instance<RPI::Model> shaderBallModel = m_meshFeatureProcessor->GetModel(m_shaderBallMeshHandles[i]);
-                if (shaderBallModel)
-                {
-                    updateShaderBallTransform(shaderBallModel);
-                }
-                else
-                {
-                    m_shaderBallChangedHandles.push_back(ModelChangedHandler(updateShaderBallTransform));
-                    m_meshFeatureProcessor->ConnectModelChangeEventHandler(m_shaderBallMeshHandles[i], m_shaderBallChangedHandles.back());
-                }
+                m_shaderBallMeshHandles[i] = LoadMesh(
+                    ShaderBallModelFilePath,
+                    ModelChangedHandler{
+                        [this, i](const Data::Instance<RPI::Model>& model)
+                        {
+                            const Aabb& aabb = model->GetModelAsset()->GetAabb();
+                            const Vector3 translation{ 0.0f, -aabb.GetMin().GetZ() * aznumeric_cast<float>(i), -aabb.GetMin().GetY() };
+                            const auto transform = Transform::CreateTranslation(translation);
+                            m_meshFeatureProcessor->SetTransform(m_shaderBallMeshHandles[i], transform);
+                        } });
             }
         }
 
@@ -177,7 +172,7 @@ namespace AtomSampleViewer
             const Vector3 nonUniformScale{ 24.f, 24.f, 1.0f };
             const Vector3 translation{ 0.f, 0.f, 0.0f };
             const auto transform = Transform::CreateTranslation(translation);
-            m_floorMeshHandle = LoadMesh(CubeModelFilePath);
+            m_floorMeshHandle = LoadMesh(CubeModelFilePath, ModelChangedHandler{});
             m_meshFeatureProcessor->SetTransform(m_floorMeshHandle, transform, nonUniformScale);
         }
 
@@ -437,7 +432,7 @@ namespace AtomSampleViewer
             auto material = AZ::RPI::Material::FindOrCreate(materialAsset);
             auto bunnyAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::ModelAsset>(BunnyModelFilePath,
                 RPI::AssetUtils::TraceLevel::Assert);
-            m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor{ bunnyAsset }, material);
+            m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor(bunnyAsset, material));
 
             GetMeshFeatureProcessor()->SetTransform(m_meshHandle, Transform::CreateRotationZ(Constants::Pi));
         }

--- a/Gem/Code/Source/MultiSceneExampleComponent.h
+++ b/Gem/Code/Source/MultiSceneExampleComponent.h
@@ -35,7 +35,7 @@ namespace AtomSampleViewer
         : public AZ::TickBus::Handler
         , public AzFramework::WindowNotificationBus::Handler
     {
-        using ModelChangedHandler = AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler;
+        using ModelChangedHandler = AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler;
         using PointLightHandle = AZ::Render::PointLightFeatureProcessorInterface::LightHandle;
         using DiskLightHandle = AZ::Render::DiskLightFeatureProcessorInterface::LightHandle;
         using DirectionalLightHandle = AZ::Render::DirectionalLightFeatureProcessorInterface::LightHandle;
@@ -85,9 +85,6 @@ namespace AtomSampleViewer
         // Meshes
         AZStd::vector<AZ::Render::MeshFeatureProcessorInterface::MeshHandle> m_shaderBallMeshHandles;
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_floorMeshHandle;
-
-        // Model change handlers
-        AZStd::vector<ModelChangedHandler> m_shaderBallChangedHandles;
 
         // Various FeatureProcessor handles
         PointLightHandle m_pointLightHandle;

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
@@ -157,7 +157,8 @@ namespace AtomSampleViewer
         AZ::Data::Instance<AZ::RPI::Material> material,
         AZ::Transform transform)
     {
-        AZ::Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, material);
+        AZ::Render::MeshFeatureProcessorInterface::MeshHandle meshHandle =
+            GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(modelAsset, material));
         GetMeshFeatureProcessor()->SetTransform(meshHandle, transform);
         return meshHandle;
     }

--- a/Gem/Code/Source/Performance/HighInstanceExampleComponent.cpp
+++ b/Gem/Code/Source/Performance/HighInstanceExampleComponent.cpp
@@ -242,7 +242,7 @@ namespace AtomSampleViewer
                 AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;
                 modelAsset.Create(instanceData.m_modelAssetId);
 
-                instanceData.m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, materialInstance);
+                instanceData.m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(modelAsset, materialInstance));
                 GetMeshFeatureProcessor()->SetTransform(instanceData.m_meshHandle, instanceData.m_transform);
             }
         }

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -459,7 +459,7 @@ namespace AtomSampleViewer
 
             commandList->BuildBottomLevelAccelerationStructure(*m_triangleRayTracingBlas);
             commandList->BuildBottomLevelAccelerationStructure(*m_rectangleRayTracingBlas);
-            commandList->BuildTopLevelAccelerationStructure(*m_rayTracingTlas);
+            commandList->BuildTopLevelAccelerationStructure(*m_rayTracingTlas, {});
         };
 
         m_scopeProducers.emplace_back(

--- a/Gem/Code/Source/RenderTargetTextureExampleComponent.cpp
+++ b/Gem/Code/Source/RenderTargetTextureExampleComponent.cpp
@@ -229,7 +229,7 @@ namespace AtomSampleViewer
         // bunny mesh
         auto bunnyAsset = RPI::AssetUtils::LoadAssetByProductPath<RPI::ModelAsset>(BunnyModelFilePath,
             RPI::AssetUtils::TraceLevel::Assert);
-        m_meshHandle = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor{ bunnyAsset }, m_material);
+        m_meshHandle = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor(bunnyAsset, m_material));
         meshFeatureProcessor->SetTransform(m_meshHandle, Transform::CreateTranslation(Vector3(0.f, 0.f, 0.21f)));
 
         // Set camera to use no clip controller and adjust its fov and transform

--- a/Gem/Code/Source/SSRExampleComponent.cpp
+++ b/Gem/Code/Source/SSRExampleComponent.cpp
@@ -86,7 +86,8 @@ namespace AtomSampleViewer
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             transform.SetTranslation(0.0f, 0.0f, -0.05f);
 
-            m_statueMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_statueMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_statueMeshHandle, transform);
         }
 
@@ -97,7 +98,8 @@ namespace AtomSampleViewer
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             transform.SetTranslation(-4.5f, 0.0f, 0.49f);
 
-            m_boxMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_boxMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_boxMeshHandle, transform);
         }
 
@@ -109,7 +111,8 @@ namespace AtomSampleViewer
             transform *= AZ::Transform::CreateRotationZ(AZ::Constants::Pi);
             transform.SetTranslation(4.5f, 0.0f, 0.89f);
 
-            m_shaderBallMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_shaderBallMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_shaderBallMeshHandle, transform);
         }
     }
@@ -145,7 +148,8 @@ namespace AtomSampleViewer
 
         // load mesh
         AZ::Data::Asset<AZ::RPI::ModelAsset> planeModel = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/plane.fbx.azmodel", AZ::RPI::AssetUtils::TraceLevel::Error);
-        m_groundMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ planeModel }, AZ::RPI::Material::FindOrCreate(m_groundMaterialAsset));
+        m_groundMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+            AZ::Render::MeshHandleDescriptor(planeModel, AZ::RPI::Material::FindOrCreate(m_groundMaterialAsset)));
 
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         const AZ::Vector3 nonUniformScale(15.0f, 15.0f, 1.0f);

--- a/Gem/Code/Source/SceneReloadSoakTestComponent.cpp
+++ b/Gem/Code/Source/SceneReloadSoakTestComponent.cpp
@@ -103,9 +103,9 @@ namespace AtomSampleViewer
         Data::Asset<ModelAsset> modelAsset;
         modelAsset.Create(m_modelAssetId);
 
-        auto meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor{ modelAsset }, materialInstance);
+        auto meshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor(modelAsset, materialInstance));
         GetMeshFeatureProcessor()->SetTransform(meshHandle, transform);
-        m_meshHandles.push_back(AZStd::move(meshHandle));
+        m_meshHandles.emplace_back(AZStd::move(meshHandle));
     }
 
     void SceneReloadSoakTestComponent::DestroyLatticeInstances()

--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -342,11 +342,7 @@ namespace AtomSampleViewer
     {
         using namespace AZ;
 
-        m_materialInstance = RPI::Material::FindOrCreate(m_materialAsset);
-        m_floorMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor{ m_floorModelAsset }, m_materialInstance);
-        m_bunnyMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(Render::MeshHandleDescriptor{ m_bunnyModelAsset }, m_materialInstance);
-
-        auto updateFloorTransform = [&](Data::Instance<RPI::Model> model)
+        auto updateFloorTransform = [&](const Data::Instance<RPI::Model>& model)
         {
             const AZ::Aabb& aabb = model->GetModelAsset()->GetAabb();
             const float maxZ = aabb.GetMax().GetZ();
@@ -355,14 +351,14 @@ namespace AtomSampleViewer
             const auto transform = AZ::Transform::CreateTranslation(translation);
             GetMeshFeatureProcessor()->SetTransform(m_floorMeshHandle, transform, nonUniformScale);
             m_floorMeshIsReady = true;
-            if (m_bunnyMeshIsReady)
+            if (m_bunnyMeshIsReady || m_floorMeshIsReady)
             {
                 // Now that the models are initialized, we can allow the script to continue.
                 ScriptRunnerRequestBus::Broadcast(&ScriptRunnerRequests::ResumeScript);
             }
         };
 
-        auto updateBunnyTransform = [&](Data::Instance<RPI::Model> model)
+        auto updateBunnyTransform = [&](const Data::Instance<RPI::Model>& model)
         {
             const AZ::Aabb& aabb = model->GetModelAsset()->GetAabb();
             const float minZ = aabb.GetMin().GetZ();
@@ -371,31 +367,25 @@ namespace AtomSampleViewer
             transform.SetUniformScale(1.5f);
             GetMeshFeatureProcessor()->SetTransform(m_bunnyMeshHandle, transform);
             m_bunnyMeshIsReady = true;
-            if (m_floorMeshIsReady)
+            if (m_bunnyMeshIsReady || m_floorMeshIsReady)
             {
                 // Now that the models are initialized, we can allow the script to continue.
                 ScriptRunnerRequestBus::Broadcast(&ScriptRunnerRequests::ResumeScript);
             }
         };
 
-        m_floorReadyHandle = ModelChangedHandler(updateFloorTransform);
-        m_bunnyReadyHandle = ModelChangedHandler(updateBunnyTransform);
+        m_materialInstance = RPI::Material::FindOrCreate(m_materialAsset);
 
-        GetMeshFeatureProcessor()->ConnectModelChangeEventHandler(m_floorMeshHandle, m_floorReadyHandle);
-        GetMeshFeatureProcessor()->ConnectModelChangeEventHandler(m_bunnyMeshHandle, m_bunnyReadyHandle);
-
-        // Currently there's no way for the mesh feature procesor to announce change on connect if the model is ready already.
-        // This can go away when AZ::Event::Handler's callback can be called publicly.
-        Data::Instance<RPI::Model> floorModel = GetMeshFeatureProcessor()->GetModel(m_floorMeshHandle);
-        if (floorModel)
         {
-            updateFloorTransform(floorModel);
+            Render::MeshHandleDescriptor descriptor(m_floorModelAsset, m_materialInstance);
+            descriptor.m_modelChangedEventHandler = AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler(updateFloorTransform);
+            m_floorMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
         }
 
-        Data::Instance<RPI::Model> bunnyModel = GetMeshFeatureProcessor()->GetModel(m_bunnyMeshHandle);
-        if (bunnyModel)
         {
-            updateBunnyTransform(bunnyModel);
+            Render::MeshHandleDescriptor descriptor(m_bunnyModelAsset, m_materialInstance);
+            descriptor.m_modelChangedEventHandler = AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler(updateBunnyTransform);
+            m_bunnyMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
         }
     }
 

--- a/Gem/Code/Source/ShadowExampleComponent.h
+++ b/Gem/Code/Source/ShadowExampleComponent.h
@@ -119,9 +119,6 @@ namespace AtomSampleViewer
         AZ::Data::Instance<AZ::RPI::Material> m_materialInstance;
 
         // ModelReadyHandles
-        using ModelChangedHandler = AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler;
-        ModelChangedHandler m_bunnyReadyHandle;
-        ModelChangedHandler m_floorReadyHandle;
         bool m_bunnyMeshIsReady = false;
         bool m_floorMeshIsReady = false;
 

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.h
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.h
@@ -104,10 +104,6 @@ namespace AtomSampleViewer
 
         // model
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
-        AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_meshChangedHandler
-        {
-            [&](AZ::Data::Instance<AZ::RPI::Model> model) { OnModelReady(model); }
-        };
         bool m_sponzaExteriorAssetLoaded = false;
 
         // GUI

--- a/Gem/Code/Source/SkinnedMeshContainer.cpp
+++ b/Gem/Code/Source/SkinnedMeshContainer.cpp
@@ -172,13 +172,12 @@ namespace AtomSampleViewer
 
             if (renderData.m_skinnedMeshInstance->m_model)
             {
-                AZ::Render::MeshHandleDescriptor meshDescriptor;
-                meshDescriptor.m_modelAsset = renderData.m_skinnedMeshInstance->m_model->GetModelAsset();
+                AZ::Render::MeshHandleDescriptor meshDescriptor(
+                    renderData.m_skinnedMeshInstance->m_model->GetModelAsset(), materialOverrideInstance);
                 meshDescriptor.m_isRayTracingEnabled = false;
                 meshDescriptor.m_isAlwaysDynamic = true;
-                renderData.m_meshHandle =
-                    AZStd::make_shared<AZ::Render::MeshFeatureProcessorInterface::MeshHandle>(m_meshFeatureProcessor->AcquireMesh(
-                        meshDescriptor, materialOverrideInstance));
+                renderData.m_meshHandle = AZStd::make_shared<AZ::Render::MeshFeatureProcessorInterface::MeshHandle>(
+                    m_meshFeatureProcessor->AcquireMesh(meshDescriptor));
                 m_meshFeatureProcessor->SetTransform(*renderData.m_meshHandle, renderData.m_rootTransform);
             }
             // If render proxies already exist, they will be auto-freed

--- a/Gem/Code/Source/SkinnedMeshExampleComponent.cpp
+++ b/Gem/Code/Source/SkinnedMeshExampleComponent.cpp
@@ -53,7 +53,7 @@ namespace AtomSampleViewer
     void SkinnedMeshExampleComponent::CreatePlaneObject()
     {
         auto meshAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/plane.fbx.azmodel");
-        m_planeMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ meshAsset });
+        m_planeMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(meshAsset));
         GetMeshFeatureProcessor()->SetTransform(m_planeMeshHandle, AZ::Transform::CreateIdentity());
     }
 

--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -108,7 +108,7 @@ namespace AtomSampleViewer
         m_sponzaInteriorAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>
             ("Objects/Sponza.fbx.azmodel", traceLevel);
 
-        m_sponzaInteriorMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_sponzaInteriorAsset });
+        m_sponzaInteriorMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor(m_sponzaInteriorAsset));
 
         // rotate the entities 180 degrees about Z (the vertical axis)
         // This makes it consistent with how it was positioned in the world when the world was Y-up.

--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -102,20 +102,15 @@ namespace AtomSampleViewer
         Data::Asset<RPI::MaterialAsset> materialAsset = RPI::AssetUtils::GetAssetByProductPath<RPI::MaterialAsset>(DefaultPbrMaterialPath, RPI::AssetUtils::TraceLevel::Assert);
 
         // Create Mesh and Model
-        MeshFeatureProcessorInterface* meshFeatureProcessor = GetMeshFeatureProcessor();
-        m_meshHandle = meshFeatureProcessor->AcquireMesh(MeshHandleDescriptor{ modelAsset }, RPI::Material::FindOrCreate(materialAsset));
-        meshFeatureProcessor->SetTransform(m_meshHandle, Transform::CreateIdentity());
-        Data::Instance<RPI::Model> model = meshFeatureProcessor->GetModel(m_meshHandle);
+        Render::MeshHandleDescriptor descriptor(modelAsset, RPI::Material::FindOrCreate(materialAsset));
+        descriptor.m_modelChangedEventHandler =
+            AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler{ [this](const AZ::Data::Instance<AZ::RPI::Model>& model)
+                                                                          {
+                                                                              OnModelReady(model);
+                                                                          } };
 
-        // Async Model loading
-        if (model)
-        {
-            OnModelReady(model);
-        }
-        else
-        {
-            meshFeatureProcessor->ConnectModelChangeEventHandler(m_meshHandle, m_meshChangedHandler);
-        }
+        m_meshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
+        GetMeshFeatureProcessor()->SetTransform(m_meshHandle, Transform::CreateIdentity());
     }
 
     void SsaoExampleComponent::DeactivateModel()

--- a/Gem/Code/Source/SsaoExampleComponent.h
+++ b/Gem/Code/Source/SsaoExampleComponent.h
@@ -72,13 +72,6 @@ namespace AtomSampleViewer
         void SwitchAOType();
 
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
-        AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler m_meshChangedHandler
-        {
-            [&](AZ::Data::Instance<AZ::RPI::Model> model)
-            {
-                OnModelReady(model);
-            }
-        };
         
         AZ::RPI::RenderPipelinePtr m_ssaoPipeline;
         AZ::RPI::RenderPipelinePtr m_originalPipeline;

--- a/Gem/Code/Source/TransparencyExampleComponent.cpp
+++ b/Gem/Code/Source/TransparencyExampleComponent.cpp
@@ -74,7 +74,6 @@ namespace AtomSampleViewer
         }
         m_meshHandles.clear();
 
-        m_meshLoadEventHandlers.clear();
         AZ::TickBus::Handler::BusDisconnect();
     }
 
@@ -140,22 +139,15 @@ namespace AtomSampleViewer
     {
         auto materialInstance = AZ::RPI::Material::Create(m_materialAsset);
 
-        AZ::Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ m_modelAsset }, materialInstance);
-        GetMeshFeatureProcessor()->SetTransform(meshHandle, transform);
+        AZ::Render::MeshHandleDescriptor descriptor(m_modelAsset, materialInstance);
+        descriptor.m_modelChangedEventHandler =
+            AZ::Render::MeshHandleDescriptor::ModelChangedEvent::Handler{ [this](const AZ::Data::Instance<AZ::RPI::Model>& /*model*/)
+                                                                          {
+                                                                              m_loadedMeshCounter++;
+                                                                          } };
 
-        AZ::Data::Instance<AZ::RPI::Model> model = GetMeshFeatureProcessor()->GetModel(meshHandle);
-        if (model)
-        {
-            m_loadedMeshCounter++;
-        }
-        else
-        {
-            m_meshLoadEventHandlers.push_back(AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler
-                {
-                    [this](AZ::Data::Instance<AZ::RPI::Model> model) { m_loadedMeshCounter++; }
-                });
-            GetMeshFeatureProcessor()->ConnectModelChangeEventHandler(meshHandle, m_meshLoadEventHandlers.back());
-        }
+        AZ::Render::MeshFeatureProcessorInterface::MeshHandle meshHandle = GetMeshFeatureProcessor()->AcquireMesh(descriptor);
+        GetMeshFeatureProcessor()->SetTransform(meshHandle, transform);
 
         m_meshHandles.push_back(std::move(meshHandle));
     }

--- a/Gem/Code/Source/TransparencyExampleComponent.h
+++ b/Gem/Code/Source/TransparencyExampleComponent.h
@@ -43,7 +43,6 @@ namespace AtomSampleViewer
         AZ::Data::Asset<AZ::RPI::ModelAsset> m_modelAsset;
         AZ::Data::Asset<AZ::RPI::MaterialAsset> m_materialAsset;
         AZStd::vector<AZ::Render::MeshFeatureProcessorInterface::MeshHandle> m_meshHandles;
-        AZStd::vector<AZ::Render::MeshFeatureProcessorInterface::ModelChangedEvent::Handler> m_meshLoadEventHandlers;
         Utils::DefaultIBL m_defaultIbl;
 
         bool m_waitingForMeshes = false;

--- a/Gem/Code/Source/Utils/Utils.cpp
+++ b/Gem/Code/Source/Utils/Utils.cpp
@@ -170,11 +170,12 @@ namespace AtomSampleViewer
             constexpr uint32_t width = 4;
             constexpr uint32_t height = 4;
 
-            AZStd::string assetName = AZStd::string::format("SolidColorBackground_%u", color);
-            AZ::Data::AssetId assetId = AZ::Uuid::CreateName(assetName.c_str());
+            const AZStd::string assetName = AZStd::string::format("SolidColorBackground_%u", color);
+            const AZ::Data::InstanceId instanceId = AZ::Data::InstanceId::CreateName(assetName.c_str());
 
             // Check for existing image of the same color
-            AZ::Data::Instance<AZ::RPI::StreamingImage> existingImage = AZ::Data::InstanceDatabase<AZ::RPI::StreamingImage>::Instance().Find(AZ::Data::InstanceId::CreateFromAssetId(assetId));
+            AZ::Data::Instance<AZ::RPI::StreamingImage> existingImage =
+                AZ::Data::InstanceDatabase<AZ::RPI::StreamingImage>::Instance().Find(instanceId);
             if (existingImage)
             {
                 return existingImage;
@@ -193,7 +194,7 @@ namespace AtomSampleViewer
             // Create a new streaming image
 
             AZ::RPI::StreamingImageAssetCreator imageCreator;
-            imageCreator.Begin(assetId);
+            imageCreator.Begin(AZ::Data::AssetId(instanceId.GetGuid(), 0));
 
             int32_t arraySize = 6;
             AZ::RHI::Format format = AZ::RHI::Format::R8G8B8A8_UNORM_SRGB;
@@ -209,8 +210,7 @@ namespace AtomSampleViewer
             // Create the mip chain
 
             AZ::RPI::ImageMipChainAssetCreator mipChainCreator;
-            assetId.m_subId = 1;
-            mipChainCreator.Begin(assetId, 1, 6);
+            mipChainCreator.Begin(AZ::Data::AssetId(instanceId.GetGuid(), 1), 1, 6);
 
             uint32_t pitch = width * pixelSize;
 
@@ -236,7 +236,7 @@ namespace AtomSampleViewer
             AZ::Data::Asset<AZ::RPI::StreamingImageAsset> imageAsset;
             imageCreator.End(imageAsset);
 
-            return AZ::RPI::StreamingImage::FindOrCreate(imageAsset);
+            return AZ::Data::InstanceDatabase<AZ::RPI::StreamingImage>::Instance().FindOrCreate(instanceId, imageAsset);
         }
 
         AZStd::string ResolvePath(const AZStd::string& path)

--- a/Gem/Code/Source/XRRPIExampleComponent.cpp
+++ b/Gem/Code/Source/XRRPIExampleComponent.cpp
@@ -93,7 +93,8 @@ namespace AtomSampleViewer
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             transform.SetTranslation(0.0f, 0.0f, -0.05f);
 
-            m_statueMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_statueMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_statueMeshHandle, transform);
         }
 
@@ -104,7 +105,8 @@ namespace AtomSampleViewer
             AZ::Transform transform = AZ::Transform::CreateIdentity();
             transform.SetTranslation(-4.5f, 0.0f, 0.49f);
 
-            m_boxMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_boxMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_boxMeshHandle, transform);
         }
 
@@ -116,7 +118,8 @@ namespace AtomSampleViewer
             transform *= AZ::Transform::CreateRotationZ(AZ::Constants::Pi);
             transform.SetTranslation(4.5f, 0.0f, 0.89f);
 
-            m_shaderBallMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_shaderBallMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_shaderBallMeshHandle, transform);
         }
 
@@ -126,8 +129,10 @@ namespace AtomSampleViewer
             AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/left_hand_controller.fbx.azmodel", AZ::RPI::AssetUtils::TraceLevel::Assert);
             AZ::Transform transform = AZ::Transform::CreateIdentity();
 
-            m_leftControllerMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
-            m_rightControllerMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ modelAsset }, AZ::RPI::Material::FindOrCreate(materialAsset));
+            m_leftControllerMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
+            m_rightControllerMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+                AZ::Render::MeshHandleDescriptor(modelAsset, AZ::RPI::Material::FindOrCreate(materialAsset)));
             GetMeshFeatureProcessor()->SetTransform(m_leftControllerMeshHandle, transform);
             GetMeshFeatureProcessor()->SetTransform(m_rightControllerMeshHandle, transform);
         }
@@ -164,7 +169,8 @@ namespace AtomSampleViewer
 
         // load mesh
         AZ::Data::Asset<AZ::RPI::ModelAsset> planeModel = AZ::RPI::AssetUtils::GetAssetByProductPath<AZ::RPI::ModelAsset>("objects/plane.fbx.azmodel", AZ::RPI::AssetUtils::TraceLevel::Error);
-        m_groundMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(AZ::Render::MeshHandleDescriptor{ planeModel }, AZ::RPI::Material::FindOrCreate(m_groundMaterialAsset));
+        m_groundMeshHandle = GetMeshFeatureProcessor()->AcquireMesh(
+            AZ::Render::MeshHandleDescriptor(planeModel, AZ::RPI::Material::FindOrCreate(m_groundMaterialAsset)));
 
         AZ::Transform transform = AZ::Transform::CreateIdentity();
         const AZ::Vector3 nonUniformScale(15.0f, 15.0f, 1.0f);


### PR DESCRIPTION
This is a companion to the following pr, https://github.com/o3de/o3de/pull/17309, which updates the mesh feature processor, descriptor, and acquire function to preset custom materials and event handlers so they are available before acquire is called.