### PR TITLE
RayTracing-related resources

### DIFF
--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
@@ -10,9 +10,9 @@
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
-#include <Atom/RHI/SingleDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/SingleDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -63,10 +63,10 @@ namespace AZ
             Data::Instance<RPI::Shader> m_rayGenerationShader;
             Data::Instance<RPI::Shader> m_missShader;
             Data::Instance<RPI::Shader> m_hitShader;
-            RHI::Ptr<RHI::SingleDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+            RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
 
             // ray tracing shader table
-            RHI::Ptr<RHI::SingleDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+            RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
 
             // ray tracing global pipeline state
             RHI::ConstPtr<RHI::MultiDevicePipelineState> m_globalPipelineState;

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -602,7 +602,7 @@ namespace AtomSampleViewer
         m_quadInputAssemblyBuffer = nullptr;
         m_quadStreamBufferViews.fill(AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView>());
         m_terrainPipelineStates.fill(nullptr);
-        m_modelStreamBufferViews.fill(AZ::RPI::ModelLod::StreamBufferViewList());
+        m_modelStreamBufferViews.fill(AZ::RPI::ModelLod::TempStreamBufferViewList());
         m_modelPipelineStates.fill(nullptr);
         m_model = nullptr;
         m_copyTexturePipelineState = nullptr;
@@ -897,7 +897,8 @@ namespace AtomSampleViewer
                         RHI::SingleDeviceDrawItem drawItem;
                         drawItem.m_arguments = mesh.m_drawArguments;
                         drawItem.m_pipelineState = m_modelPipelineStates[ShadowScope]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                        drawItem.m_indexBufferView = &mesh.m_indexBufferView;
+                        auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                        drawItem.m_indexBufferView = &deviceIndexBufferView;
                         drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                         drawItem.m_shaderResourceGroups = shaderResourceGroups;
                         drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_modelStreamBufferViews[ShadowScope].size());
@@ -1021,7 +1022,8 @@ namespace AtomSampleViewer
                         RHI::SingleDeviceDrawItem drawItem;
                         drawItem.m_arguments = mesh.m_drawArguments;
                         drawItem.m_pipelineState = m_modelPipelineStates[ForwardScope]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                        drawItem.m_indexBufferView = &mesh.m_indexBufferView;
+                        auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                        drawItem.m_indexBufferView = &deviceIndexBufferView;
                         drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                         drawItem.m_shaderResourceGroups = shaderResourceGroups;
                         drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_modelStreamBufferViews[ForwardScope].size());

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -129,7 +129,7 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, NumScopes> m_terrainPipelineStates;
 
         // Model related variables
-        AZStd::array<AZ::RPI::ModelLod::StreamBufferViewList, NumScopes> m_modelStreamBufferViews;
+        AZStd::array<AZ::RPI::ModelLod::TempStreamBufferViewList, NumScopes> m_modelStreamBufferViews;
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, NumScopes> m_modelPipelineStates;
         AZ::Data::Instance<AZ::RPI::Model> m_model;
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -1266,7 +1266,8 @@ namespace AtomSampleViewer
                     RHI::SingleDeviceDrawItem drawItem;
                     drawItem.m_arguments = subMesh.m_mesh->m_drawArguments;
                     drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    drawItem.m_indexBufferView = &subMesh.m_mesh->m_indexBufferView;
