### PR TITLE
Buffer-related resources

### DIFF
--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -162,7 +162,7 @@ namespace AZ
             RHI::ShaderInputConstantIndex constantIndex;
 
             // Bind scene TLAS buffer
-            const RHI::Ptr<RHI::SingleDeviceBuffer> tlasBuffer = m_rayTracingFeatureProcessor->GetTlas()->GetTlasBuffer();
+            auto tlasBuffer = m_rayTracingFeatureProcessor->GetTlas()->GetTlasBuffer();
             if (tlasBuffer)
             {
                 // TLAS

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -50,12 +50,12 @@ namespace AtomSampleViewer
     {
         using namespace AZ;
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         m_depthImageAttachmentId = RHI::AttachmentId("A2C_Depth");
         m_multisamleDepthImageAttachmentId = RHI::AttachmentId("A2C_MSAA_Depth");
@@ -145,10 +145,10 @@ namespace AtomSampleViewer
         RectangleBufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-        m_rectangleInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_rectangleInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
         RHI::ResultCode result = RHI::ResultCode::Success;
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
         request.m_buffer = m_rectangleInputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{RHI::BufferBindFlags::InputAssembly, sizeof(bufferData)};
         request.m_initialData = &bufferData;
@@ -160,14 +160,14 @@ namespace AtomSampleViewer
         }
         
         m_rectangleStreamBufferViews[0] = {
-            *m_rectangleInputAssemblyBuffer,
+            *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(RectangleBufferData, m_positions),
             sizeof(RectangleBufferData::m_positions),
             sizeof(VertexPosition)
         };
         
         m_rectangleStreamBufferViews[1] = {
-            *m_rectangleInputAssemblyBuffer,
+            *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(RectangleBufferData, m_uvs),
             sizeof(RectangleBufferData::m_uvs),
             sizeof(VertexUV)
@@ -398,7 +398,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_rectangleInputAssemblyBuffer,
+                    *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     offsetof(RectangleBufferData, m_indices),
                     sizeof(RectangleBufferData::m_indices),
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
@@ -18,8 +18,8 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/ScopeId.h>
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RHI/SingleDeviceStreamBufferView.h>
@@ -91,8 +91,8 @@ namespace AtomSampleViewer
             AZStd::array<VertexUV, 4> m_uvs;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_rectangleInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_rectangleInputAssemblyBuffer;
         AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
 

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -171,11 +171,11 @@ namespace AtomSampleViewer
     {
         const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        m_quadBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_quadBufferPool = aznew RHI::MultiDeviceBufferPool();
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_quadBufferPool->Init(*device, bufferPoolDesc);
+        m_quadBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         struct BufferData
         {
@@ -193,9 +193,9 @@ namespace AtomSampleViewer
             uv.m_uv[1] = 1.0f - uv.m_uv[1];
         }
 
-        m_quadInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_quadInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
         RHI::ResultCode result = RHI::ResultCode::Success;
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
 
         request.m_buffer = m_quadInputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -209,7 +209,7 @@ namespace AtomSampleViewer
 
         AZ::RHI::SingleDeviceStreamBufferView positionsBufferView =
         {
-            *m_quadInputAssemblyBuffer,
+            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -217,7 +217,7 @@ namespace AtomSampleViewer
 
         AZ::RHI::SingleDeviceStreamBufferView normalsBufferView =
         {
-            *m_quadInputAssemblyBuffer,
+            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_normals),
             sizeof(BufferData::m_normals),
             sizeof(VertexNormal)
@@ -225,7 +225,7 @@ namespace AtomSampleViewer
 
         AZ::RHI::SingleDeviceStreamBufferView uvsBufferView =
         {
-            *m_quadInputAssemblyBuffer,
+            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -240,7 +240,7 @@ namespace AtomSampleViewer
 
         m_quadIndexBufferView =
         {
-            *m_quadInputAssemblyBuffer,
+            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
@@ -120,8 +120,8 @@ namespace AtomSampleViewer
         };
        
         // Quad related variables
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_quadBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_quadInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_quadBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
         AZ::RHI::SingleDeviceIndexBufferView m_quadIndexBufferView;
         AZStd::array<AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView>, NumScopes> m_quadStreamBufferViews;
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -59,7 +59,7 @@ namespace AtomSampleViewer
 
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> GetSrg(const AZStd::string srgName);
             void CompileSrg(const AZStd::string srgName);
-            bool SetBufferView(const AZStd::string srgName, const AZStd::string srgId, const AZ::RHI::SingleDeviceBufferView* bufferView);
+            bool SetBufferView(const AZStd::string srgName, const AZStd::string srgId, const AZ::RHI::MultiDeviceBufferView* bufferView);
 
         private:
             AZStd::unordered_map<AZ::Name, AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>> m_srgMap;
@@ -90,7 +90,7 @@ namespace AtomSampleViewer
         {
             static const uint32_t FloatSizeInBytes = static_cast<uint32_t>(sizeof(float));
         public:
-            FloatBuffer(AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> bufferPool, const uint32_t sizeInBytes);
+            FloatBuffer(AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> bufferPool, const uint32_t sizeInBytes);
             ~FloatBuffer();
 
             // Allocates data if the provided handle is empty, else it updates it
@@ -103,14 +103,14 @@ namespace AtomSampleViewer
             bool UpdateBuffer(const FloatBufferHandle& handle, const void* data, const uint32_t sizeInBytes);
 
             // Maps host data to the device
-            bool MapData(const AZ::RHI::SingleDeviceBufferMapRequest& mapRequest, const void* data);
+            bool MapData(const AZ::RHI::MultiDeviceBufferMapRequest& mapRequest, const void* data);
 
             // Create the buffer
             void CreateBufferFromPool(const uint32_t byteCount);
 
             // Buffer resource
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool = nullptr;
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_buffer = nullptr;
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool = nullptr;
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_buffer = nullptr;
 
             // Number of bytes that are allocated
             uint32_t m_allocatedInBytes = 0;
@@ -180,14 +180,14 @@ namespace AtomSampleViewer
         void CreateColorBuffer(
             const AZ::Name& bufferName,
             const AZ::Vector4& colorVal,
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer>& buffer,
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView>& bufferView);
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>& buffer,
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView>& bufferView);
 
         // Create indirect buffer that will contain index of the view into the bindless heap
         void CreateIndirectBuffer(
             const AZ::Name& bufferName,
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer>& indirectionBuffer,
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView>& bufferView,
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>& indirectionBuffer,
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView>& bufferView,
             size_t byteSize);
 
         // Helper function to allocate or update data in the FloatBuffer
@@ -276,23 +276,23 @@ namespace AtomSampleViewer
         AZ::Data::Instance<AZ::RPI::Model> m_model = nullptr;
 
         // BufferPool used to allocate buffers in this example
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool = nullptr;
 
         // Indirection buffer holding uint indices of texture resources
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_imageIndirectionBuffer = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_imageIndirectionBuffer = nullptr;
         // Indirection buffer holding uint indices of buffer resources
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_bufferIndirectionBuffer = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_bufferIndirectionBuffer = nullptr;
         // View associated with the buffer holding indices to bindless images
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_imageIndirectionBufferView = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_imageIndirectionBufferView = nullptr;
         // View associated with the buffer holding indices to bindless buffers
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_bufferIndirectionBufferView = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_bufferIndirectionBufferView = nullptr;
 
         // Color buffer holding color related floats
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_colorBuffer1 = nullptr;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_colorBuffer2 = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_colorBuffer1 = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_colorBuffer2 = nullptr;
         // Views related to the buffers declared above
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_colorBuffer1View = nullptr;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_colorBuffer2View = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_colorBuffer1View = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_colorBuffer2View = nullptr;
 
         // Thread count for compute shaders.
         int m_bufferNumThreadsX = 1;
@@ -332,9 +332,9 @@ namespace AtomSampleViewer
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_imageDispatchPipelineState;
         
         // Compute pass related buffer pool which will create a rwbuffer
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_computeBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_computeBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_computeBufferView;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_computeBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_computeBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_computeBufferView;
         AZ::RHI::BufferViewDescriptor m_rwBufferViewDescriptor;
 
          // Compute pass related image pool which will create a rwimage

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
@@ -80,8 +80,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
         AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
@@ -90,9 +90,9 @@ namespace AtomSampleViewer
         // ----------------------------
         // Compute Buffer
         // ----------------------------
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_computeBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_computeBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_computeBufferView;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_computeBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_computeBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_computeBufferView;
         AZ::RHI::BufferViewDescriptor m_bufferViewDescriptor;
         AZ::RHI::AttachmentId m_bufferAttachmentId = AZ::RHI::AttachmentId("bufferAttachmentId");
 

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -78,12 +78,12 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_bufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_bufferPool->Init(*device, bufferPoolDesc);
+            m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
             UpdateVertexPositions(0);
 
@@ -94,12 +94,12 @@ namespace AtomSampleViewer
             SetVertexUV(m_bufferData.m_uvs.data(), 2, 1.0f, 1.0f);
             SetVertexUV(m_bufferData.m_uvs.data(), 3, 1.0f, 0.0f);
 
-            m_positionBuffer = RHI::Factory::Get().CreateBuffer();
-            m_indexBuffer = RHI::Factory::Get().CreateBuffer();
-            m_uvBuffer = RHI::Factory::Get().CreateBuffer();
+            m_positionBuffer = aznew RHI::MultiDeviceBuffer();
+            m_indexBuffer = aznew RHI::MultiDeviceBuffer();
+            m_uvBuffer = aznew RHI::MultiDeviceBuffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             
             request.m_buffer = m_indexBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, indexBufSize };
@@ -139,14 +139,14 @@ namespace AtomSampleViewer
             }
 
             m_streamBufferViews[0] = {
-                *m_positionBuffer,
+                *m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
             };
 
             m_streamBufferViews[1] = {
-                *m_uvBuffer,
+                *m_uvBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
@@ -228,7 +228,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_indexBuffer,
+                    *m_indexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     indexBufSize,
                     RHI::IndexFormat::Uint16
@@ -328,7 +328,7 @@ namespace AtomSampleViewer
 
     void CopyQueueComponent::UploadVertexBuffer()
     {
-        AZ::RHI::SingleDeviceBufferStreamRequest request;
+        AZ::RHI::MultiDeviceBufferStreamRequest request;
         request.m_buffer = m_positionBuffer.get();
         request.m_byteCount = static_cast<uint32_t>(m_bufferData.m_positions.size() * sizeof(VertexPosition));
         request.m_sourceData = m_bufferData.m_positions.data();

--- a/Gem/Code/Source/RHI/CopyQueueComponent.h
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.h
@@ -13,7 +13,7 @@
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Factory.h>
@@ -60,10 +60,10 @@ namespace AtomSampleViewer
 
         AZ::RHI::ShaderInputImageIndex m_textureInputIndex;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_indexBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_positionBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_uvBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indexBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_uvBuffer;
 
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -74,12 +74,12 @@ namespace AtomSampleViewer
         using namespace AZ;
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         BufferData bufferData;
         SetVertexPosition(bufferData.m_positions.data(), 0, -1.0f, -1.0f, 0.0f);
@@ -91,9 +91,9 @@ namespace AtomSampleViewer
         SetVertexColor(bufferData.m_colors.data(), 2, 0.0, 0.0, 1.0, 1.0);
 
         SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
-        m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
         request.m_initialData = &bufferData;
@@ -101,7 +101,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -109,7 +109,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_colors),
             sizeof(BufferData::m_colors),
             sizeof(VertexColor)
@@ -117,7 +117,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
@@ -60,8 +60,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, geometryIndexCount> m_indices;
         };
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
         AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
@@ -19,7 +19,7 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
@@ -152,16 +152,16 @@ namespace AtomSampleViewer
 
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_shaderBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_instancesBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_copyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_shaderBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_instancesBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_copyBufferPool;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_sourceIndirectBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_instancesDataBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_resetCounterBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_indirectDispatchBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_sourceIndirectBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_instancesDataBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_resetCounterBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indirectDispatchBuffer;
 
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_drawPipelineState;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_cullPipelineState;
@@ -176,8 +176,8 @@ namespace AtomSampleViewer
         AZ::RHI::SingleDeviceIndirectBufferView m_indirectDrawBufferView;
         AZ::RHI::SingleDeviceIndirectBufferView m_indirectDispatchBufferView;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_sourceIndirectBufferView;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_instancesDataBufferView;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_sourceIndirectBufferView;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_instancesDataBufferView;
 
         AZ::RHI::IndirectBufferLayout m_indirectDrawBufferLayout;
         AZ::RHI::IndirectBufferLayout m_indirectDispatchBufferLayout;

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -68,8 +68,8 @@ namespace AtomSampleViewer
         AZ::RHI::SingleDeviceStreamBufferView m_streamBufferView[2];
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         // ----------------------
         // Pipeline state and SRG

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -172,18 +172,18 @@ namespace AtomSampleViewer
         using namespace AZ;
         const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_bufferPool = aznew RHI::MultiDeviceBufferPool();
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_bufferPool->Init(*device, bufferPoolDesc);
+        m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         BufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-        m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
         RHI::ResultCode result = RHI::ResultCode::Success;
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -197,7 +197,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -205,7 +205,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -213,7 +213,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/MRTExampleComponent.h
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
@@ -57,8 +57,8 @@ namespace AtomSampleViewer
         void ReadRenderTargetShader();
         void ReadScreenShader();
         
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZStd::array<AZ::RHI::TransientImageDescriptor, 3> m_renderTargetImageDescriptors;
 

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -48,12 +48,12 @@ namespace AtomSampleViewer
     {
         using namespace AZ;
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         AZStd::vector<RHI::SamplePosition> emptySamplePositions;
         AZStd::vector<RHI::SamplePosition> customSamplePositions = { RHI::SamplePosition(3, 3), RHI::SamplePosition(11, 3), RHI::SamplePosition(3, 11), RHI::SamplePosition(11, 11) };
@@ -136,9 +136,9 @@ namespace AtomSampleViewer
 
         SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
 
-        m_triangleInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_triangleInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
         request.m_buffer = m_triangleInputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
         request.m_initialData = &bufferData;
@@ -146,7 +146,7 @@ namespace AtomSampleViewer
 
         m_triangleStreamBufferViews[0] =
         {
-            *m_triangleInputAssemblyBuffer,
+            *m_triangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(TriangleBufferData, m_positions),
             sizeof(TriangleBufferData::m_positions),
             sizeof(VertexPosition)
@@ -154,7 +154,7 @@ namespace AtomSampleViewer
 
         m_triangleStreamBufferViews[1] =
         {
-            *m_triangleInputAssemblyBuffer,
+            *m_triangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(TriangleBufferData, m_colors),
             sizeof(TriangleBufferData::m_colors),
             sizeof(VertexColor)
@@ -189,10 +189,10 @@ namespace AtomSampleViewer
         QuadBufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-        m_quadInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_quadInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
         RHI::ResultCode result = RHI::ResultCode::Success;
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
 
         request.m_buffer = m_quadInputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -206,14 +206,14 @@ namespace AtomSampleViewer
         }
 
         m_quadStreamBufferViews[0] = {
-            *m_quadInputAssemblyBuffer,
+            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(QuadBufferData, m_positions),
             sizeof(QuadBufferData::m_positions),
             sizeof(VertexPosition)
         };
 
         m_quadStreamBufferViews[1] = {
-            *m_quadInputAssemblyBuffer,
+            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(QuadBufferData, m_uvs),
             sizeof(QuadBufferData::m_uvs),
             sizeof(VertexUV)
@@ -341,7 +341,7 @@ namespace AtomSampleViewer
 
             const RHI::SingleDeviceIndexBufferView indexBufferView =
             {
-                *m_triangleInputAssemblyBuffer,
+                *m_triangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(TriangleBufferData, m_indices),
                 sizeof(TriangleBufferData::m_indices),
                 RHI::IndexFormat::Uint16
@@ -454,7 +454,7 @@ namespace AtomSampleViewer
 
             const RHI::SingleDeviceIndexBufferView indexBufferView =
             {
-                *m_quadInputAssemblyBuffer,
+                *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(QuadBufferData, m_indices),
                 sizeof(QuadBufferData::m_indices),
                 RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.h
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.h
@@ -18,8 +18,8 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/ScopeId.h>
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RHI/SingleDeviceStreamBufferView.h>
@@ -103,9 +103,9 @@ namespace AtomSampleViewer
         void CreateCustomMSAAResolveScope();
 
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_triangleInputAssemblyBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_quadInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_triangleInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
         
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState>, s_numMSAAExamples> m_pipelineStates;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_customResolveMSAAPipelineState;

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -224,12 +224,12 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
             BufferData bufferData;
 
@@ -241,9 +241,9 @@ namespace AtomSampleViewer
             SetVertexColor(bufferData.m_colors.data(), 2, 0.0, 0.0, 1.0, 1.0);
             SetVertexColor(bufferData.m_colors.data(), 3, 0.0, 0.0, 1.0, 1.0);
 
-            m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -251,7 +251,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer,
+                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -259,7 +259,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer,
+                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
@@ -459,7 +459,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_inputAssemblyBuffer,
+                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     offsetof(BufferData, m_indices),
                     sizeof(BufferData::m_indices),
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
@@ -18,7 +18,7 @@
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -82,8 +82,8 @@ namespace AtomSampleViewer
             const AZ::RHI::ShaderInputConstantIndex& matrixConstantId);
 
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;
 

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -149,11 +149,11 @@ namespace AtomSampleViewer
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
 
-        m_bufferPool = AZ::RHI::Factory::Get().CreateBufferPool();
+        m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        result = m_bufferPool->Init(*device, bufferPoolDesc);
+        result = m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
         if (result != AZ::RHI::ResultCode::Success)
         {
             AZ_Error("MultiThreadComponent", false, "Failed to initialize buffer pool with error code %d", result);
@@ -162,8 +162,8 @@ namespace AtomSampleViewer
 
         SingleCubeBufferData bufferData = CreateSingleCubeBufferData(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f));
 
-        m_inputAssemblyBuffer = AZ::RHI::Factory::Get().CreateBuffer();
-        AZ::RHI::SingleDeviceBufferInitRequest request;
+        m_inputAssemblyBuffer = aznew AZ::RHI::MultiDeviceBuffer();
+        AZ::RHI::MultiDeviceBufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, sizeof(SingleCubeBufferData) };
@@ -177,7 +177,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(SingleCubeBufferData, m_positions),
             sizeof(SingleCubeBufferData::m_positions),
             sizeof(VertexPosition)
@@ -185,7 +185,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(SingleCubeBufferData, m_colors),
             sizeof(SingleCubeBufferData::m_colors),
             sizeof(VertexColor)
@@ -193,7 +193,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(SingleCubeBufferData, m_indices),
             sizeof(SingleCubeBufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/MultiThreadComponent.h
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.h
@@ -9,8 +9,8 @@
 
 #include <RHI/BasicRHIComponent.h>
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <MultiThreadComponent_Traits_Platform.h>
@@ -75,8 +75,8 @@ namespace AtomSampleViewer
 
         AZStd::array<AZ::Matrix4x4, s_numberOfCubes> m_cubeTransforms;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -9,7 +9,7 @@
 
 #include <AzCore/Math/MatrixUtils.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameAttachment.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
@@ -235,17 +235,17 @@ namespace AtomSampleViewer
 
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
 
-        m_bufferPool = AZ::RHI::Factory::Get().CreateBufferPool();
+        m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        m_bufferPool->Init(*device, bufferPoolDesc);
+        m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         BufferData bufferData = CreateBufferData();
 
-        m_inputAssemblyBuffer = AZ::RHI::Factory::Get().CreateBuffer();
+        m_inputAssemblyBuffer = aznew AZ::RHI::MultiDeviceBuffer();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
-        AZ::RHI::SingleDeviceBufferInitRequest request;
+        AZ::RHI::MultiDeviceBufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -259,7 +259,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -267,7 +267,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_colors),
             sizeof(BufferData::m_colors),
             sizeof(VertexColor)
@@ -275,7 +275,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[2] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_normals),
             sizeof(BufferData::m_normals),
             sizeof(VertexNormal)
@@ -283,7 +283,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.h
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.h
@@ -10,8 +10,8 @@
 
 #include <RHI/BasicRHIComponent.h>
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
@@ -91,8 +91,8 @@ namespace AtomSampleViewer
         
         static const int s_shadowMapSize = 1024;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState>, 2> m_pipelineStates;

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -154,22 +154,22 @@ namespace AtomSampleViewer
     {
         using namespace AZ;
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         {
             // Create quad buffer and views
             BufferData bufferData;
             SetFullScreenRect(bufferData.m_positions.data(), nullptr, bufferData.m_indices.data());
 
-            m_quadInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+            m_quadInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_quadInputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -182,7 +182,7 @@ namespace AtomSampleViewer
             }
 
             m_quadStreamBufferView = {
-                *m_quadInputAssemblyBuffer,
+                *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -282,7 +282,7 @@ namespace AtomSampleViewer
                 return;
             }
             
-            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(RHI::AttachmentId{QueryExample::PredicationBufferId}, m_predicationBuffer);
+            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(RHI::AttachmentId{QueryExample::PredicationBufferId}, m_predicationBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
             AZ_Error(QueryExample::SampleName, result == RHI::ResultCode::Success, "Failed to import predication buffer with error %d", result);
 
             frameGraph.UseQueryPool(
@@ -309,7 +309,7 @@ namespace AtomSampleViewer
             descriptor.m_sourceQueryPool = m_occlusionQueryPool.get();
             descriptor.m_firstQuery = m_occlusionQueries[m_currentOcclusionQueryIndex].m_query->GetHandle();
             descriptor.m_queryCount = 1;
-            descriptor.m_destinationBuffer = m_predicationBuffer.get();
+            descriptor.m_destinationBuffer = m_predicationBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             descriptor.m_destinationOffset = 0;
             descriptor.m_destinationStride = sizeof(uint64_t);
 
@@ -430,7 +430,7 @@ namespace AtomSampleViewer
             {
                 const RHI::SingleDeviceIndexBufferView quadIndexBufferView =
                 {
-                    *m_quadInputAssemblyBuffer,
+                    *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     offsetof(BufferData, m_indices),
                     sizeof(BufferData::m_indices),
                     RHI::IndexFormat::Uint16
@@ -484,7 +484,7 @@ namespace AtomSampleViewer
                     }
                     case QueryType::Predication:
                     {
-                        commandList->BeginPredication(*m_predicationBuffer, 0, RHI::PredicationOp::EqualZero);
+                        commandList->BeginPredication(*m_predicationBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex), 0, RHI::PredicationOp::EqualZero);
                         commandList->Submit(drawItem, 0);
                         commandList->EndPredication();
                         break;
@@ -588,16 +588,16 @@ namespace AtomSampleViewer
             return;
         }
 
-        m_predicationBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_predicationBufferPool = aznew RHI::MultiDeviceBufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Predication | RHI::BufferBindFlags::CopyWrite;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_predicationBufferPool->Init(*device, bufferPoolDesc);
+        m_predicationBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
-        m_predicationBuffer = RHI::Factory::Get().CreateBuffer();
+        m_predicationBuffer = aznew RHI::MultiDeviceBuffer();
 
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
         request.m_buffer = m_predicationBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::Predication | RHI::BufferBindFlags::CopyWrite, sizeof(uint64_t) };
         RHI::ResultCode result = m_predicationBufferPool->InitBuffer(request);

--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -16,8 +16,8 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/ScopeId.h>
 
-#include <Atom/RHI/SingleDeviceBuffer.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBuffer.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 #include <Atom/RHI/SingleDeviceQueryPool.h>
@@ -92,8 +92,8 @@ namespace AtomSampleViewer
         void SetQueryType(QueryType type);
         void DrawSampleSettings();
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_quadInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
 
         struct BufferData
         {
@@ -128,8 +128,8 @@ namespace AtomSampleViewer
 
         QueryType m_currentType = QueryType::Occlusion;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_predicationBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_predicationBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_predicationBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_predicationBuffer;
         AZ::RHI::BufferScopeAttachmentDescriptor m_predicationBufferAttachmentDescriptor;
 
         bool m_timestampEnabled = false;

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -68,12 +68,12 @@ namespace AtomSampleViewer
 
         // create input assembly buffer pool
         {
-            m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
-            [[maybe_unused]] RHI::ResultCode resultCode = m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+            [[maybe_unused]] RHI::ResultCode resultCode = m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "Failed to initialize input assembly buffer pool");
         }
 
@@ -101,10 +101,10 @@ namespace AtomSampleViewer
             SetVertexPosition(m_triangleVertices.data(), 1, 0.5f, -0.5f, 1.0);
             SetVertexPosition(m_triangleVertices.data(), 2, -0.5f, -0.5f, 1.0);
 
-            m_triangleVB = RHI::Factory::Get().CreateBuffer();
+            m_triangleVB = aznew RHI::MultiDeviceBuffer();
             m_triangleVB->SetName(AZ::Name("Triangle VB"));
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_triangleVB.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(m_triangleVertices) };
             request.m_initialData = m_triangleVertices.data();
@@ -113,7 +113,7 @@ namespace AtomSampleViewer
             // index buffer
             SetVertexIndexIncreasing(m_triangleIndices.data(), m_triangleIndices.size());
 
-            m_triangleIB = RHI::Factory::Get().CreateBuffer();
+            m_triangleIB = aznew RHI::MultiDeviceBuffer();
             m_triangleIB->SetName(AZ::Name("Triangle IB"));
 
             request.m_buffer = m_triangleIB.get();
@@ -130,10 +130,10 @@ namespace AtomSampleViewer
             SetVertexPosition(m_rectangleVertices.data(), 2,  0.5f, -0.5f, 1.0);
             SetVertexPosition(m_rectangleVertices.data(), 3, -0.5f, -0.5f, 1.0);
 
-            m_rectangleVB = RHI::Factory::Get().CreateBuffer();
+            m_rectangleVB = aznew RHI::MultiDeviceBuffer();
             m_rectangleVB->SetName(AZ::Name("Rectangle VB"));
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_rectangleVB.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(m_rectangleVertices) };
             request.m_initialData = m_rectangleVertices.data();
@@ -147,7 +147,7 @@ namespace AtomSampleViewer
             m_rectangleIndices[4] = 2;
             m_rectangleIndices[5] = 3;
 
-            m_rectangleIB = RHI::Factory::Get().CreateBuffer();
+            m_rectangleIB = aznew RHI::MultiDeviceBuffer();
             m_rectangleIB->SetName(AZ::Name("Rectangle IB"));
 
             request.m_buffer = m_rectangleIB.get();
@@ -162,9 +162,9 @@ namespace AtomSampleViewer
         FullScreenBufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-        m_fullScreenInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_fullScreenInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
         request.m_buffer = m_fullScreenInputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
         request.m_initialData = &bufferData;
@@ -172,7 +172,7 @@ namespace AtomSampleViewer
 
         m_fullScreenStreamBufferViews[0] =
         {
-            *m_fullScreenInputAssemblyBuffer,
+            *m_fullScreenInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(FullScreenBufferData, m_positions),
             sizeof(FullScreenBufferData::m_positions),
             sizeof(VertexPosition)
@@ -180,7 +180,7 @@ namespace AtomSampleViewer
 
         m_fullScreenStreamBufferViews[1] =
         {
-            *m_fullScreenInputAssemblyBuffer,
+            *m_fullScreenInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(FullScreenBufferData, m_uvs),
             sizeof(FullScreenBufferData::m_uvs),
             sizeof(VertexUV)
@@ -188,7 +188,7 @@ namespace AtomSampleViewer
 
         m_fullScreenIndexBufferView =
         {
-            *m_fullScreenInputAssemblyBuffer,
+            *m_fullScreenInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(FullScreenBufferData, m_indices),
             sizeof(FullScreenBufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -337,7 +337,7 @@ namespace AtomSampleViewer
             {
                 RHI::SingleDeviceStreamBufferView triangleVertexBufferView =
                 {
-                    *m_triangleVB,
+                    *m_triangleVB->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     sizeof(m_triangleVertices),
                     sizeof(VertexPosition)
@@ -345,7 +345,7 @@ namespace AtomSampleViewer
 
                 RHI::SingleDeviceIndexBufferView triangleIndexBufferView =
                 {
-                    *m_triangleIB,
+                    *m_triangleIB->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     sizeof(m_triangleIndices),
                     RHI::IndexFormat::Uint16
@@ -367,7 +367,7 @@ namespace AtomSampleViewer
             {
                 RHI::SingleDeviceStreamBufferView rectangleVertexBufferView =
                 {
-                    *m_rectangleVB,
+                    *m_rectangleVB->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     sizeof(m_rectangleVertices),
                     sizeof(VertexPosition)
@@ -375,7 +375,7 @@ namespace AtomSampleViewer
 
                 RHI::SingleDeviceIndexBufferView rectangleIndexBufferView =
                 {
-                    *m_rectangleIB,
+                    *m_rectangleIB->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     sizeof(m_rectangleIndices),
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -18,7 +18,7 @@
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <RHI/BasicRHIComponent.h>
 #include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
 #include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
@@ -66,7 +66,7 @@ namespace AtomSampleViewer
         static const uint32_t m_imageHeight = 1080;
 
         // resource pools
-        RHI::Ptr<RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
+        RHI::Ptr<RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         RHI::Ptr<RHI::SingleDeviceImagePool> m_imagePool;
         RHI::Ptr<RHI::SingleDeviceRayTracingBufferPools> m_rayTracingBufferPools;
 
@@ -74,15 +74,15 @@ namespace AtomSampleViewer
         AZStd::array<VertexPosition, 3> m_triangleVertices;
         AZStd::array<uint16_t, 3> m_triangleIndices;
 
-        RHI::Ptr<RHI::SingleDeviceBuffer> m_triangleVB;
-        RHI::Ptr<RHI::SingleDeviceBuffer> m_triangleIB;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_triangleVB;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_triangleIB;
 
         // rectangle vertex/index buffers
         AZStd::array<VertexPosition, 4> m_rectangleVertices;
         AZStd::array<uint16_t, 6> m_rectangleIndices;
 
-        RHI::Ptr<RHI::SingleDeviceBuffer> m_rectangleVB;
-        RHI::Ptr<RHI::SingleDeviceBuffer> m_rectangleIB;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_rectangleVB;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_rectangleIB;
 
         // ray tracing acceleration structures
         RHI::Ptr<RHI::SingleDeviceRayTracingBlas> m_triangleRayTracingBlas;
@@ -133,7 +133,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        RHI::Ptr<RHI::SingleDeviceBuffer> m_fullScreenInputAssemblyBuffer;
+        RHI::Ptr<RHI::MultiDeviceBuffer> m_fullScreenInputAssemblyBuffer;
         AZStd::array<RHI::SingleDeviceStreamBufferView, 2> m_fullScreenStreamBufferViews;
         RHI::SingleDeviceIndexBufferView m_fullScreenIndexBufferView;
         RHI::InputStreamLayout m_fullScreenInputStreamLayout;

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -93,21 +93,21 @@ namespace AtomSampleViewer
         }
 
         {
-            m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_bufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_bufferPool->Init(*device, bufferPoolDesc);
+            m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
             SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-            m_positionBuffer = RHI::Factory::Get().CreateBuffer();
-            m_indexBuffer = RHI::Factory::Get().CreateBuffer();
-            m_uvBuffer = RHI::Factory::Get().CreateBuffer();
+            m_positionBuffer = aznew RHI::MultiDeviceBuffer();
+            m_indexBuffer = aznew RHI::MultiDeviceBuffer();
+            m_uvBuffer = aznew RHI::MultiDeviceBuffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
 
             request.m_buffer = m_positionBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, positionBufSize };
@@ -143,14 +143,14 @@ namespace AtomSampleViewer
             }
 
             m_streamBufferViews[0] = {
-                *m_positionBuffer,
+                *m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
             };
 
             m_streamBufferViews[1] = {
-                *m_uvBuffer,
+                *m_uvBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
@@ -311,7 +311,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_indexBuffer,
+                    *m_indexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     indexBufSize,
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
@@ -123,10 +123,10 @@ namespace AtomSampleViewer
 
 
         // ---------------- streaming buffer variables ----------------
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_indexBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_positionBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_uvBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indexBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_uvBuffer;
 
         struct BufferData
         {

--- a/Gem/Code/Source/RHI/StencilExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.cpp
@@ -52,12 +52,12 @@ namespace AtomSampleViewer
         RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
 
             BufferData bufferData;
@@ -96,9 +96,9 @@ namespace AtomSampleViewer
             // Triangles index
             SetVertexIndexIncreasing(bufferData.m_indices.data(), s_numberOfVertices);
 
-            m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -106,7 +106,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer,
+                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -114,7 +114,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer,
+                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
@@ -205,7 +205,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_inputAssemblyBuffer,
+                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     offsetof(BufferData, m_indices),
                     sizeof(BufferData::m_indices),
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -11,7 +11,7 @@
 
 #include <AzCore/Math/Vector3.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/SingleDeviceImagePool.h>
@@ -47,8 +47,8 @@ namespace AtomSampleViewer
         // Triangles setting
         void SetTriangleVertices(int startIndex, VertexPosition* vertexData, AZ::Vector3 center, float offset);
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineStateBasePass;
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState>, 8> m_pipelineStateStencil;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -17,7 +17,7 @@
 #include <Atom/RPI.Public/Model/Model.h>
 #include <Atom/RPI.Public/Model/ModelLod.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -59,7 +59,7 @@ namespace AtomSampleViewer
         };
 
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
         // Load the shader
         {
@@ -132,11 +132,11 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
-            m_rectangleInputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_rectangleInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_rectangleInputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -148,14 +148,14 @@ namespace AtomSampleViewer
             }
 
             m_rectangleStreamBufferViews[0u] = {
-                *m_rectangleInputAssemblyBuffer,
+                *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(RectangleBufferData, m_positions),
                 sizeof(RectangleBufferData::m_positions),
                 sizeof(VertexPosition)
             };
 
             m_rectangleStreamBufferViews[1u] = {
-                *m_rectangleInputAssemblyBuffer,
+                *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(RectangleBufferData, m_uvs),
                 sizeof(RectangleBufferData::m_uvs),
                 sizeof(VertexUV)
@@ -207,7 +207,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_rectangleInputAssemblyBuffer,
+                    *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     offsetof(RectangleBufferData, m_indices),
                     sizeof(RectangleBufferData::m_indices),
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
@@ -39,8 +39,8 @@ namespace AtomSampleViewer
         // AZ::TickBus::Handler overrides...
         void OnTick(float deltaTime, AZ::ScriptTimePoint scriptTime);
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_rectangleInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_rectangleInputAssemblyBuffer;
         AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -58,21 +58,21 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_bufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_bufferPool->Init(*device, bufferPoolDesc);
+            m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
             SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-            m_positionBuffer = RHI::Factory::Get().CreateBuffer();
-            m_indexBuffer = RHI::Factory::Get().CreateBuffer();
-            m_uvBuffer = RHI::Factory::Get().CreateBuffer();
+            m_positionBuffer = aznew RHI::MultiDeviceBuffer();
+            m_indexBuffer = aznew RHI::MultiDeviceBuffer();
+            m_uvBuffer = aznew RHI::MultiDeviceBuffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
 
             request.m_buffer = m_positionBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, positionBufSize };
@@ -108,14 +108,14 @@ namespace AtomSampleViewer
             }
 
             m_streamBufferViews[0] = {
-                *m_positionBuffer,
+                *m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
             };
 
             m_streamBufferViews[1] = {
-                *m_uvBuffer,
+                *m_uvBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
@@ -228,7 +228,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_indexBuffer,
+                    *m_indexBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     0,
                     indexBufSize,
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/TextureExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
@@ -53,10 +53,10 @@ namespace AtomSampleViewer
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixInputIndex;
         AZ::RHI::ShaderInputConstantIndex m_uvMatrixInputIndex;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_indexBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_positionBuffer;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_uvBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indexBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_uvBuffer;
 
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -206,12 +206,12 @@ namespace AtomSampleViewer
     void TextureMapExampleComponent::CreateInputAssemblyBufferPool()
     {
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = AZ::RHI::Factory::Get().CreateBufferPool();
+        m_inputAssemblyBufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
 
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
     }
 
     void TextureMapExampleComponent::InitRenderTargetBufferView()
@@ -767,9 +767,9 @@ namespace AtomSampleViewer
         uint32_t uvSize, void* uvData, uint32_t uvTypeSize,
         uint32_t indexSize, void* indexData)
     {
-        m_positionBuffer[target] = AZ::RHI::Factory::Get().CreateBuffer();
+        m_positionBuffer[target] = aznew AZ::RHI::MultiDeviceBuffer();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
-        AZ::RHI::SingleDeviceBufferInitRequest request;
+        AZ::RHI::MultiDeviceBufferInitRequest request;
         request.m_buffer = m_positionBuffer[target].get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, posSize };
         request.m_initialData = posData;
@@ -782,13 +782,13 @@ namespace AtomSampleViewer
 
         m_bufferViews[target].m_streamBufferViews[0] =
         {
-            *m_positionBuffer[target],
+            *m_positionBuffer[target]->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             0,
             posSize,
             sizeof(VertexPosition)
         };
 
-        m_uvBuffer[target] = AZ::RHI::Factory::Get().CreateBuffer();
+        m_uvBuffer[target] = aznew AZ::RHI::MultiDeviceBuffer();
         request.m_buffer = m_uvBuffer[target].get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, uvSize };
         request.m_initialData = uvData;
@@ -801,13 +801,13 @@ namespace AtomSampleViewer
 
         m_bufferViews[target].m_streamBufferViews[1] =
         {
-            *m_uvBuffer[target],
+            *m_uvBuffer[target]->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             0,
             uvSize,
             uvTypeSize
         };
 
-        m_indexBuffer[target] = AZ::RHI::Factory::Get().CreateBuffer();
+        m_indexBuffer[target] = aznew AZ::RHI::MultiDeviceBuffer();
         request.m_buffer = m_indexBuffer[target].get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, indexSize };
         request.m_initialData = indexData;
@@ -820,7 +820,7 @@ namespace AtomSampleViewer
 
         m_bufferViews[target].m_indexBufferView =
         {
-            *m_indexBuffer[target],
+            *m_indexBuffer[target]->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             0,
             indexSize,
             AZ::RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -115,11 +115,11 @@ namespace AtomSampleViewer
         // -------------------------------------
         // Input Assembly buffer and buffer view
         // -------------------------------------
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         // array for buffer and buffer view ( all render targets + screen)
-        AZStd::array< AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer>, s_numOfTargets + 1> m_positionBuffer;
-        AZStd::array< AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer>, s_numOfTargets + 1> m_uvBuffer;
-        AZStd::array< AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer>, s_numOfTargets + 1> m_indexBuffer;
+        AZStd::array< AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>, s_numOfTargets + 1> m_positionBuffer;
+        AZStd::array< AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>, s_numOfTargets + 1> m_uvBuffer;
+        AZStd::array< AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>, s_numOfTargets + 1> m_indexBuffer;
         AZStd::array<BufferViewData, s_numOfTargets + 1> m_bufferViews;
 
         // ---------------------------------------

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -66,12 +66,12 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_inputAssemblyBufferPool = RHI::Factory::Get().CreateBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(*device, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
             BufferData bufferData;
 
@@ -85,9 +85,9 @@ namespace AtomSampleViewer
 
             SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
 
-            m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
-            RHI::SingleDeviceBufferInitRequest request;
+            RHI::MultiDeviceBufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -95,7 +95,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer,
+                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -103,7 +103,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer,
+                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
@@ -198,7 +198,7 @@ namespace AtomSampleViewer
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
-                    *m_inputAssemblyBuffer,
+                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
                     offsetof(BufferData, m_indices),
                     sizeof(BufferData::m_indices),
                     RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.h
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.h
@@ -17,7 +17,7 @@
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -47,8 +47,8 @@ namespace AtomSampleViewer
         void OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
 
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -22,7 +22,7 @@
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -91,17 +91,17 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
         AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
         AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_constantBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_constantBufferPool;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_constantBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_constantBuffer;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferView> m_constantBufferView;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_constantBufferView;
 
         // --------------------------------------------------------
         // Pipeline state and SRG to be constructed from the shader

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
@@ -446,11 +446,11 @@ namespace AtomSampleViewer
     {
         const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        m_bufferPool = RHI::Factory::Get().CreateBufferPool();
+        m_bufferPool = aznew RHI::MultiDeviceBufferPool();
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_bufferPool->Init(*device, bufferPoolDesc);
+        m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
 
         struct BufferData
         {
@@ -462,9 +462,9 @@ namespace AtomSampleViewer
         BufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-        m_inputAssemblyBuffer = RHI::Factory::Get().CreateBuffer();
+        m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
         RHI::ResultCode result = RHI::ResultCode::Success;
-        RHI::SingleDeviceBufferInitRequest request;
+        RHI::MultiDeviceBufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -478,7 +478,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -486,7 +486,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -494,7 +494,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer,
+            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
@@ -20,7 +20,7 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
@@ -133,9 +133,9 @@ namespace AtomSampleViewer
         int m_numThreadsZ = 1;
 
         // Bufferpool for creating the IA buffer
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
         // Buffer for the IA of the full screen quad.
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
         // Bufferviews into the full screen quad IA
         AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
         // Indexview of the full screen quad index buffer

--- a/Gem/Code/Source/RHI/XRExampleComponent.h
+++ b/Gem/Code/Source/RHI/XRExampleComponent.h
@@ -18,7 +18,7 @@
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -94,9 +94,9 @@ namespace AtomSampleViewer
         //! Create the relevant Scope
         void CreateScope();
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
         AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
         AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState;
 


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as in all places, where the related RPI-resources (i.e. `RPI::Buffer` which now uses `RHI::MultiDeviceBuffer` etc.) also change.

This specifically introduces resources related to `MultiDeviceBuffer`.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [Buffer-related resources](https://github.com/o3de/o3de/commit/77d6e7f8b1147dac969add2e8289cb0486ee0356).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|this PR|open|
|`Image`|||
|`Query`|||
|`PipelineState`|||
|`RayTracing`|||
|`TransientAttachmentPool`|||
|`SwapChain`|||
|`SRG`|||
|`DrawItem`|||
|`FrameGraph`|||
