### PR TITLE
Image-related resources

### DIFF
--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -10,8 +10,8 @@
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceImage.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 
@@ -74,7 +74,7 @@ namespace AtomSampleViewer
         // Import non transient images
         for (uint32_t i = 0; i < m_sceneImages.size(); ++i)
         {
-            frameGraphBuilder.GetAttachmentDatabase().ImportImage(m_sceneIds[i], m_sceneImages[i]);
+            frameGraphBuilder.GetAttachmentDatabase().ImportImage(m_sceneIds[i], m_sceneImages[i]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
         }
 
         // Generate transient images
@@ -144,17 +144,15 @@ namespace AtomSampleViewer
 
     void AsyncComputeExampleComponent::CreateSceneRenderTargets()
     {
-        const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-
-        m_imagePool = RHI::Factory::Get().CreateImagePool();
+        m_imagePool = aznew RHI::MultiDeviceImagePool();
         RHI::ImagePoolDescriptor imagePoolDesc;
         imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
-        m_imagePool->Init(*device, imagePoolDesc);
+        m_imagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
 
         for (auto& image : m_sceneImages)
         {
-            image = RHI::Factory::Get().CreateImage();
-            RHI::SingleDeviceImageInitRequest initImageRequest;
+            image = aznew RHI::MultiDeviceImage();
+            RHI::MultiDeviceImageInitRequest initImageRequest;
             RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(0, 0, 0, 0);
             initImageRequest.m_image = image.get();
             initImageRequest.m_descriptor = RHI::ImageDescriptor::Create2D(
@@ -169,8 +167,6 @@ namespace AtomSampleViewer
 
     void AsyncComputeExampleComponent::CreateQuad()
     {
-        const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-
         m_quadBufferPool = aznew RHI::MultiDeviceBufferPool();
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -795,7 +791,7 @@ namespace AtomSampleViewer
             auto& source = m_sceneIds[m_previousSceneImageIndex];
             auto& shaderResourceGroup = m_shaderResourceGroups[CopyTextureScope].front();
 
-            const RHI::SingleDeviceImageView* imageView = context.GetImageView(source);
+            const auto* imageView = context.GetImageView(source);
             shaderResourceGroup->SetImageView(m_copyTextureShaderInputImageIndex, imageView);
             shaderResourceGroup->Compile();
         };
@@ -962,7 +958,7 @@ namespace AtomSampleViewer
 
         const auto compileFunction = [this](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const RHI::SingleDeviceImageView* imageView = context.GetImageView(m_shadowAttachmentId);
+            const auto* imageView = context.GetImageView(m_shadowAttachmentId);
 
             for (const auto& shaderResourceGroup : m_shaderResourceGroups[ForwardScope])
             {
@@ -1073,8 +1069,8 @@ namespace AtomSampleViewer
 
         const auto compileFunction = [this](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const RHI::SingleDeviceImageView* hdrSceneView = context.GetImageView(m_sceneIds[m_previousSceneImageIndex]);
-            const RHI::SingleDeviceImageView* luminanceView = context.GetImageView(m_averageLuminanceAttachmentId);
+            const auto* hdrSceneView = context.GetImageView(m_sceneIds[m_previousSceneImageIndex]);
+            const auto* luminanceView = context.GetImageView(m_averageLuminanceAttachmentId);
 
             for (const auto& shaderResourceGroup : m_shaderResourceGroups[TonemappingScope])
             {
@@ -1147,7 +1143,7 @@ namespace AtomSampleViewer
 
         const auto compileFunction = [this](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const RHI::SingleDeviceImageView* imageView = context.GetImageView(m_sceneIds[m_previousSceneImageIndex]);
+            const auto* imageView = context.GetImageView(m_sceneIds[m_previousSceneImageIndex]);
 
             for (const auto& shaderResourceGroup : m_shaderResourceGroups[LuminanceMapScope])
             {
@@ -1243,8 +1239,8 @@ namespace AtomSampleViewer
 
             const auto compileFunction = [this, inputAttachmentId, outputAttachmentId, i](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
-                const RHI::SingleDeviceImageView* inputView = context.GetImageView(inputAttachmentId);
-                const RHI::SingleDeviceImageView* outputView = context.GetImageView(outputAttachmentId);
+                const auto* inputView = context.GetImageView(inputAttachmentId);
+                const auto* outputView = context.GetImageView(outputAttachmentId);
 
                 const auto& shaderResourceGroup = m_shaderResourceGroups[LuminanceReduceScope][i];
                 shaderResourceGroup->SetImageView(m_luminanceReduceShaderInputImageIndex, inputView);

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -165,8 +165,8 @@ namespace AtomSampleViewer
         // Scene images
         static constexpr uint32_t NumSceneImages = 2;
         AZStd::array<AZ::RHI::AttachmentId, NumSceneImages> m_sceneIds = { { AZ::RHI::AttachmentId("SceneId1"), AZ::RHI::AttachmentId("SceneId2") } };
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImagePool> m_imagePool;
-        AZStd::array<AZ::RHI::Ptr<AZ::RHI::SingleDeviceImage>, NumSceneImages> m_sceneImages;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool;
+        AZStd::array<AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage>, NumSceneImages> m_sceneImages;
         uint32_t m_currentSceneImageIndex = 0;
         uint32_t m_previousSceneImageIndex = 1;
 

--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -552,7 +552,7 @@ namespace AtomSampleViewer
             mipAsset.BlockUntilLoadComplete();
             imageMipAssets.emplace_back(mipAsset);
 
-            const RHI::SingleDeviceImageSubresourceLayout subImageLayout = mipAsset->GetSubImageLayout(0);
+            const auto subImageLayout = mipAsset->GetSubImageLayout(0);
             imageSubresourceLayouts.emplace_back(subImageLayout);
         }
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -338,9 +338,9 @@ namespace AtomSampleViewer
         AZ::RHI::BufferViewDescriptor m_rwBufferViewDescriptor;
 
          // Compute pass related image pool which will create a rwimage
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImagePool> m_rwImagePool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImage> m_computeImage;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImageView> m_computeImageView;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_rwImagePool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_computeImage;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImageView> m_computeImageView;
         AZ::RHI::ImageViewDescriptor m_rwImageViewDescriptor;
 
         // Compute pass related SRGs

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -9,8 +9,6 @@
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceImage.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -9,8 +9,6 @@
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceImage.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/ScopeProducerFunction.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
@@ -344,9 +342,9 @@ namespace AtomSampleViewer
 
         const auto compileFunctionScreen = [this](const AZ::RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const AZ::RHI::SingleDeviceImageView* imageViewR = context.GetImageView(m_attachmentID[0]);
-            const AZ::RHI::SingleDeviceImageView* imageViewG = context.GetImageView(m_attachmentID[1]);
-            const AZ::RHI::SingleDeviceImageView* imageViewB = context.GetImageView(m_attachmentID[2]);
+            const auto* imageViewR = context.GetImageView(m_attachmentID[0]);
+            const auto* imageViewG = context.GetImageView(m_attachmentID[1]);
+            const auto* imageViewB = context.GetImageView(m_attachmentID[2]);
 
             m_shaderResourceGroups[1]->SetImageView(m_shaderInputImageIndices[0], imageViewR);
             m_shaderResourceGroups[1]->SetImageView(m_shaderInputImageIndices[1], imageViewG);

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -439,7 +439,7 @@ namespace AtomSampleViewer
 
         const auto compileFunction = [this](const AZ::RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const AZ::RHI::SingleDeviceImageView* imageView = context.GetImageView(m_sampleProperties[static_cast<uint32_t>(MSAAType::MSAA4X_Custom_Resolve)].m_attachmentId);
+            const auto* imageView = context.GetImageView(m_sampleProperties[static_cast<uint32_t>(MSAAType::MSAA4X_Custom_Resolve)].m_attachmentId);
             m_customMSAAResolveShaderResourceGroup->SetImageView(m_customMSAAResolveTextureInputIndex, imageView);
             m_customMSAAResolveShaderResourceGroup->Compile();
         };

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -491,7 +491,7 @@ namespace AtomSampleViewer
 
         const auto compileFunctionMainView = [this](const AZ::RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const AZ::RHI::SingleDeviceImageView* imageView = context.GetImageView(m_transientImageDescriptor.m_attachmentId);
+            const auto* imageView = context.GetImageView(m_transientImageDescriptor.m_attachmentId);
 
             m_shaderResourceGroups[1]->SetImageView(m_shaderInputImageIndex, imageView);
             m_shaderResourceGroups[1]->Compile();

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -67,7 +67,7 @@ namespace AtomSampleViewer
 
         // resource pools
         RHI::Ptr<RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        RHI::Ptr<RHI::SingleDeviceImagePool> m_imagePool;
+        RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
         RHI::Ptr<RHI::SingleDeviceRayTracingBufferPools> m_rayTracingBufferPools;
 
         // triangle vertex/index buffers
@@ -120,8 +120,8 @@ namespace AtomSampleViewer
         bool m_buildLocalSrgs = true;
 
         // output image, written to by the ray tracing shader and displayed in the fullscreen draw shader
-        RHI::Ptr<RHI::SingleDeviceImage> m_outputImage;
-        RHI::Ptr<RHI::SingleDeviceImageView> m_outputImageView;
+        RHI::Ptr<RHI::MultiDeviceImage> m_outputImage;
+        RHI::Ptr<RHI::MultiDeviceImageView> m_outputImageView;
         RHI::ImageViewDescriptor m_outputImageViewDescriptor;
         RHI::AttachmentId m_outputImageAttachmentId = RHI::AttachmentId("outputImageAttachmentId");
 

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -14,7 +14,6 @@
 #include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
 
 namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -487,9 +487,9 @@ namespace AtomSampleViewer
 
         const auto compileFunction = [this](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const AZ::RHI::SingleDeviceImageView* positionImageView = context.GetImageView(m_positionAttachmentId);
-            const AZ::RHI::SingleDeviceImageView* normalImageView = context.GetImageView(m_normalAttachmentId);
-            const AZ::RHI::SingleDeviceImageView* albedoImageView = context.GetImageView(m_albedoAttachmentId);
+            const auto* positionImageView = context.GetImageView(m_positionAttachmentId);
+            const auto* normalImageView = context.GetImageView(m_normalAttachmentId);
+            const auto* albedoImageView = context.GetImageView(m_albedoAttachmentId);
 
             m_compositionSubpassInputsSRG->SetImageView(m_subpassInputPosition, positionImageView);
             m_compositionSubpassInputsSRG->SetImageView(m_subpassInputNormal, normalImageView);

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -46,12 +46,12 @@ namespace AtomSampleViewer
 
         ImGuiSidebar m_imguiSidebar;
         AzFramework::WindowSize m_windowSize;
-        AZ::RHI::SingleDeviceImageSubresourceLayout m_imageLayout;
+        AZ::RHI::MultiDeviceImageSubresourceLayout m_imageLayout;
 
         // Rendering resources
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImagePool> m_imagePool = nullptr;
-        AZ::Data::Instance<AZ::RHI::SingleDeviceImage> m_image = nullptr;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImageView> m_imageView = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool = nullptr;
+        AZ::Data::Instance<AZ::RHI::MultiDeviceImage> m_image = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImageView> m_imageView = nullptr;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup = nullptr;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_pipelineState = nullptr;
 

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -14,8 +14,6 @@
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceImage.h>
-#include <Atom/RHI/SingleDeviceImagePool.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -7,8 +7,6 @@
  */
 
 
-#include <Atom/RHI/SingleDeviceImagePool.h>
-
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
@@ -574,7 +572,7 @@ namespace AtomSampleViewer
 
         const auto compileFunction = [this, target](const AZ::RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            const AZ::RHI::SingleDeviceImageView* imageView = context.GetImageView(m_attachmentID[target]);
+            const auto* imageView = context.GetImageView(m_attachmentID[target]);
 
             m_screenSRGs[target]->SetImageView(m_shaderInputImageIndices[target], imageView);
             m_screenSRGs[target]->Compile();

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
@@ -95,11 +95,11 @@ namespace AtomSampleViewer
         {
             if (m_useImageShadingRate)
             {
-                frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentId }, m_shadingRateImages[m_frameCount % m_shadingRateImages.size()]);
+                frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentId }, m_shadingRateImages[m_frameCount % m_shadingRateImages.size()]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                 if (!Utils::GetRHIDevice()->GetFeatures().m_dynamicShadingRateImage)
                 {
                     // We cannot update and use the same shading rate image because "m_dynamicShadingRateImage" is not supported.
-                    frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentUpdateId }, m_shadingRateImages[(m_frameCount + m_shadingRateImages.size() - 1) % m_shadingRateImages.size()]);
+                    frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentUpdateId }, m_shadingRateImages[(m_frameCount + m_shadingRateImages.size() - 1) % m_shadingRateImages.size()]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
                 }
             }
             m_frameCount++;
@@ -169,10 +169,10 @@ namespace AtomSampleViewer
         const auto& tileSize = device->GetLimits().m_shadingRateTileSize;
         m_shadingRateImageSize = Vector2(ceil(static_cast<float>(m_outputWidth) / tileSize.m_width), ceil(static_cast<float>(m_outputHeight) / tileSize.m_height));
 
-        m_imagePool = RHI::Factory::Get().CreateImagePool();
+        m_imagePool = aznew RHI::MultiDeviceImagePool();
         RHI::ImagePoolDescriptor imagePoolDesc;
         imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShadingRate | RHI::ImageBindFlags::ShaderReadWrite;
-        m_imagePool->Init(*device, imagePoolDesc);
+        m_imagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
 
         // Initialize the shading rate images with proper values. Invalid values may cause a crash.
         uint32_t width = static_cast<uint32_t>(m_shadingRateImageSize.GetX());
@@ -200,8 +200,8 @@ namespace AtomSampleViewer
         m_shadingRateImages.resize(device->GetFeatures().m_dynamicShadingRateImage ? 1 : device->GetDescriptor().m_frameCountMax+3);
         for (auto& image : m_shadingRateImages)
         {
-            image = RHI::Factory::Get().CreateImage();
-            RHI::SingleDeviceImageInitRequest initImageRequest;
+            image = aznew RHI::MultiDeviceImage();
+            RHI::MultiDeviceImageInitRequest initImageRequest;
             RHI::ClearValue clearValue = RHI::ClearValue::CreateVector4Float(1, 1, 1, 1);
             initImageRequest.m_image = image.get();
             initImageRequest.m_descriptor = RHI::ImageDescriptor::Create2D(
@@ -212,17 +212,17 @@ namespace AtomSampleViewer
             initImageRequest.m_optimizedClearValue = &clearValue;
             m_imagePool->InitImage(initImageRequest);
 
-            RHI::SingleDeviceImageUpdateRequest request;
+            RHI::MultiDeviceImageUpdateRequest request;
             request.m_image = image.get();
             request.m_sourceData = shadingRatePatternData.data();
-            request.m_sourceSubresourceLayout = RHI::SingleDeviceImageSubresourceLayout(
+            request.m_sourceSubresourceLayout = RHI::MultiDeviceImageSubresourceLayout();
+            request.m_sourceSubresourceLayout.Init(RHI::MultiDevice::DefaultDevice, {
                 RHI::Size(width, height, 1),
                 height,
                 width * formatSize,
                 bufferSize,
                 1,
-                1
-            );
+                1});
 
             m_imagePool->UpdateImageContents(request);
         }        
@@ -444,8 +444,6 @@ namespace AtomSampleViewer
 
     void VariableRateShadingExampleComponent::CreateInputAssemblyBuffersAndViews()
     {
-        const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-
         m_bufferPool = aznew RHI::MultiDeviceBufferPool();
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -627,7 +625,7 @@ namespace AtomSampleViewer
             if (m_useImageShadingRate)
             {
                 Vector2 center = m_cursorPos * m_shadingRateImageSize;
-                const RHI::SingleDeviceImageView* shadingRateImageView = context.GetImageView(RHI::AttachmentId(shadingRateAttachmentId));
+                const auto* shadingRateImageView = context.GetImageView(RHI::AttachmentId(shadingRateAttachmentId));
                 m_computeShaderResourceGroup->SetImageView(m_shadingRateIndex, shadingRateImageView);
                 m_computeShaderResourceGroup->SetConstant(m_centerIndex, center);
                 m_computeShaderResourceGroup->Compile();
@@ -713,7 +711,7 @@ namespace AtomSampleViewer
         {
             if (m_showShadingRateImage)
             {
-                const RHI::SingleDeviceImageView* shadingRateImageView = context.GetImageView(RHI::AttachmentId(VariableRateShading::ShadingRateAttachmentId));
+                const auto* shadingRateImageView = context.GetImageView(RHI::AttachmentId(VariableRateShading::ShadingRateAttachmentId));
                 m_imageShaderResourceGroup->SetImageView(m_shadingRateDisplayIndex, shadingRateImageView);
                 m_imageShaderResourceGroup->Compile();
             }

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
@@ -144,9 +144,9 @@ namespace AtomSampleViewer
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // Image pool containing the shading rate images.
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceImagePool> m_imagePool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool;
         // List of shading rate images used as attachments.
-        AZStd::fixed_vector<AZ::RHI::Ptr<AZ::RHI::SingleDeviceImage>, AZ::RHI::Limits::Device::FrameCountMax> m_shadingRateImages;
+        AZStd::fixed_vector<AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage>, AZ::RHI::Limits::Device::FrameCountMax> m_shadingRateImages;
 
         // Cursor position (mouse or touch)
         AZ::Vector2 m_cursorPos;

--- a/Gem/Code/Source/ReadbackExampleComponent.cpp
+++ b/Gem/Code/Source/ReadbackExampleComponent.cpp
@@ -276,9 +276,8 @@ namespace AtomSampleViewer
 
     void ReadbackExampleComponent::ReadbackCallback(const AZ::RPI::AttachmentReadback::ReadbackResult& result)
     {
-        const AZ::RHI::ImageSubresourceRange range(0, 0, 0, 0);
-        AZ::RHI::SingleDeviceImageSubresourceLayout layout;
-        m_previewImage->GetRHIImage()->GetSubresourceLayouts(range, &layout, nullptr);
+        AZ::RHI::MultiDeviceImageSubresourceLayout layout;
+        m_previewImage->GetRHIImage()->GetSubresourceLayout(layout);
 
         m_textureNeedsUpdate = true;
         m_resultData = result.m_dataBuffer;
@@ -291,10 +290,9 @@ namespace AtomSampleViewer
 
     void ReadbackExampleComponent::UploadReadbackResult() const
     {
-        const AZ::RHI::ImageSubresourceRange range(0, 0, 0, 0);
-        AZ::RHI::SingleDeviceImageSubresourceLayout layout;
-        m_previewImage->GetRHIImage()->GetSubresourceLayouts(range, &layout, nullptr);
-        AZ::RHI::SingleDeviceImageUpdateRequest updateRequest;
+        AZ::RHI::MultiDeviceImageSubresourceLayout layout;
+        m_previewImage->GetRHIImage()->GetSubresourceLayout(layout);
+        AZ::RHI::MultiDeviceImageUpdateRequest updateRequest;
         updateRequest.m_image = m_previewImage->GetRHIImage();
         updateRequest.m_sourceSubresourceLayout = layout;
         updateRequest.m_sourceData = m_resultData->begin();

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -372,7 +372,7 @@ namespace AtomSampleViewer
         if (m_imguiSidebar.Begin())
         {
             Data::Instance<RPI::StreamingImagePool> streamingImagePool = RPI::ImageSystemInterface::Get()->GetSystemStreamingPool();
-            const RHI::SingleDeviceStreamingImagePool* rhiPool = streamingImagePool->GetRHIPool();
+            const auto* rhiPool = streamingImagePool->GetRHIPool();
             const RHI::HeapMemoryUsage& memoryUsage = rhiPool->GetHeapMemoryUsage(RHI::HeapMemoryLevel::Device);
 
             const size_t MB = 1024*1024;


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as in all places, where the related RPI-resources (i.e. `RPI::Image` which now uses `RHI::MultiDeviceImage` etc.) also change.

This specifically introduces resources related to `MultiDeviceImage`.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [Image-related resources](https://github.com/o3de/o3de/commit/c01d32e1c1664d57718c5a2a5631d56ecda65b60).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|[#661](https://github.com/o3de/o3de-atom-sampleviewer/pull/661)|merged|
|`Image`|this PR|open|
|`Query`|||
|`PipelineState`|||
|`RayTracing`|||
|`TransientAttachmentPool`|||
|`SwapChain`|||
|`SRG`|||
|`DrawItem`|||
|`FrameGraph`|||