+                    auto deviceIndexBufferView{subMesh.m_mesh->m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                    drawItem.m_indexBufferView = &deviceIndexBufferView;
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(subMesh.bufferStreamViewArray.size());

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -132,7 +132,7 @@ namespace AtomSampleViewer
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_perSubMeshSrg;
 
             const AZ::RPI::ModelLod::Mesh* m_mesh;
-            AZ::RPI::ModelLod::StreamBufferViewList bufferStreamViewArray;
+            AZ::RPI::ModelLod::TempStreamBufferViewList bufferStreamViewArray;
 
             AZ::Matrix4x4 m_modelMatrix;
 

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -11,8 +11,8 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Matrix4x4.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
-#include <Atom/RHI/SingleDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/SingleDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
+#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/SingleDeviceDispatchRaysItem.h>
 #include <Atom/RHI/Device.h>
@@ -20,8 +20,8 @@
 #include <Atom/RHI/MultiDevicePipelineState.h>
 #include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <RHI/BasicRHIComponent.h>
-#include <Atom/RHI/SingleDeviceRayTracingBufferPools.h>
-#include <Atom/RHI/SingleDeviceRayTracingAccelerationStructure.h>
+#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
+#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
 
 namespace AtomSampleViewer
 {
@@ -68,7 +68,7 @@ namespace AtomSampleViewer
         // resource pools
         RHI::Ptr<RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
-        RHI::Ptr<RHI::SingleDeviceRayTracingBufferPools> m_rayTracingBufferPools;
+        RHI::Ptr<RHI::MultiDeviceRayTracingBufferPools> m_rayTracingBufferPools;
 
         // triangle vertex/index buffers
         AZStd::array<VertexPosition, 3> m_triangleVertices;
@@ -85,9 +85,9 @@ namespace AtomSampleViewer
         RHI::Ptr<RHI::MultiDeviceBuffer> m_rectangleIB;
 
         // ray tracing acceleration structures
-        RHI::Ptr<RHI::SingleDeviceRayTracingBlas> m_triangleRayTracingBlas;
-        RHI::Ptr<RHI::SingleDeviceRayTracingBlas> m_rectangleRayTracingBlas;
-        RHI::Ptr<RHI::SingleDeviceRayTracingTlas> m_rayTracingTlas;
+        RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_triangleRayTracingBlas;
+        RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_rectangleRayTracingBlas;
+        RHI::Ptr<RHI::MultiDeviceRayTracingTlas> m_rayTracingTlas;
         RHI::BufferViewDescriptor m_tlasBufferViewDescriptor;
         RHI::AttachmentId m_tlasBufferAttachmentId = RHI::AttachmentId("tlasBufferAttachmentId");
 
@@ -98,10 +98,10 @@ namespace AtomSampleViewer
         Data::Instance<RPI::Shader> m_closestHitSolidShader;
 
         // ray tracing pipeline state
-        RHI::Ptr<RHI::SingleDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+        RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
 
         // ray tracing shader table
-        RHI::Ptr<RHI::SingleDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+        RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
 
         // ray tracing global shader resource group and pipeline state
         Data::Instance<RPI::ShaderResourceGroup> m_globalSrg;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -409,7 +409,8 @@ namespace AtomSampleViewer
                     RHI::SingleDeviceDrawItem drawItem;
                     drawItem.m_arguments = mesh.m_drawArguments;
                     drawItem.m_pipelineState = modelData.m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    drawItem.m_indexBufferView = &mesh.m_indexBufferView;
+                    auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                    drawItem.m_indexBufferView = &deviceIndexBufferView;
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(modelData.m_streamBufferList.size());

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -72,7 +72,7 @@ namespace AtomSampleViewer
 
         struct ModelData
         {
-            AZ::RPI::ModelLod::StreamBufferViewList m_streamBufferList;
+            AZ::RPI::ModelLod::TempStreamBufferViewList m_streamBufferList;
             AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
             ModelType m_modelType = ModelType_ShaderBall;

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -306,7 +306,7 @@ namespace AtomSampleViewer
                 RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
                 drawPacketBuilder.Begin(nullptr);
                 drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-                drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
+                drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
                 drawPacketBuilder.SetRootConstants(m_rootConstantData.GetConstantData());
                 drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup());
 

--- a/Gem/Code/Source/RootConstantsExampleComponent.h
+++ b/Gem/Code/Source/RootConstantsExampleComponent.h
@@ -68,7 +68,7 @@ namespace AtomSampleViewer
        
         // Models
         AZStd::vector<AZ::Data::Instance<AZ::RPI::Model>> m_models;
-        AZStd::vector<AZStd::vector<AZ::RPI::ModelLod::StreamBufferViewList>> m_modelStreamBufferViews;
+        AZStd::vector<AZStd::vector<AZ::RPI::ModelLod::TempStreamBufferViewList>> m_modelStreamBufferViews;
 
         // Cache interfaces
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as some changes that have been introduced in the meantime (i.e. in `ModelLod`).

This specifically introduces resources related to `MultiDeviceRayTracing`*.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [RayTracing-related resources](https://github.com/o3de/o3de/commit/210610c04cf555dfd62d05869798e6c7ffa11177).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|[#661](https://github.com/o3de/o3de-atom-sampleviewer/pull/661)|merged|
|`Image`|#662|open|
|`Query`|#663|open|
|`PipelineState`|#664|open|
|`RayTracing`|this PR|open|
|`TransientAttachmentPool`|||
|`SwapChain`|||
|`SRG`|||
|`DrawItem`|||
|`FrameGraph`|||