### PR TITLE
Query-related resources

### DIFF
--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -20,8 +20,8 @@
 #include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/SingleDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceQueryPool.h>
-#include <Atom/RHI/SingleDeviceQuery.h>
+#include <Atom/RHI/MultiDeviceQueryPool.h>
+#include <Atom/RHI/MultiDeviceQuery.h>
 #include <Atom/RHI/SingleDeviceStreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
@@ -109,13 +109,13 @@ namespace AtomSampleViewer
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_quadPipelineState;
         AZ::RHI::ConstPtr<AZ::RHI::SingleDevicePipelineState> m_boudingBoxPipelineState;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceQueryPool> m_occlusionQueryPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceQueryPool> m_timeStampQueryPool;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceQueryPool> m_statisticsQueryPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceQueryPool> m_occlusionQueryPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceQueryPool> m_timeStampQueryPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceQueryPool> m_statisticsQueryPool;
 
         struct QueryEntry
         {
-            AZ::RHI::Ptr<AZ::RHI::SingleDeviceQuery> m_query;
+            AZ::RHI::Ptr<AZ::RHI::MultiDeviceQuery> m_query;
             bool m_isValid = false; // Indicates if the query has been written at least once.
         };
 


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as in all places, where the related RPI-resources (i.e. `RPI::Query` which now uses `RHI::MultiDeviceQuery` etc.) also change.

This specifically introduces resources related to `MultiDeviceQuery`.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [Query-related resources](https://github.com/o3de/o3de/commit/ca7e5750040a5e010a0d375e198373a9e47b1f84).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|[#661](https://github.com/o3de/o3de-atom-sampleviewer/pull/661)|merged|
|`Image`|#662|merged|
|`Query`|this PR||
|`PipelineState`|||
|`RayTracing`|||
|`TransientAttachmentPool`|||
|`SwapChain`|||
|`SRG`|||
|`DrawItem`|||
|`FrameGraph`|||