### PR TITLE
Ensure directional light shadow is turned on by default in the ASV examples

### DIFF
--- a/Gem/Code/Source/CullingAndLodExampleComponent.cpp
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.cpp
@@ -224,6 +224,7 @@ namespace AtomSampleViewer
             dirLightFP->SetDirection(handle, lightTransform.GetBasis(1));
 
             dirLightFP->SetRgbIntensity(handle, Render::PhotometricColor<Render::PhotometricUnit::Lux>(m_directionalLightIntensity * DirectionalLightColor));
+            dirLightFP->SetShadowEnabled(handle, m_dirShadowEnabled);
             dirLightFP->SetCascadeCount(handle, s_cascadesCountDefault);
             dirLightFP->SetShadowmapSize(handle, s_shadowmapSizes[s_shadowmapSizeIndexDefault]);
             dirLightFP->SetDebugFlags(handle,

--- a/Gem/Code/Source/CullingAndLodExampleComponent.h
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.h
@@ -116,6 +116,7 @@ namespace AtomSampleViewer
         static constexpr int s_shadowmapSizeIndexDefault = 3;
         static constexpr int s_cascadesCountDefault = 4;
         static constexpr float s_ratioLogarithmUniformDefault = 0.8f;
+        bool m_dirShadowEnabled = true;
         int m_directionalLightShadowmapSizeIndex = 0;
         int m_cascadeCount = 0;
         float m_ratioLogarithmUniform = 0.f;

--- a/Gem/Code/Source/DiffuseGIExampleComponent.cpp
+++ b/Gem/Code/Source/DiffuseGIExampleComponent.cpp
@@ -399,6 +399,7 @@ namespace AtomSampleViewer
             const auto lightTransform = AZ::Transform::CreateRotationZ(m_directionalLightYaw) * AZ::Transform::CreateRotationX(m_directionalLightPitch);
             directionalLightFeatureProcessor->SetDirection(m_directionalLightHandle, lightTransform.GetBasis(1));
             directionalLightFeatureProcessor->SetRgbIntensity(m_directionalLightHandle, AZ::Render::PhotometricColor<AZ::Render::PhotometricUnit::Lux>(m_directionalLightIntensity * m_directionalLightColor));
+            directionalLightFeatureProcessor->SetShadowEnabled(m_directionalLightHandle, true);
             directionalLightFeatureProcessor->SetCascadeCount(m_directionalLightHandle, 4);
             directionalLightFeatureProcessor->SetShadowmapSize(m_directionalLightHandle, AZ::Render::ShadowmapSize::Size2048);
             directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(m_directionalLightHandle, false);

--- a/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
+++ b/Gem/Code/Source/MultiRenderPipelineExampleComponent.cpp
@@ -214,6 +214,7 @@ namespace AtomSampleViewer
         featureProcessor->SetDirection(handle, lightTransform.GetBasis(1));
         AZ::Render::PhotometricColor<AZ::Render::PhotometricUnit::Lux> lightColor(Color::CreateOne() * 5.0f);
         featureProcessor->SetRgbIntensity(handle, lightColor);
+        featureProcessor->SetShadowEnabled(handle, true);
         featureProcessor->SetCascadeCount(handle, 4);
         featureProcessor->SetShadowmapSize(handle, Render::ShadowmapSize::Size2048);
         featureProcessor->SetViewFrustumCorrectionEnabled(handle, true);

--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -252,6 +252,7 @@ namespace AtomSampleViewer
             const auto lightDir = Transform::CreateLookAt(
                 helperPosition,
                 Vector3::CreateZero());
+            m_directionalLightFeatureProcessor->SetShadowEnabled(m_directionalLightHandle, true);
             m_directionalLightFeatureProcessor->SetDirection(m_directionalLightHandle, lightDir.GetBasis(1));
 
             m_directionalLightFeatureProcessor->SetShadowmapSize(m_directionalLightHandle, Render::ShadowmapSize::Size512);

--- a/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
+++ b/Gem/Code/Source/ParallaxMappingExampleComponent.cpp
@@ -167,6 +167,7 @@ namespace AtomSampleViewer
     {
         const AZ::Render::DirectionalLightFeatureProcessorInterface::LightHandle handle = m_directionalLightFeatureProcessor->AcquireLight();
 
+        m_directionalLightFeatureProcessor->SetShadowEnabled(handle, true);
         m_directionalLightFeatureProcessor->SetShadowmapSize(handle, AZ::Render::ShadowmapSize::Size2048);
         m_directionalLightFeatureProcessor->SetCascadeCount(handle, 4);
         m_directionalLightFeatureProcessor->SetShadowmapFrustumSplitSchemeRatio(handle, 0.5f);

--- a/Gem/Code/Source/Performance/HighInstanceExampleComponent.cpp
+++ b/Gem/Code/Source/Performance/HighInstanceExampleComponent.cpp
@@ -504,6 +504,7 @@ namespace AtomSampleViewer
             lightTransform.GetBasis(1));
 
         featureProcessor->SetRgbIntensity(handle, AZ::Render::PhotometricColor<AZ::Render::PhotometricUnit::Lux>(AZ::Color::CreateOne() * m_testParameters.m_directionalLightIntensity));
+        featureProcessor->SetShadowEnabled(handle, true);
         featureProcessor->SetCascadeCount(handle, m_testParameters.m_numDirectionalLightShadowCascades);
         featureProcessor->SetShadowmapSize(handle, m_testParameters.m_shadowmapSize);
         featureProcessor->SetViewFrustumCorrectionEnabled(handle, false);

--- a/Gem/Code/Source/ShadowExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowExampleComponent.cpp
@@ -398,6 +398,7 @@ namespace AtomSampleViewer
 
         AZ::Render::PhotometricColor<AZ::Render::PhotometricUnit::Lux> lightColor(DirectionalLightColor * m_directionalLightIntensity);
         featureProcessor->SetRgbIntensity(handle, lightColor);
+        featureProcessor->SetShadowEnabled(handle, m_shadowEnabled);
         featureProcessor->SetShadowmapSize(handle, s_shadowmapImageSizes[m_directionalLightImageSizeIndex]);
         featureProcessor->SetShadowFarClipDistance(handle, FarClipDistance);
         featureProcessor->SetCascadeCount(handle, static_cast<uint16_t>(m_cascadeCount));

--- a/Gem/Code/Source/ShadowExampleComponent.h
+++ b/Gem/Code/Source/ShadowExampleComponent.h
@@ -153,6 +153,8 @@ namespace AtomSampleViewer
             FarClipDistance * 3 / 4,
             FarClipDistance * 4 / 4
         };
