### PR TITLE
Fixed compilation bug releated with splash image:

### DIFF
--- a/Gem/Resources/Splash.bmp
+++ b/Gem/Resources/Splash.bmp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd314f41b90bc9cba384d86eed865568343cbd332568f74c8ca39a08bc43836
+size 1200056


### PR DESCRIPTION
```
C:\GIT\o3de\build\Code\LauncherUnified\AtomSampleViewer.GameLauncher.rc(11):
error RC2135:
file not found: C:/GIT/o3de/AtomSampleViewer/Gem/Resources/LegacyLogoLauncher.bmp
```

The bug was caused by this o3de PR:
https://github.com/o3de/o3de/pull/17317