### PR TITLE
SRG-related resources

### DIFF
--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -382,7 +382,7 @@ namespace AtomSampleViewer
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
         drawRequest.m_sortKey = 0;
-        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup();
+        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
         drawPacketBuilder.AddDrawItem(drawRequest);
 
         // Submit draw packet

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -167,7 +167,7 @@ namespace AZ
                 RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
 
                 bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_scene"));
-                m_shaderResourceGroup->SetBufferView(bufferIndex, tlasBuffer->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_shaderResourceGroup->SetBufferView(bufferIndex, tlasBuffer->BuildBufferView(bufferViewDescriptor).get());
             }
 
             // Bind constants
@@ -219,7 +219,7 @@ namespace AZ
 
             const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
             {
-                m_shaderResourceGroup->GetRHIShaderResourceGroup()
+                m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
             };
 
             RHI::SingleDeviceDispatchRaysItem dispatchRaysItem;

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -388,7 +388,7 @@ namespace AtomSampleViewer
 
             for (uint32_t rectIndex = context.GetSubmitRange().m_startIndex; rectIndex < context.GetSubmitRange().m_endIndex; ++rectIndex)
             {
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {m_shaderResourceGroups[typeIndex][rectIndex]->GetRHIShaderResourceGroup()};
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {m_shaderResourceGroups[typeIndex][rectIndex]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()};
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -74,7 +74,7 @@ namespace AtomSampleViewer
         // Import non transient images
         for (uint32_t i = 0; i < m_sceneImages.size(); ++i)
         {
-            frameGraphBuilder.GetAttachmentDatabase().ImportImage(m_sceneIds[i], m_sceneImages[i]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+            frameGraphBuilder.GetAttachmentDatabase().ImportImage(m_sceneIds[i], m_sceneImages[i]);
         }
 
         // Generate transient images
@@ -808,7 +808,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[CopyTextureScope].front()->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[CopyTextureScope].front()->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
@@ -876,7 +876,7 @@ namespace AtomSampleViewer
                     drawIndexed.m_indexCount = 6;
                     drawIndexed.m_instanceCount = 1;
 
-                    const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[ShadowScope][0]->GetRHIShaderResourceGroup() };
+                    const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[ShadowScope][0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                     RHI::SingleDeviceDrawItem drawItem;
                     drawItem.m_arguments = drawIndexed;
@@ -891,7 +891,7 @@ namespace AtomSampleViewer
                 else
                 {
                     // Models
-                    const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[ShadowScope][i]->GetRHIShaderResourceGroup() };
+                    const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[ShadowScope][i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
                     for (const auto& mesh : m_model->GetLods()[0]->GetMeshes())
                     {
                         RHI::SingleDeviceDrawItem drawItem;
@@ -973,7 +973,7 @@ namespace AtomSampleViewer
             RHI::CommandList* commandList = context.GetCommandList();
 
             // Bind ViewSrg
-            commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup());
+            commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             // Set persistent viewport and scissor state.
             const auto& imageSize = m_sceneImages[m_currentSceneImageIndex]->GetDescriptor().m_size;
@@ -989,8 +989,8 @@ namespace AtomSampleViewer
                     // Terrain
                     const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
                     {
-                        m_shaderResourceGroups[ForwardScope][0]->GetRHIShaderResourceGroup(),
-                        m_viewShaderResourceGroup->GetRHIShaderResourceGroup()
+                        m_shaderResourceGroups[ForwardScope][0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                        m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                     };
 
                     RHI::DrawIndexed drawIndexed;
@@ -1013,8 +1013,8 @@ namespace AtomSampleViewer
                     // Model
                     const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
                     {
-                        m_shaderResourceGroups[ForwardScope][i]->GetRHIShaderResourceGroup(),
-                        m_viewShaderResourceGroup->GetRHIShaderResourceGroup()
+                        m_shaderResourceGroups[ForwardScope][i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                        m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                     };
 
                     for (const auto& mesh : m_model->GetLods()[0]->GetMeshes())
@@ -1087,7 +1087,7 @@ namespace AtomSampleViewer
             RHI::CommandList* commandList = context.GetCommandList();
 
             RHI::SingleDeviceDispatchItem dispatchItem;
-            decltype(dispatchItem.m_shaderResourceGroups) shaderResourceGroups = { { m_shaderResourceGroups[TonemappingScope][0]->GetRHIShaderResourceGroup() } };
+            decltype(dispatchItem.m_shaderResourceGroups) shaderResourceGroups = { { m_shaderResourceGroups[TonemappingScope][0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() } };
 
             RHI::DispatchDirect dispatchArgs;
 
@@ -1169,7 +1169,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[LuminanceMapScope][0]->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[LuminanceMapScope][0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
@@ -1255,7 +1255,7 @@ namespace AtomSampleViewer
                 RHI::CommandList* commandList = context.GetCommandList();
 
                 RHI::SingleDeviceDispatchItem dispatchItem;
-                decltype(dispatchItem.m_shaderResourceGroups) shaderResourceGroups = { { m_shaderResourceGroups[LuminanceReduceScope][i]->GetRHIShaderResourceGroup() } };
+                decltype(dispatchItem.m_shaderResourceGroups) shaderResourceGroups = { { m_shaderResourceGroups[LuminanceReduceScope][i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() } };
 
                 RHI::DispatchDirect dispatchArgs;
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -558,7 +558,7 @@ namespace AtomSampleViewer
         {
             AZ::Data::Instance<AZ::RPI::StreamingImage> image = LoadStreamingImage(InternalBP::Images[textureIdx], InternalBP::SampleName);
             m_images.push_back(image);
-            m_imageViews.push_back(image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_imageViews.push_back(image->GetImageView());
         }
 
         // Load appropriate cubemap textures used by the unbounded texture array
@@ -746,32 +746,32 @@ namespace AtomSampleViewer
             RHI::MultiDeviceBufferMapResponse mapResponse;
             m_bufferPool->MapBuffer(mapRequest, mapResponse);
 
-            AZStd::vector<const RHI::SingleDeviceImageView*> views;
+            AZStd::vector<const RHI::MultiDeviceImageView*> views;
             AZStd::vector<bool> isViewReadOnly;
 
             //Add read only 2d texture views
             for (AZ::Data::Instance<AZ::RPI::StreamingImage> image : m_images)
             {
-                views.push_back(image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                views.push_back(image->GetImageView());
                 isViewReadOnly.push_back(true);
             }
 
             //Add read only cube map texture views
             for (AZ::Data::Instance<AZ::RPI::StreamingImage> image : m_cubemapImages)
             {
-                views.push_back(image->GetImageView()->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                views.push_back(image->GetImageView());
                 isViewReadOnly.push_back(true);
             }
 
             //Ad read write texture view
-            views.push_back(m_computeImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            views.push_back(m_computeImageView.get());
             isViewReadOnly.push_back(false);
 
             // Populate the indirect buffer with indices of the views that reside within the bindless heap
             uint32_t arrayIndex = 0;
             auto indirectionBufferIndex = indirectionBufferSrg->FindShaderInputBufferIndex(AZ::Name{ "m_imageIndirectionBuffer" });
             indirectionBufferSrg->SetBindlessViews(
-                indirectionBufferIndex, m_imageIndirectionBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get(), views, static_cast<uint32_t*>(mapResponse.m_data[RHI::MultiDevice::DefaultDeviceIndex]),
+                indirectionBufferIndex, m_imageIndirectionBufferView.get(), views, static_cast<uint32_t*>(mapResponse.m_data[RHI::MultiDevice::DefaultDeviceIndex]),
                 isViewReadOnly, arrayIndex);
 
             m_bufferPool->UnmapBuffer(*m_imageIndirectionBuffer);
@@ -783,24 +783,24 @@ namespace AtomSampleViewer
             RHI::MultiDeviceBufferMapResponse mapResponse;
             m_bufferPool->MapBuffer(mapRequest, mapResponse);
 
-            AZStd::vector<const RHI::SingleDeviceBufferView*> views;
+            AZStd::vector<const RHI::MultiDeviceBufferView*> views;
             AZStd::vector<bool> isViewReadOnly;
            
             // Add read only buffer views
-            views.push_back(m_colorBuffer1View->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            views.push_back(m_colorBuffer1View.get());
             isViewReadOnly.push_back(true);
-            views.push_back(m_colorBuffer2View->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            views.push_back(m_colorBuffer2View.get());
             isViewReadOnly.push_back(true);
 
             //Add read write buffer view
-            views.push_back(m_computeBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            views.push_back(m_computeBufferView.get());
             isViewReadOnly.push_back(false);
 
             //Populate the indirect buffer with indices of the views that reside within the bindless heap
             uint32_t arrayIndex = 0;
             auto indirectionBufferIndex = indirectionBufferSrg->FindShaderInputBufferIndex(AZ::Name{ "m_bufferIndirectionBuffer" });
             indirectionBufferSrg->SetBindlessViews(
-                indirectionBufferIndex, m_bufferIndirectionBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get(), views, static_cast<uint32_t*>(mapResponse.m_data[RHI::MultiDevice::DefaultDeviceIndex]),
+                indirectionBufferIndex, m_bufferIndirectionBufferView.get(), views, static_cast<uint32_t*>(mapResponse.m_data[RHI::MultiDevice::DefaultDeviceIndex]),
                 isViewReadOnly, arrayIndex);
 
             m_bufferPool->UnmapBuffer(*m_bufferIndirectionBuffer);
@@ -845,7 +845,7 @@ namespace AtomSampleViewer
     {
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> srg = GetSrg(srgName);
         const AZ::RHI::ShaderInputBufferIndex inputIndex = srg->FindShaderInputBufferIndex(AZ::Name(srgId));
-        [[maybe_unused]] bool set = srg->SetBufferView(inputIndex, bufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+        [[maybe_unused]] bool set = srg->SetBufferView(inputIndex, bufferView);
         AZ_Assert(set, "Failed to set the buffer view");
 
         return false;
@@ -1012,7 +1012,7 @@ namespace AtomSampleViewer
             // attach compute buffer
             {
                 [[maybe_unused]] RHI::ResultCode result =
-                    frameGraph.GetAttachmentDatabase().ImportBuffer(m_bufferAttachmentId, m_computeBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                    frameGraph.GetAttachmentDatabase().ImportBuffer(m_bufferAttachmentId, m_computeBuffer);
                 AZ_Error(
                     InternalBP::SampleName, result == RHI::ResultCode::Success, "Failed to import compute buffer with error %d", result);
 
@@ -1028,7 +1028,7 @@ namespace AtomSampleViewer
                 AZ_Error(
                     InternalBP::SampleName, computeBufferIndex.IsValid(), "Failed to find shader input buffer %s.",
                     computeBufferId.GetCStr());
-                m_bufferDispatchSRG->SetBufferView(computeBufferIndex, m_computeBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_bufferDispatchSRG->SetBufferView(computeBufferIndex, m_computeBufferView.get());
                 m_bufferDispatchSRG->Compile();
             }
 
@@ -1046,7 +1046,7 @@ namespace AtomSampleViewer
             commandList->SetScissors(&m_scissor, 1);
 
             AZStd::array<const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups;
-            shaderResourceGroups[0] = m_bufferDispatchSRG->GetRHIShaderResourceGroup();
+            shaderResourceGroups[0] = m_bufferDispatchSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             RHI::SingleDeviceDispatchItem dispatchItem;
             RHI::DispatchDirect dispatchArgs;
@@ -1085,7 +1085,7 @@ namespace AtomSampleViewer
             // attach compute buffer
             {
                 [[maybe_unused]] RHI::ResultCode result =
-                    frameGraph.GetAttachmentDatabase().ImportImage(m_imageAttachmentId, m_computeImage->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                    frameGraph.GetAttachmentDatabase().ImportImage(m_imageAttachmentId, m_computeImage);
                 AZ_Error(
                     InternalBP::SampleName, result == RHI::ResultCode::Success, "Failed to import compute buffer with error %d", result);
 
@@ -1101,7 +1101,7 @@ namespace AtomSampleViewer
                 AZ_Error(
                     InternalBP::SampleName, computeBufferIndex.IsValid(), "Failed to find shader input buffer %s.",
                     computeBufferId.GetCStr());
-                m_imageDispatchSRG->SetImageView(computeBufferIndex, m_computeImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_imageDispatchSRG->SetImageView(computeBufferIndex, m_computeImageView.get());
                 m_imageDispatchSRG->Compile();
             }
 
@@ -1119,7 +1119,7 @@ namespace AtomSampleViewer
             commandList->SetScissors(&m_scissor, 1);
 
             AZStd::array<const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups;
-            shaderResourceGroups[0] = m_imageDispatchSRG->GetRHIShaderResourceGroup();
+            shaderResourceGroups[0] = m_imageDispatchSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             RHI::SingleDeviceDispatchItem dispatchItem;
             RHI::DispatchDirect dispatchArgs;
@@ -1255,13 +1255,13 @@ namespace AtomSampleViewer
 
                     const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
                     {
-                        m_bindlessSrg->GetSrg(m_samplerSrgName)->GetRHIShaderResourceGroup(),
-                        subMesh.m_perSubMeshSrg->GetRHIShaderResourceGroup(),
-                        m_bindlessSrg->GetSrg(m_floatBufferSrgName)->GetRHIShaderResourceGroup(),
+                        m_bindlessSrg->GetSrg(m_samplerSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                        subMesh.m_perSubMeshSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                        m_bindlessSrg->GetSrg(m_floatBufferSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
 #if ATOMSAMPLEVIEWER_TRAIT_BINDLESS_PROTOTYPE_SUPPORTS_DIRECT_BOUND_UNBOUNDED_ARRAY
-                        m_bindlessSrg->GetSrg(m_imageSrgName)->GetRHIShaderResourceGroup(),
+                        m_bindlessSrg->GetSrg(m_imageSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
 #endif
-                        m_bindlessSrg->GetSrg(m_indirectionBufferSrgName)->GetRHIShaderResourceGroup(),
+                        m_bindlessSrg->GetSrg(m_indirectionBufferSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
                     };
                     RHI::SingleDeviceDrawItem drawItem;
                     drawItem.m_arguments = subMesh.m_mesh->m_drawArguments;

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -254,7 +254,7 @@ namespace AtomSampleViewer
         // Image array holding all of the Stream cubemap images
         AZStd::vector<AZ::Data::Instance<AZ::RPI::StreamingImage>> m_cubemapImages;
 
-        AZStd::vector<const AZ::RHI::SingleDeviceImageView*> m_imageViews;
+        AZStd::vector<const AZ::RHI::MultiDeviceImageView*> m_imageViews;
 
         // Light direction handle
         FloatBufferHandle m_lightDirectionHandle;

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -277,7 +277,7 @@ namespace AtomSampleViewer
         {
             // attach compute buffer
             {
-                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(m_bufferAttachmentId, m_computeBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(m_bufferAttachmentId, m_computeBuffer);
                 AZ_Error(s_computeExampleName, result == RHI::ResultCode::Success, "Failed to import compute buffer with error %d", result);
 
                 RHI::BufferScopeAttachmentDescriptor desc;
@@ -290,7 +290,7 @@ namespace AtomSampleViewer
                 const Name computeBufferId{ "m_computeBuffer" };
                 RHI::ShaderInputBufferIndex computeBufferIndex = m_dispatchSRGs[1]->FindShaderInputBufferIndex(computeBufferId);
                 AZ_Error(s_computeExampleName, computeBufferIndex.IsValid(), "Failed to find shader input buffer %s.", computeBufferId.GetCStr());
-                m_dispatchSRGs[1]->SetBufferView(computeBufferIndex, m_computeBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_dispatchSRGs[1]->SetBufferView(computeBufferIndex, m_computeBufferView.get());
                 m_dispatchSRGs[1]->Compile();
             }
 
@@ -308,8 +308,8 @@ namespace AtomSampleViewer
             commandList->SetScissors(&m_scissor, 1);
 
             AZStd::array <const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups;
-            shaderResourceGroups[0] = m_dispatchSRGs[0]->GetRHIShaderResourceGroup();
-            shaderResourceGroups[1] = m_dispatchSRGs[1]->GetRHIShaderResourceGroup();
+            shaderResourceGroups[0] = m_dispatchSRGs[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+            shaderResourceGroups[1] = m_dispatchSRGs[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
             
             RHI::SingleDeviceDispatchItem dispatchItem;
             RHI::DispatchDirect dispatchArgs;
@@ -374,7 +374,7 @@ namespace AtomSampleViewer
                 const Name computeBufferId{ "m_computeBuffer" };
                 RHI::ShaderInputBufferIndex computeBufferIndex = m_drawSRGs[1]->FindShaderInputBufferIndex(computeBufferId);
                 AZ_Error(s_computeExampleName, computeBufferIndex.IsValid(), "Failed to find shader input buffer %s.", computeBufferId.GetCStr());
-                m_drawSRGs[1]->SetBufferView(computeBufferIndex, m_computeBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_drawSRGs[1]->SetBufferView(computeBufferIndex, m_computeBufferView.get());
                 m_drawSRGs[1]->Compile();
             }
 
@@ -396,7 +396,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_drawSRGs[0]->GetRHIShaderResourceGroup(), m_drawSRGs[1]->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_drawSRGs[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(), m_drawSRGs[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -238,7 +238,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -204,7 +204,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 3;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -586,14 +586,14 @@ namespace AtomSampleViewer
             FindShaderInputIndex(&m_sceneInstancesDataBufferIndex, m_sceneShaderResourceGroup, instancesDataId, IndirectRendering::SampleName);
             FindShaderInputIndex(&m_sceneMatrixInputIndex, m_sceneShaderResourceGroup, matrixId, IndirectRendering::SampleName);
             float screenAspect = GetViewportWidth() / GetViewportHeight();
-            m_sceneShaderResourceGroup->SetBufferView(m_sceneInstancesDataBufferIndex, m_instancesDataBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_sceneShaderResourceGroup->SetBufferView(m_sceneInstancesDataBufferIndex, m_instancesDataBufferView.get());
             m_sceneShaderResourceGroup->SetConstant(m_sceneMatrixInputIndex, AZ::Matrix4x4::CreateScale(AZ::Vector3(1.f/ screenAspect, 1.f, 1.f)));
             m_sceneShaderResourceGroup->Compile();
         }
 
         {
             uint32_t sequenceTypeIndex = static_cast<uint32_t>(m_mode);
-            m_indirectCommandsShaderResourceGroups[sequenceTypeIndex]->SetBufferView(m_cullingInputIndirectBufferIndices[sequenceTypeIndex], m_sourceIndirectBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+            m_indirectCommandsShaderResourceGroups[sequenceTypeIndex]->SetBufferView(m_cullingInputIndirectBufferIndices[sequenceTypeIndex], m_sourceIndirectBufferView.get());
         }
     }
 
@@ -622,7 +622,7 @@ namespace AtomSampleViewer
             const auto* countBufferView = context.GetBufferView(RHI::AttachmentId{ IndirectRendering::CountBufferAttachmentId });
             m_copyDescriptor.m_sourceBuffer = m_resetCounterBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             m_copyDescriptor.m_sourceOffset = 0;
-            m_copyDescriptor.m_destinationBuffer = &countBufferView->GetBuffer();
+            m_copyDescriptor.m_destinationBuffer = countBufferView->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
             m_copyDescriptor.m_destinationOffset = 0;
             m_copyDescriptor.m_size = static_cast<uint32_t>(m_resetCounterBuffer->GetDescriptor().m_byteCount);
         };
@@ -697,7 +697,7 @@ namespace AtomSampleViewer
                 const auto* countBufferView = context.GetBufferView(RHI::AttachmentId{ IndirectRendering::CountBufferAttachmentId });
 
                 m_cullShaderResourceGroup->SetBufferView(m_cullingCountBufferIndex, countBufferView);
-                m_drawIndirect.m_countBuffer = &countBufferView->GetBuffer();
+                m_drawIndirect.m_countBuffer = countBufferView->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get();
                 m_drawIndirect.m_countBufferByteOffset = 0;
             }
 
@@ -712,7 +712,7 @@ namespace AtomSampleViewer
             uint32_t stride = m_indirectDrawBufferSignature->GetByteStride();
             m_indirectDrawBufferView =
             {
-                culledBufferView->GetBuffer(),
+                *(culledBufferView->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get()),
                 *m_indirectDrawBufferSignature,
                 0,
                 stride * m_numObjects,
@@ -726,12 +726,12 @@ namespace AtomSampleViewer
 
             RHI::SingleDeviceDispatchItem dispatchItem;
             uint32_t numSrgs = 0;
-            dispatchItem.m_shaderResourceGroups[numSrgs++] = m_cullShaderResourceGroup->GetRHIShaderResourceGroup();
-            dispatchItem.m_shaderResourceGroups[numSrgs++] = m_sceneShaderResourceGroup->GetRHIShaderResourceGroup();
+            dispatchItem.m_shaderResourceGroups[numSrgs++] = m_cullShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+            dispatchItem.m_shaderResourceGroups[numSrgs++] = m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
 
             for (const auto& srg : m_indirectCommandsShaderResourceGroups)
             {
-                dispatchItem.m_shaderResourceGroups[numSrgs++] = srg->GetRHIShaderResourceGroup();
+                dispatchItem.m_shaderResourceGroups[numSrgs++] = srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
             }
 
             // Submit the dispatch in an indirect manner.
@@ -826,7 +826,7 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_sceneShaderResourceGroup->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             // In case multi indirect drawing is not supported
             // we need to emit multiple indirect draw calls.

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
@@ -66,7 +66,7 @@ namespace AtomSampleViewer
             }
 
             {
-                frameGraphBuilder.GetAttachmentDatabase().ImportBuffer(AZ::Name{ InputAssembly::ImportedInputAssemblyBufferAttachmentId }, m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+                frameGraphBuilder.GetAttachmentDatabase().ImportBuffer(AZ::Name{ InputAssembly::ImportedInputAssemblyBufferAttachmentId }, m_inputAssemblyBuffer);
             }
 
             float aspectRatio = static_cast<float>(m_outputWidth / m_outputHeight);
@@ -301,7 +301,7 @@ namespace AtomSampleViewer
 
             for (uint32_t index = context.GetSubmitRange().m_startIndex; index < context.GetSubmitRange().m_endIndex; ++index)
             {
-                dispatchItem.m_shaderResourceGroups[0] = m_dispatchSRG[index]->GetRHIShaderResourceGroup();
+                dispatchItem.m_shaderResourceGroups[0] = m_dispatchSRG[index]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
                 commandList->Submit(dispatchItem, index);
             }
         };
@@ -369,9 +369,9 @@ namespace AtomSampleViewer
                 const auto* inputAssemblyBufferView = context.GetBufferView(RHI::AttachmentId{ InputAssembly::InputAssemblyBufferAttachmentId });
                 if (inputAssemblyBufferView)
                 {
-                    m_streamBufferView[0] = {inputAssemblyBufferView->GetBuffer(), 0, sizeof(BufferData), sizeof(BufferData::value_type)};
+                    m_streamBufferView[0] = {*(inputAssemblyBufferView->GetBuffer()), 0, sizeof(BufferData), sizeof(BufferData::value_type)};
 
-                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::SingleDeviceStreamBufferView>(&m_streamBufferView[0], 1));
+                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView>(&m_streamBufferView[0], 1));
                 }
             }
 
@@ -379,9 +379,9 @@ namespace AtomSampleViewer
                 const auto* inputAssemblyBufferView = context.GetBufferView(RHI::AttachmentId{ InputAssembly::ImportedInputAssemblyBufferAttachmentId });
                 if (inputAssemblyBufferView)
                 {
-                    m_streamBufferView[1] = {inputAssemblyBufferView->GetBuffer(), 0, sizeof(BufferData), sizeof(BufferData::value_type)};
+                    m_streamBufferView[1] = {*(inputAssemblyBufferView->GetBuffer()), 0, sizeof(BufferData), sizeof(BufferData::value_type)};
 
-                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::SingleDeviceStreamBufferView>(&m_streamBufferView[1], 1));
+                    RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView>(&m_streamBufferView[1], 1));
                 }
             }
         };
@@ -407,9 +407,10 @@ namespace AtomSampleViewer
 
             for (uint32_t index = context.GetSubmitRange().m_startIndex; index < context.GetSubmitRange().m_endIndex; ++index)
             {
-                drawItem.m_streamBufferViews = &m_streamBufferView[index];
+                auto deviceStreamBufferView{m_streamBufferView[index].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = &deviceStreamBufferView;
 
-                RHI::SingleDeviceShaderResourceGroup* rhiSRGS[] = { m_drawSRG[index]->GetRHIShaderResourceGroup() };
+                RHI::SingleDeviceShaderResourceGroup* rhiSRGS[] = { m_drawSRG[index]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
                 drawItem.m_shaderResourceGroups = rhiSRGS;
 
                 commandList->Submit(drawItem, index);

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -65,7 +65,7 @@ namespace AtomSampleViewer
         // -------------------------------------------------
         // Input Assembly buffer and its Streams/Index Views
         // -------------------------------------------------
-        AZ::RHI::SingleDeviceStreamBufferView m_streamBufferView[2];
+        AZ::RHI::MultiDeviceStreamBufferView m_streamBufferView[2];
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -290,7 +290,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
@@ -364,7 +364,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[1]->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -351,7 +351,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 3;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_triangleShaderResourceGroup->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_triangleShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
@@ -464,7 +464,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_customMSAAResolveShaderResourceGroup->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_customMSAAResolveShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -469,7 +469,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 2;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -153,7 +153,7 @@ namespace AtomSampleViewer
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        result = m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        result = m_bufferPool->Init(AZ::RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
         if (result != AZ::RHI::ResultCode::Success)
         {
             AZ_Error("MultiThreadComponent", false, "Failed to initialize buffer pool with error code %d", result);
@@ -177,7 +177,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(SingleCubeBufferData, m_positions),
             sizeof(SingleCubeBufferData::m_positions),
             sizeof(VertexPosition)
@@ -185,7 +185,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(SingleCubeBufferData, m_colors),
             sizeof(SingleCubeBufferData::m_colors),
             sizeof(VertexColor)
@@ -193,7 +193,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
             offsetof(SingleCubeBufferData, m_indices),
             sizeof(SingleCubeBufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16
@@ -326,11 +326,11 @@ namespace AtomSampleViewer
             
             for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)
             {
-                const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup() };
+                const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 AZ::RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
-                drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
                 drawItem.m_indexBufferView = &m_indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -420,11 +420,11 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = geometryIndexCount;
             drawIndexed.m_instanceCount = 1;
 
-            const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup() };
+            const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             AZ::RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
-            drawItem.m_pipelineState = m_pipelineStates[0]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawItem.m_pipelineState = m_pipelineStates[0]->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
             drawItem.m_indexBufferView = &m_indexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
@@ -509,11 +509,11 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = geometryIndexCount;
             drawIndexed.m_instanceCount = 1;
 
-            const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[1]->GetRHIShaderResourceGroup() };
+            const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(AZ::RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             AZ::RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
-            drawItem.m_pipelineState = m_pipelineStates[1]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawItem.m_pipelineState = m_pipelineStates[1]->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
             drawItem.m_indexBufferView = &m_indexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -282,7 +282,7 @@ namespace AtomSampleViewer
                 return;
             }
             
-            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(RHI::AttachmentId{QueryExample::PredicationBufferId}, m_predicationBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(RHI::AttachmentId{QueryExample::PredicationBufferId}, m_predicationBuffer);
             AZ_Error(QueryExample::SampleName, result == RHI::ResultCode::Success, "Failed to import predication buffer with error %d", result);
 
             frameGraph.UseQueryPool(
@@ -440,7 +440,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
@@ -505,12 +505,12 @@ namespace AtomSampleViewer
                 }
 
                 // Draw occluding quad
-                shaderResourceGroups[0] = m_shaderResourceGroups[1]->GetRHIShaderResourceGroup();
+                shaderResourceGroups[0] = m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
                 commandList->Submit(drawItem, 1);
 
                 // Draw quad to use for the oclussion query
                 drawItem.m_pipelineState = m_boudingBoxPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                shaderResourceGroups[0] = m_shaderResourceGroups[2]->GetRHIShaderResourceGroup();
+                shaderResourceGroups[0] = m_shaderResourceGroups[2]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
                 auto& queryEntry = m_occlusionQueries[m_currentOcclusionQueryIndex];
                 queryEntry.m_query->GetDeviceQuery(RHI::MultiDevice::DefaultDeviceIndex)->Begin(*commandList, m_precisionOcclusionEnabled ? RHI::QueryControlFlags::PreciseOcclusion : RHI::QueryControlFlags::None);
                 commandList->Submit(drawItem, 2);

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -431,7 +431,7 @@ namespace AtomSampleViewer
 
             m_tlasBufferViewDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, (uint32_t)m_rayTracingTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
 
-            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(m_tlasBufferAttachmentId, m_rayTracingTlas->GetTlasBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex));
+            [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportBuffer(m_tlasBufferAttachmentId, m_rayTracingTlas->GetTlasBuffer());
             AZ_Error(RayTracingExampleName, result == RHI::ResultCode::Success, "Failed to import TLAS buffer with error %d", result);
 
             RHI::BufferScopeAttachmentDescriptor desc;
@@ -476,7 +476,7 @@ namespace AtomSampleViewer
         {
             // attach output image
             {
-                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(m_outputImageAttachmentId, m_outputImage->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                [[maybe_unused]] RHI::ResultCode result = frameGraph.GetAttachmentDatabase().ImportImage(m_outputImageAttachmentId, m_outputImage);
                 AZ_Error(RayTracingExampleName, result == RHI::ResultCode::Success, "Failed to import output image with error %d", result);
 
                 RHI::ImageScopeAttachmentDescriptor desc;
@@ -511,11 +511,11 @@ namespace AtomSampleViewer
 
                 uint32_t tlasBufferByteCount = aznumeric_cast<uint32_t>(m_rayTracingTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
-                m_globalSrg->SetBufferView(tlasConstantIndex, m_rayTracingTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor)->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_globalSrg->SetBufferView(tlasConstantIndex, m_rayTracingTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor).get());
 
                 RHI::ShaderInputImageIndex outputConstantIndex;
                 FindShaderInputIndex(&outputConstantIndex, m_globalSrg, AZ::Name{ "m_output" }, RayTracingExampleName);
-                m_globalSrg->SetImageView(outputConstantIndex, m_outputImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_globalSrg->SetImageView(outputConstantIndex, m_outputImageView.get());
 
                 // set hit shader data, each array element corresponds to the InstanceIndex() of the geometry in the TLAS
                 // Note: this method is used instead of LocalRootSignatures for compatibility with non-DX12 platforms
@@ -585,7 +585,7 @@ namespace AtomSampleViewer
             RHI::CommandList* commandList = context.GetCommandList();
 
             const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                m_globalSrg->GetRHIShaderResourceGroup()
+                m_globalSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
             };
 
             RHI::SingleDeviceDispatchRaysItem dispatchRaysItem;
@@ -643,7 +643,7 @@ namespace AtomSampleViewer
                 const Name outputImageId{ "m_output" };
                 RHI::ShaderInputImageIndex outputImageIndex = m_drawSRG->FindShaderInputImageIndex(outputImageId);
                 AZ_Error(RayTracingExampleName, outputImageIndex.IsValid(), "Failed to find shader input image %s.", outputImageId.GetCStr());
-                m_drawSRG->SetImageView(outputImageIndex, m_outputImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_drawSRG->SetImageView(outputImageIndex, m_outputImageView.get());
                 m_drawSRG->Compile();
             }
 
@@ -663,7 +663,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_drawSRG->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_drawSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -307,7 +307,7 @@ namespace AtomSampleViewer
                 commandList->SetScissors(&m_scissor, 1);
 
                 // Bind ViewSrg
-                commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup());
+                commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                 const RHI::SingleDeviceIndexBufferView indexBufferView =
                 {
@@ -322,10 +322,10 @@ namespace AtomSampleViewer
                 drawIndexed.m_instanceCount = 1;
 
                 const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                    (m_mode ? m_demoShaderResourceGroup->GetRHIShaderResourceGroup() :
-                              m_renderShaderResourceGroup->GetRHIShaderResourceGroup()
+                    (m_mode ? m_demoShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() :
+                              m_renderShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                     ),
-                    m_viewShaderResourceGroup->GetRHIShaderResourceGroup()
+                    m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                 };
 
                 RHI::SingleDeviceDrawItem drawItem;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -389,7 +389,7 @@ namespace AtomSampleViewer
             RHI::CommandList* commandList = context.GetCommandList();
 
             // Bind ViewSrg
-            commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup());
+            commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             // Set persistent viewport and scissor state.
             commandList->SetViewports(&m_viewport, 1);
@@ -401,7 +401,7 @@ namespace AtomSampleViewer
                 const auto& modelData = m_opaqueModelsData[i];
                 const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
                 {
-                    modelData.m_shaderResourceGroup->GetRHIShaderResourceGroup()
+                    modelData.m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get()
                 };
 
                 for (const auto& mesh : m_models[modelData.m_modelType]->GetLods()[0]->GetMeshes())
@@ -503,7 +503,7 @@ namespace AtomSampleViewer
             RHI::CommandList* commandList = context.GetCommandList();
 
             // Bind ViewSrg
-            commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup());
+            commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
             // Set persistent viewport and scissor state.
             commandList->SetViewports(&m_viewport, 1);
@@ -511,8 +511,8 @@ namespace AtomSampleViewer
 
             const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
             {
-                m_compositionSubpassInputsSRG->GetRHIShaderResourceGroup(),
-                m_sceneShaderResourceGroup->GetRHIShaderResourceGroup(),
+                m_compositionSubpassInputsSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
+                m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
             };
 
             RHI::DrawLinear drawArguments;

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -198,7 +198,7 @@ namespace AtomSampleViewer
                 const float ratioYtoX = m_windowSize.m_height / static_cast<float>(m_windowSize.m_width);
                 AZStd::array<float, 2> size = { {0.7f * ratioYtoX, 0.7f} };
 
-                m_shaderResourceGroup->SetImageView(m_texture3dInputIndex, m_imageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex).get());
+                m_shaderResourceGroup->SetImageView(m_texture3dInputIndex, m_imageView.get());
                 m_shaderResourceGroup->SetConstant<uint32_t>(m_sliceIndexInputIndex, static_cast<uint32_t>(m_sliceIndex));
                 m_shaderResourceGroup->SetConstant(m_positionInputIndex, position);
                 m_shaderResourceGroup->SetConstant(m_sizeInputIndex, size);
@@ -217,7 +217,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_vertexCount = 4;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 // Create the draw item
                 RHI::SingleDeviceDrawItem drawItem;
@@ -274,7 +274,7 @@ namespace AtomSampleViewer
         {
             ImGui::Text("3D image slice index");
 
-            for (int32_t i = 0; i < static_cast<int32_t>(m_imageLayout.GetDeviceImageSubresource(RHI::MultiDevice::DefaultDeviceIndex).m_size.m_depth); i++)
+            for (int32_t i = 0; i < static_cast<int32_t>(m_imageLayout.GetDeviceImageSubresource(AZ::RHI::MultiDevice::DefaultDeviceIndex).m_size.m_depth); i++)
             {
                 const AZStd::string label = AZStd::string::format("Image Slice %d", i);
                 ScriptableImGui::RadioButton(label.c_str(), &m_sliceIndex, i);

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -218,7 +218,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_instanceCount = 1u;
 
                 const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                    m_textureArraySrg->GetRHIShaderResourceGroup(), m_textureIndexSrg->GetRHIShaderResourceGroup() };
+                    m_textureArraySrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(), m_textureIndexSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -236,7 +236,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -513,7 +513,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_targetSRGs[target]->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_targetSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
@@ -590,7 +590,7 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = m_bufferViews[target].m_indexBufferView.GetByteCount() / sizeof(uint16_t);
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_screenSRGs[target]->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_screenSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -208,7 +208,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 3;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -218,7 +218,7 @@ namespace AtomSampleViewer
             RHI::ShaderInputBufferIndex trianglesBufferIndex;
             FindShaderInputIndex(&trianglesBufferIndex, m_shaderResourceGroup, trianglesBufferId, s_trianglesConstantBufferExampleName);
 
-            [[maybe_unused]] bool set = m_shaderResourceGroup->SetBufferView(trianglesBufferIndex, m_constantBufferView->GetDeviceBufferView(RHI::MultiDevice::DefaultDeviceIndex).get(), 0);
+            [[maybe_unused]] bool set = m_shaderResourceGroup->SetBufferView(trianglesBufferIndex, m_constantBufferView.get(), 0);
             AZ_Assert(set, "Failed to set the buffer view");
 
             // All SRG data has been set already, it only had the buffer view to be set, we can compile now.
@@ -260,7 +260,7 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 3;
                 drawIndexed.m_instanceCount = s_numberOfTrianglesTotal;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup() };
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
@@ -95,11 +95,11 @@ namespace AtomSampleViewer
         {
             if (m_useImageShadingRate)
             {
-                frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentId }, m_shadingRateImages[m_frameCount % m_shadingRateImages.size()]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentId }, m_shadingRateImages[m_frameCount % m_shadingRateImages.size()]);
                 if (!Utils::GetRHIDevice()->GetFeatures().m_dynamicShadingRateImage)
                 {
                     // We cannot update and use the same shading rate image because "m_dynamicShadingRateImage" is not supported.
-                    frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentUpdateId }, m_shadingRateImages[(m_frameCount + m_shadingRateImages.size() - 1) % m_shadingRateImages.size()]->GetDeviceImage(RHI::MultiDevice::DefaultDeviceIndex));
+                    frameGraphBuilder.GetAttachmentDatabase().ImportImage(RHI::AttachmentId{ VariableRateShading::ShadingRateAttachmentUpdateId }, m_shadingRateImages[(m_frameCount + m_shadingRateImages.size() - 1) % m_shadingRateImages.size()]);
                 }
             }
             m_frameCount++;
@@ -554,7 +554,7 @@ namespace AtomSampleViewer
                 commandList->SetFragmentShadingRate(m_shadingRate, combinators);
             }
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_modelShaderResourceGroup->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_modelShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
             // We have to wait until the updating of the initial contents of the shading rate image is done if
             // dynamic mode is not supported (since the CPU would try to read it while the GPU is updating the contents)
             bool useImageShadingRate = m_useImageShadingRate && (device->GetFeatures().m_dynamicShadingRateImage || m_frameCount > device->GetDescriptor().m_frameCountMax);
@@ -642,7 +642,7 @@ namespace AtomSampleViewer
             RHI::CommandList* commandList = context.GetCommandList();
 
             RHI::SingleDeviceDispatchItem dispatchItem;
-            decltype(dispatchItem.m_shaderResourceGroups) shaderResourceGroups = { { m_computeShaderResourceGroup->GetRHIShaderResourceGroup() } };
+            decltype(dispatchItem.m_shaderResourceGroups) shaderResourceGroups = { { m_computeShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() } };
 
             RHI::DispatchDirect dispatchArgs;
 
@@ -730,7 +730,7 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_imageShaderResourceGroup->GetRHIShaderResourceGroup() };
+            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_imageShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
             RHI::DrawIndexed drawIndexed;
             drawIndexed.m_indexCount = 6;

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -373,7 +373,7 @@ namespace AtomSampleViewer
 
             for (uint32_t i = indexStart; i < indexEnd; ++i)
             {
-                const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup() };
+                const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get() };
 
                 AZ::RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -308,7 +308,7 @@ namespace AtomSampleViewer
                 drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
                 drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
                 drawPacketBuilder.SetRootConstants(m_rootConstantData.GetConstantData());
-                drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup());
+                drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
 
                 RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
                 drawRequest.m_listTag = m_drawListTag;

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -1176,10 +1176,10 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::ShowTransientAttachmentProfilerWindow()
     {
-        auto* transientStats = AZ::RHI::RHIMemoryStatisticsInterface::Get()->GetTransientAttachmentStatistics();
-        if (transientStats)
+        const auto& transientStats = AZ::RHI::RHIMemoryStatisticsInterface::Get()->GetTransientAttachmentStatistics();
+        if (!transientStats.empty())
         {
-            m_showTransientAttachmentProfiler = m_imguiTransientAttachmentProfiler.Draw(*transientStats);
+            m_showTransientAttachmentProfiler = m_imguiTransientAttachmentProfiler.Draw(transientStats);
         }
     }
 

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -501,7 +501,7 @@ namespace AtomSampleViewer
             drawRequest.m_listTag = m_image3dDrawListTag;
             drawRequest.m_pipelineState = m_image3dPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
             drawRequest.m_sortKey = 0;
-            drawRequest.m_uniqueShaderResourceGroup = image3d.m_srg->GetRHIShaderResourceGroup();
+            drawRequest.m_uniqueShaderResourceGroup = image3d.m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
             drawPacketBuilder.AddDrawItem(drawRequest);
 
             // Submit draw packet...
@@ -524,7 +524,7 @@ namespace AtomSampleViewer
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
         drawRequest.m_sortKey = 0;
-        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup();
+        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
         drawPacketBuilder.AddDrawItem(drawRequest);
 
         // Submit draw packet...

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -281,7 +281,7 @@ namespace AtomSampleViewer
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
         drawRequest.m_sortKey = 0;
-        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup();
+        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
         drawPacketBuilder.AddDrawItem(drawRequest);
 
         // Submit draw packet


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as some changes that have been introduced in the meantime (i.e. in `TransientAttachmentPool` etc.).

This specifically introduces resources related to `MultiDeviceShaderResourceGroup`.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [SRG-related resources](https://github.com/o3de/o3de/commit/b5b0fb08009ca7a5b34d03337eb15f8e9c27c2d1).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|[#661](https://github.com/o3de/o3de-atom-sampleviewer/pull/661)|merged|
|`Image`|#662|merged|
|`Query`|#663|merged|
|`PipelineState`|#664|merged|
|`RayTracing`|#667|merged|
|`TransientAttachmentPool`|too small, together with SRG||
|`SwapChain`|nothing to do||
|`SRG`|this PR|open|
|`DrawItem`|||
|`FrameGraph`|||