+
+        bool m_shadowEnabled = true;
         bool m_useFullscreenBlur = false;
         bool m_isCascadeCorrectionEnabled = false;
         bool m_isDebugColoringEnabled = false;

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.cpp
@@ -242,6 +242,7 @@ namespace AtomSampleViewer
                 lightTransform.GetBasis(1));
 
             featureProcessor->SetRgbIntensity(handle, AZ::Render::PhotometricColor<AZ::Render::PhotometricUnit::Lux>(DirectionalLightColor * m_directionalLightIntensity));
+            featureProcessor->SetShadowEnabled(handle, m_shadowEnabled);
             featureProcessor->SetCascadeCount(handle, s_cascadesCountDefault);
             featureProcessor->SetShadowmapSize(handle, s_shadowmapSizes[s_shadowmapSizeIndexDefault]);
             featureProcessor->SetViewFrustumCorrectionEnabled(handle, m_isCascadeCorrectionEnabled);

--- a/Gem/Code/Source/ShadowedSponzaExampleComponent.h
+++ b/Gem/Code/Source/ShadowedSponzaExampleComponent.h
@@ -137,6 +137,7 @@ namespace AtomSampleViewer
         int m_filteringSampleCountDirectional = 16;
         int m_filteringSampleCountDisk = 16;
 
+        bool m_shadowEnabled = true;
         bool m_useFullscreenBlur = false;
         bool m_isCascadeCorrectionEnabled = false;
         bool m_isDebugColoringEnabled = false;

--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -153,6 +153,7 @@ namespace AtomSampleViewer
 
         AZ::Render::PhotometricColor<AZ::Render::PhotometricUnit::Lux> sunColor(AZ::Color(1.0f, 1.0f, 0.97f, 1.0f) * 20.f);
         m_directionalLightFeatureProcessor->SetRgbIntensity(handle, sunColor);
+        m_directionalLightFeatureProcessor->SetShadowEnabled(handle, true);
         m_directionalLightFeatureProcessor->SetCascadeCount(handle, 4);
         m_directionalLightFeatureProcessor->SetShadowmapSize(handle, AZ::Render::ShadowmapSizeNamespace::ShadowmapSize::Size2048);
         m_directionalLightFeatureProcessor->SetViewFrustumCorrectionEnabled(handle, true);


### PR DESCRIPTION
This should fix some of the failed test cases in #657 

Partially Fix #657 

This PR is to set the directional light shadow to be enabled by default due to [https://github.com/o3de/o3de/pull/16913](https://github.com/o3de/o3de/pull/16913) grants access to control whether or not a directional light is casting shadow.

![image](https://github.com/o3de/o3de-atom-sampleviewer/assets/5073925/7ceafab3-d2c5-44a7-82d7-7caa4ddaff28)
