### PR TITLE
DrawItem-related resources

### DIFF
--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -19,7 +19,7 @@
 
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -372,21 +372,21 @@ namespace AtomSampleViewer
     void BloomExampleComponent::DrawImage(const ImageToDraw* imageInfo)
     {
         // Build draw packet
-        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
         RHI::DrawLinear drawLinear;
         drawLinear.m_vertexCount = 4;
         drawPacketBuilder.SetDrawArguments(drawLinear);
 
-        RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;
-        drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;
-        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup();
         drawPacketBuilder.AddDrawItem(drawRequest);
 
         // Submit draw packet
-        AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket(drawPacketBuilder.End());
+        auto drawPacket{drawPacketBuilder.End()};
         m_dynamicDraw->AddDrawPacket(m_scene, AZStd::move(drawPacket));
     }
 

--- a/Gem/Code/Source/DynamicDrawExampleComponent.h
+++ b/Gem/Code/Source/DynamicDrawExampleComponent.h
@@ -16,8 +16,8 @@
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 #include <Atom/RHI/DrawList.h>
 

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -160,14 +160,14 @@ namespace AtomSampleViewer
         }
         
         m_rectangleStreamBufferViews[0] = {
-            *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_rectangleInputAssemblyBuffer,
             offsetof(RectangleBufferData, m_positions),
             sizeof(RectangleBufferData::m_positions),
             sizeof(VertexPosition)
         };
         
         m_rectangleStreamBufferViews[1] = {
-            *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_rectangleInputAssemblyBuffer,
             offsetof(RectangleBufferData, m_uvs),
             sizeof(RectangleBufferData::m_uvs),
             sizeof(VertexUV)
@@ -405,7 +405,7 @@ namespace AtomSampleViewer
                 };
                 drawItem.m_indexBufferView = &indexBufferView;
 
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2>& streamBufferViews = m_rectangleStreamBufferViews;
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> streamBufferViews{m_rectangleStreamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex),m_rectangleStreamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(streamBufferViews.size());
                 drawItem.m_streamBufferViews = streamBufferViews.data();
 

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
@@ -20,9 +20,9 @@
 
 #include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -93,7 +93,7 @@ namespace AtomSampleViewer
         };
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_rectangleInputAssemblyBuffer;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
 
         // Shader Resource

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -203,25 +203,25 @@ namespace AtomSampleViewer
             return;
         }
 
-        AZ::RHI::SingleDeviceStreamBufferView positionsBufferView =
+        AZ::RHI::MultiDeviceStreamBufferView positionsBufferView =
         {
-            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_quadInputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
         };
 
-        AZ::RHI::SingleDeviceStreamBufferView normalsBufferView =
+        AZ::RHI::MultiDeviceStreamBufferView normalsBufferView =
         {
-            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_quadInputAssemblyBuffer,
             offsetof(BufferData, m_normals),
             sizeof(BufferData::m_normals),
             sizeof(VertexNormal)
         };
 
-        AZ::RHI::SingleDeviceStreamBufferView uvsBufferView =
+        AZ::RHI::MultiDeviceStreamBufferView uvsBufferView =
         {
-            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_quadInputAssemblyBuffer,
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -236,7 +236,7 @@ namespace AtomSampleViewer
 
         m_quadIndexBufferView =
         {
-            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_quadInputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -600,9 +600,9 @@ namespace AtomSampleViewer
 
         m_quadBufferPool = nullptr;
         m_quadInputAssemblyBuffer = nullptr;
-        m_quadStreamBufferViews.fill(AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView>());
+        m_quadStreamBufferViews.fill(AZStd::vector<AZ::RHI::MultiDeviceStreamBufferView>());
         m_terrainPipelineStates.fill(nullptr);
-        m_modelStreamBufferViews.fill(AZ::RPI::ModelLod::TempStreamBufferViewList());
+        m_modelStreamBufferViews.fill(AZ::RPI::ModelLod::StreamBufferViewList());
         m_modelPipelineStates.fill(nullptr);
         m_model = nullptr;
         m_copyTexturePipelineState = nullptr;
@@ -813,11 +813,17 @@ namespace AtomSampleViewer
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_copyTexturePipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                drawItem.m_indexBufferView = &m_quadIndexBufferView;
+                auto deviceIndexBufferView{m_quadIndexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_quadStreamBufferViews[CopyTextureScope].size());
-                drawItem.m_streamBufferViews = m_quadStreamBufferViews[CopyTextureScope].data();
+                AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                for(const auto& streamBufferView : m_quadStreamBufferViews[CopyTextureScope])
+                {
+                    deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                }
+                drawItem.m_streamBufferViews = deviceQuadStreamBufferViews.data();
                 commandList->Submit(drawItem);
             }
        };
@@ -881,11 +887,17 @@ namespace AtomSampleViewer
                     RHI::SingleDeviceDrawItem drawItem;
                     drawItem.m_arguments = drawIndexed;
                     drawItem.m_pipelineState = m_terrainPipelineStates[ShadowScope]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    drawItem.m_indexBufferView = &m_quadIndexBufferView;
+                    auto deviceIndexBufferView{m_quadIndexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                    drawItem.m_indexBufferView = &deviceIndexBufferView;
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_quadStreamBufferViews[ShadowScope].size());
-                    drawItem.m_streamBufferViews = m_quadStreamBufferViews[ShadowScope].data();
+                    AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                    for(const auto& streamBufferView : m_quadStreamBufferViews[ShadowScope])
+                    {
+                        deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                    }
+                    drawItem.m_streamBufferViews = deviceQuadStreamBufferViews.data();
                     commandList->Submit(drawItem, i);
                 }
                 else
@@ -895,15 +907,19 @@ namespace AtomSampleViewer
                     for (const auto& mesh : m_model->GetLods()[0]->GetMeshes())
                     {
                         RHI::SingleDeviceDrawItem drawItem;
-                        drawItem.m_arguments = mesh.m_drawArguments;
+                        drawItem.m_arguments = mesh.m_drawArguments.GetDeviceDrawArguments(RHI::MultiDevice::DefaultDeviceIndex);
                         drawItem.m_pipelineState = m_modelPipelineStates[ShadowScope]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
                         auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
                         drawItem.m_indexBufferView = &deviceIndexBufferView;
                         drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                         drawItem.m_shaderResourceGroups = shaderResourceGroups;
                         drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_modelStreamBufferViews[ShadowScope].size());
-                        drawItem.m_streamBufferViews = m_modelStreamBufferViews[ShadowScope].data();
-
+                        AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                        for(const auto& streamBufferView : m_modelStreamBufferViews[ShadowScope])
+                        {
+                            deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                        }
+                        drawItem.m_streamBufferViews = deviceQuadStreamBufferViews.data();
                         commandList->Submit(drawItem, i);
                     }
                 }
@@ -1000,11 +1016,17 @@ namespace AtomSampleViewer
                     RHI::SingleDeviceDrawItem drawItem;
                     drawItem.m_arguments = drawIndexed;
                     drawItem.m_pipelineState = m_terrainPipelineStates[ForwardScope]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                    drawItem.m_indexBufferView = &m_quadIndexBufferView;
+                    auto deviceIndexBufferView{m_quadIndexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                    drawItem.m_indexBufferView = &deviceIndexBufferView;
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_quadStreamBufferViews[ForwardScope].size());
-                    drawItem.m_streamBufferViews = m_quadStreamBufferViews[ForwardScope].data();
+                    AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                    for(const auto& streamBufferView : m_quadStreamBufferViews[ForwardScope])
+                    {
+                        deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                    }
+                    drawItem.m_streamBufferViews = deviceQuadStreamBufferViews.data();
 
                     commandList->Submit(drawItem, i);
                 }
@@ -1020,14 +1042,19 @@ namespace AtomSampleViewer
                     for (const auto& mesh : m_model->GetLods()[0]->GetMeshes())
                     {
                         RHI::SingleDeviceDrawItem drawItem;
-                        drawItem.m_arguments = mesh.m_drawArguments;
+                        drawItem.m_arguments = mesh.m_drawArguments.GetDeviceDrawArguments(RHI::MultiDevice::DefaultDeviceIndex);
                         drawItem.m_pipelineState = m_modelPipelineStates[ForwardScope]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
                         auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
                         drawItem.m_indexBufferView = &deviceIndexBufferView;
                         drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                         drawItem.m_shaderResourceGroups = shaderResourceGroups;
                         drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_modelStreamBufferViews[ForwardScope].size());
-                        drawItem.m_streamBufferViews = m_modelStreamBufferViews[ForwardScope].data();
+                        AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                        for(const auto& streamBufferView : m_modelStreamBufferViews[ForwardScope])
+                        {
+                            deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                        }
+                        drawItem.m_streamBufferViews = deviceQuadStreamBufferViews.data();
 
                         commandList->Submit(drawItem, i);
                     }
@@ -1174,11 +1201,17 @@ namespace AtomSampleViewer
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_luminancePipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                drawItem.m_indexBufferView = &m_quadIndexBufferView;
+                auto deviceIndexBufferView{m_quadIndexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_quadStreamBufferViews[LuminanceMapScope].size());
-                drawItem.m_streamBufferViews = m_quadStreamBufferViews[LuminanceMapScope].data();
+                AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView> singleDeviceQuadStreamBufferViews;
+                for(const auto& streamBufferView : m_quadStreamBufferViews[LuminanceMapScope])
+                {
+                    singleDeviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                }
+                drawItem.m_streamBufferViews = singleDeviceQuadStreamBufferViews.data();
                 commandList->Submit(drawItem);
             }
         };

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
@@ -122,14 +122,14 @@ namespace AtomSampleViewer
         // Quad related variables
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_quadBufferPool;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
-        AZ::RHI::SingleDeviceIndexBufferView m_quadIndexBufferView;
-        AZStd::array<AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView>, NumScopes> m_quadStreamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_quadIndexBufferView;
+        AZStd::array<AZStd::vector<AZ::RHI::MultiDeviceStreamBufferView>, NumScopes> m_quadStreamBufferViews;
 
         // Terrain related variables
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, NumScopes> m_terrainPipelineStates;
 
         // Model related variables
-        AZStd::array<AZ::RPI::ModelLod::TempStreamBufferViewList, NumScopes> m_modelStreamBufferViews;
+        AZStd::array<AZ::RPI::ModelLod::StreamBufferViewList, NumScopes> m_modelStreamBufferViews;
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, NumScopes> m_modelPipelineStates;
         AZ::Data::Instance<AZ::RPI::Model> m_model;
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -1264,14 +1264,19 @@ namespace AtomSampleViewer
                         m_bindlessSrg->GetSrg(m_indirectionBufferSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get(),
                     };
                     RHI::SingleDeviceDrawItem drawItem;
-                    drawItem.m_arguments = subMesh.m_mesh->m_drawArguments;
+                    drawItem.m_arguments = subMesh.m_mesh->m_drawArguments.GetDeviceDrawArguments(RHI::MultiDevice::DefaultDeviceIndex);
                     drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
                     auto deviceIndexBufferView{subMesh.m_mesh->m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
                     drawItem.m_indexBufferView = &deviceIndexBufferView;
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(subMesh.bufferStreamViewArray.size());
-                    drawItem.m_streamBufferViews = subMesh.bufferStreamViewArray.data();
+                    AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                    for(const auto& streamBufferView : subMesh.bufferStreamViewArray)
+                    {
+                        deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                    }
+                    drawItem.m_streamBufferViews = deviceQuadStreamBufferViews.data();
 
                     // Submit the triangle draw item.
                     commandList->Submit(drawItem, instanceIdx);

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -132,7 +132,7 @@ namespace AtomSampleViewer
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_perSubMeshSrg;
 
             const AZ::RPI::ModelLod::Mesh* m_mesh;
-            AZ::RPI::ModelLod::TempStreamBufferViewList bufferStreamViewArray;
+            AZ::RPI::ModelLod::StreamBufferViewList bufferStreamViewArray;
 
             AZ::Matrix4x4 m_modelMatrix;
 

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -121,7 +121,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -129,7 +129,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -137,7 +137,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -401,9 +401,12 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_drawPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
@@ -83,8 +83,8 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // ----------------------------

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -139,14 +139,14 @@ namespace AtomSampleViewer
             }
 
             m_streamBufferViews[0] = {
-                *m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_positionBuffer,
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
             };
 
             m_streamBufferViews[1] = {
-                *m_uvBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_uvBuffer,
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
@@ -247,7 +247,9 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);
             };

--- a/Gem/Code/Source/RHI/CopyQueueComponent.h
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.h
@@ -15,7 +15,7 @@
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/Device.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
@@ -93,8 +93,7 @@ namespace AtomSampleViewer
 
         BufferData m_bufferData;
 
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
 
         static const int numberOfPaths = 3;
         const char* m_filePaths[numberOfPaths] = {

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -101,7 +101,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -109,7 +109,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_colors),
             sizeof(BufferData::m_colors),
             sizeof(VertexColor)
@@ -117,7 +117,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -209,9 +209,12 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
@@ -63,8 +63,8 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // ----------------------------------

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -12,7 +12,7 @@
 #include <SampleComponentManager.h>
 
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/SingleDeviceIndirectBufferWriter.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -116,12 +116,12 @@ namespace AtomSampleViewer
     {
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        RHI::SingleDeviceStreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
-        RHI::SingleDeviceStreamBufferView& instancesIndicesStreamBufferView = m_streamBufferViews[1];
-        RHI::SingleDeviceStreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
+        RHI::MultiDeviceStreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
+        RHI::MultiDeviceStreamBufferView& instancesIndicesStreamBufferView = m_streamBufferViews[1];
+        RHI::MultiDeviceStreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
 
-        RHI::SingleDeviceIndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
-        RHI::SingleDeviceIndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
+        RHI::MultiDeviceIndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
+        RHI::MultiDeviceIndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
 
         // We use an index to identify an object at draw time.
         // On platforms that support setting inline constant through indirect commands we use an inline constant to set
@@ -176,7 +176,7 @@ namespace AtomSampleViewer
             {
                 triangleStreamBufferView =
                 {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                    *m_inputAssemblyBuffer,
                     offsetof(BufferData, m_trianglePositions),
                     sizeof(BufferData::m_trianglePositions),
                     sizeof(VertexPosition)
@@ -184,7 +184,7 @@ namespace AtomSampleViewer
 
                 triangleIndexBufferView =
                 {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                    *m_inputAssemblyBuffer,
                     offsetof(BufferData, m_triangleIndices),
                     sizeof(BufferData::m_triangleIndices),
                     RHI::IndexFormat::Uint16
@@ -192,7 +192,7 @@ namespace AtomSampleViewer
 
                 quadStreamBufferView =
                 {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                    *m_inputAssemblyBuffer,
                     offsetof(BufferData, m_quadPositions),
                     sizeof(BufferData::m_quadPositions),
                     sizeof(VertexPosition)
@@ -200,7 +200,7 @@ namespace AtomSampleViewer
 
                 quadIndexBufferView =
                 {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                    *m_inputAssemblyBuffer,
                     offsetof(BufferData, m_quadIndices),
                     sizeof(BufferData::m_quadIndices),
                     RHI::IndexFormat::Uint16
@@ -211,7 +211,7 @@ namespace AtomSampleViewer
             {
                 m_streamBufferViews[0] =
                 {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                    *m_inputAssemblyBuffer,
                     offsetof(BufferData, m_trianglePositions),
                     sizeof(BufferData::m_trianglePositions) + sizeof(BufferData::m_quadPositions),
                     sizeof(VertexPosition)
@@ -219,7 +219,7 @@ namespace AtomSampleViewer
 
                 m_indexBufferViews[0] =
                 {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                    *m_inputAssemblyBuffer,
                     offsetof(BufferData, m_triangleIndices), // Need to offset the index buffer to the proper location
                     sizeof(BufferData::m_triangleIndices) + sizeof(BufferData::m_quadIndices),
                     RHI::IndexFormat::Uint16
@@ -233,13 +233,13 @@ namespace AtomSampleViewer
 
             instancesIndicesStreamBufferView =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_instanceIndices),
                 sizeof(BufferData::m_instanceIndices),
                 sizeof(uint32_t)
             };
 
-            RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::SingleDeviceStreamBufferView>(m_streamBufferViews.data(), 2));
+            RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView>(m_streamBufferViews.data(), 2));
         }
     }
 
@@ -357,11 +357,11 @@ namespace AtomSampleViewer
 
         // Create the signature and pass the pipeline state since we may have
         // an inline constants command.
-        m_indirectDrawBufferSignature = RHI::Factory::Get().CreateIndirectBufferSignature();
-        RHI::SingleDeviceIndirectBufferSignatureDescriptor signatureDescriptor;
+        m_indirectDrawBufferSignature = aznew RHI::MultiDeviceIndirectBufferSignature;
+        RHI::MultiDeviceIndirectBufferSignatureDescriptor signatureDescriptor;
         signatureDescriptor.m_layout = m_indirectDrawBufferLayout;
-        signatureDescriptor.m_pipelineState = m_drawPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-        result = m_indirectDrawBufferSignature->Init(*device, signatureDescriptor);
+        signatureDescriptor.m_pipelineState = m_drawPipelineState.get();
+        result = m_indirectDrawBufferSignature->Init(RHI::MultiDevice::DefaultDevice, signatureDescriptor);
 
         if (result != RHI::ResultCode::Success)
         {
@@ -380,19 +380,19 @@ namespace AtomSampleViewer
         m_shaderBufferPool->InitBuffer(request);
 
         // Create a writer to populate the buffer with the commands.
-        auto indirectBufferWriter = RHI::Factory::Get().CreateIndirectBufferWriter();
-        result = indirectBufferWriter->Init(*m_sourceIndirectBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex), 0, commandsStride, s_maxNumberOfObjects, *m_indirectDrawBufferSignature);
+        RHI::Ptr<RHI::MultiDeviceIndirectBufferWriter> indirectBufferWriter = aznew RHI::MultiDeviceIndirectBufferWriter;
+        result = indirectBufferWriter->Init(*m_sourceIndirectBuffer, 0, commandsStride, s_maxNumberOfObjects, *m_indirectDrawBufferSignature);
         if (result != RHI::ResultCode::Success)
         {
             AZ_Assert(false, "Fail to initialize Indirect Buffer Writer");
             return;
         }
 
-        RHI::SingleDeviceStreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
-        RHI::SingleDeviceStreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
+        RHI::MultiDeviceStreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
+        RHI::MultiDeviceStreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
 
-        RHI::SingleDeviceIndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
-        RHI::SingleDeviceIndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
+        RHI::MultiDeviceIndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
+        RHI::MultiDeviceIndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
 
         // Write the commands using the IndirectBufferWriter
         // We alternate between drawing a triangle and a quad.
@@ -469,10 +469,10 @@ namespace AtomSampleViewer
                 return;
             }
 
-            m_indirectDispatchBufferSignature = RHI::Factory::Get().CreateIndirectBufferSignature();
+            m_indirectDispatchBufferSignature = aznew RHI::MultiDeviceIndirectBufferSignature;
             signatureDescriptor = {};
             signatureDescriptor.m_layout = m_indirectDispatchBufferLayout;
-            result = m_indirectDispatchBufferSignature->Init(*device, signatureDescriptor);
+            result = m_indirectDispatchBufferSignature->Init(RHI::MultiDevice::DefaultDevice, signatureDescriptor);
 
             if (result != RHI::ResultCode::Success)
             {
@@ -490,15 +490,15 @@ namespace AtomSampleViewer
 
             m_indirectDispatchBufferView =
             {
-                *m_indirectDispatchBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_indirectDispatchBuffer,
                 *m_indirectDispatchBufferSignature,
                 0,
                 indirectDispatchStride,
                 indirectDispatchStride
             };
 
-            m_indirectDispatchWriter = RHI::Factory::Get().CreateIndirectBufferWriter();
-            result = m_indirectDispatchWriter->Init(*m_indirectDispatchBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex), 0, indirectDispatchStride, 1, *m_indirectDispatchBufferSignature);
+            m_indirectDispatchWriter = aznew RHI::MultiDeviceIndirectBufferWriter;
+            result = m_indirectDispatchWriter->Init(*m_indirectDispatchBuffer, 0, indirectDispatchStride, 1, *m_indirectDispatchBufferSignature);
             if (result != RHI::ResultCode::Success)
             {
                 AZ_Assert(false, "Fail to initialize Indirect Buffer Writer");
@@ -712,7 +712,7 @@ namespace AtomSampleViewer
             uint32_t stride = m_indirectDrawBufferSignature->GetByteStride();
             m_indirectDrawBufferView =
             {
-                *(culledBufferView->GetBuffer()->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex).get()),
+                *(culledBufferView->GetBuffer()),
                 *m_indirectDrawBufferSignature,
                 0,
                 stride * m_numObjects,
@@ -736,7 +736,7 @@ namespace AtomSampleViewer
 
             // Submit the dispatch in an indirect manner.
             // Not really needed but it tests the indirect dispatch code.
-            RHI::DispatchIndirect dispatchArgs(1, m_indirectDispatchBufferView, 0);
+            RHI::DispatchIndirect dispatchArgs(1, m_indirectDispatchBufferView.GetDeviceIndirectBufferView(RHI::MultiDevice::DefaultDeviceIndex), 0);
 
             dispatchItem.m_arguments = dispatchArgs;
             dispatchItem.m_pipelineState = m_cullPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
@@ -838,16 +838,20 @@ namespace AtomSampleViewer
                 // Offset the indirect buffer depending on the number of indirect draw calls that we can do.
                 m_drawIndirect.m_maxSequenceCount = AZStd::min(m_numObjects - i, maxIndirectDrawCount);
                 m_drawIndirect.m_indirectBufferByteOffset = i * m_indirectDrawBufferView.GetByteStride();
-                m_drawIndirect.m_indirectBufferView = &m_indirectDrawBufferView;
+                auto deviceIndirectBufferView{m_indirectDrawBufferView.GetDeviceIndirectBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                m_drawIndirect.m_indirectBufferView = &deviceIndirectBufferView;
 
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = m_drawIndirect;
                 drawItem.m_pipelineState = m_drawPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                drawItem.m_indexBufferView = &m_indexBufferViews[0];
+                auto deviceIndexBufferView{m_indexBufferViews[0].GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = 2;
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the indirect draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
@@ -20,13 +20,13 @@
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDeviceCopyItem.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceIndirectBufferSignature.h>
-#include <Atom/RHI/SingleDeviceIndirectBufferWriter.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferSignature.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
@@ -171,18 +171,18 @@ namespace AtomSampleViewer
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumSequencesType> m_indirectCommandsShaderResourceGroups;
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 3> m_streamBufferViews;
-        AZStd::array<AZ::RHI::SingleDeviceIndexBufferView, 2> m_indexBufferViews;
-        AZ::RHI::SingleDeviceIndirectBufferView m_indirectDrawBufferView;
-        AZ::RHI::SingleDeviceIndirectBufferView m_indirectDispatchBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 3> m_streamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceIndexBufferView, 2> m_indexBufferViews;
+        AZ::RHI::MultiDeviceIndirectBufferView m_indirectDrawBufferView;
+        AZ::RHI::MultiDeviceIndirectBufferView m_indirectDispatchBufferView;
 
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_sourceIndirectBufferView;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_instancesDataBufferView;
 
         AZ::RHI::IndirectBufferLayout m_indirectDrawBufferLayout;
         AZ::RHI::IndirectBufferLayout m_indirectDispatchBufferLayout;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceIndirectBufferSignature> m_indirectDrawBufferSignature;
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceIndirectBufferSignature> m_indirectDispatchBufferSignature;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> m_indirectDrawBufferSignature;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> m_indirectDispatchBufferSignature;
 
         AZ::RHI::ShaderInputBufferIndex m_sceneInstancesDataBufferIndex;
         AZ::RHI::ShaderInputConstantIndex m_sceneMatrixInputIndex;
@@ -194,7 +194,7 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::ShaderInputBufferIndex, NumSequencesType> m_cullingInputIndirectBufferIndices;
         AZStd::array<AZ::RHI::ShaderInputBufferIndex, NumSequencesType> m_cullingOutputIndirectBufferIndices;
 
-        AZ::RHI::Ptr<AZ::RHI::SingleDeviceIndirectBufferWriter> m_indirectDispatchWriter;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> m_indirectDispatchWriter;
 
         AZ::RHI::DrawIndirect m_drawIndirect;
         AZ::RHI::SingleDeviceCopyBufferDescriptor m_copyDescriptor;

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RHI/RHISystemInterface.h>

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -195,7 +195,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -203,7 +203,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -211,7 +211,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -295,11 +295,14 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[0]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
         };
@@ -369,11 +372,14 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[1]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
         };

--- a/Gem/Code/Source/RHI/MRTExampleComponent.h
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
@@ -80,10 +79,9 @@ namespace AtomSampleViewer
             AZStd::array<VertexUV, 4> m_uvs;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
 
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
         AZStd::array<AZ::RHI::AttachmentId, 3> m_attachmentID;
         AZ::RHI::ClearValue m_clearValue;
         float m_time;

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -146,7 +146,7 @@ namespace AtomSampleViewer
 
         m_triangleStreamBufferViews[0] =
         {
-            *m_triangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_triangleInputAssemblyBuffer,
             offsetof(TriangleBufferData, m_positions),
             sizeof(TriangleBufferData::m_positions),
             sizeof(VertexPosition)
@@ -154,7 +154,7 @@ namespace AtomSampleViewer
 
         m_triangleStreamBufferViews[1] =
         {
-            *m_triangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_triangleInputAssemblyBuffer,
             offsetof(TriangleBufferData, m_colors),
             sizeof(TriangleBufferData::m_colors),
             sizeof(VertexColor)
@@ -206,14 +206,14 @@ namespace AtomSampleViewer
         }
 
         m_quadStreamBufferViews[0] = {
-            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_quadInputAssemblyBuffer,
             offsetof(QuadBufferData, m_positions),
             sizeof(QuadBufferData::m_positions),
             sizeof(VertexPosition)
         };
 
         m_quadStreamBufferViews[1] = {
-            *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_quadInputAssemblyBuffer,
             offsetof(QuadBufferData, m_uvs),
             sizeof(QuadBufferData::m_uvs),
             sizeof(VertexUV)
@@ -360,7 +360,9 @@ namespace AtomSampleViewer
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_triangleStreamBufferViews.size());
-            drawItem.m_streamBufferViews = m_triangleStreamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_triangleStreamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_triangleStreamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             // Submit the triangle draw item.
             commandList->Submit(drawItem);
@@ -473,7 +475,9 @@ namespace AtomSampleViewer
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_quadStreamBufferViews.size());
-            drawItem.m_streamBufferViews = m_quadStreamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_quadStreamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_quadStreamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             // Submit the triangle draw item.
             commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.h
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.h
@@ -20,9 +20,9 @@
 
 #include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -133,8 +133,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_triangleStreamBufferViews;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_quadStreamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_triangleStreamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_quadStreamBufferViews;
         AZ::RHI::InputStreamLayout m_triangleInputStreamLayout;
         AZ::RHI::InputStreamLayout m_quadInputStreamLayout;
 

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -251,7 +251,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -259,7 +259,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
@@ -478,7 +478,9 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
@@ -14,7 +14,6 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
@@ -176,8 +175,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
 
         // ImGui stuff.
         ImGuiSidebar m_imguiSidebar;

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -9,7 +9,7 @@
 
 #include <AzCore/Math/MatrixUtils.h>
 
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <AzCore/Math/Random.h>
@@ -177,7 +177,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_positions),
             sizeof(SingleCubeBufferData::m_positions),
             sizeof(VertexPosition)
@@ -185,7 +185,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_colors),
             sizeof(SingleCubeBufferData::m_colors),
             sizeof(VertexColor)
@@ -193,7 +193,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(AZ::RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_indices),
             sizeof(SingleCubeBufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16
@@ -331,11 +331,14 @@ namespace AtomSampleViewer
                 AZ::RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
-                drawItem.m_indexBufferView = &m_indexBufferView;
+                auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem, i);
             }

--- a/Gem/Code/Source/RHI/MultiThreadComponent.h
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.h
@@ -86,7 +86,7 @@ namespace AtomSampleViewer
         AZ::RHI::ShaderInputConstantIndex m_shaderIndexViewProj;
 
         AZ::RHI::AttachmentId m_depthStencilID;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -259,7 +259,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -267,7 +267,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_colors),
             sizeof(BufferData::m_colors),
             sizeof(VertexColor)
@@ -275,7 +275,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[2] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_normals),
             sizeof(BufferData::m_normals),
             sizeof(VertexNormal)
@@ -283,7 +283,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16
@@ -425,11 +425,15 @@ namespace AtomSampleViewer
             AZ::RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[0]->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 3> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex),
+                    m_streamBufferViews[2].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
         };
@@ -514,11 +518,15 @@ namespace AtomSampleViewer
             AZ::RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[1]->GetDevicePipelineState(AZ::RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 3> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex),
+                    m_streamBufferViews[2].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
         };

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.h
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.h
@@ -12,7 +12,6 @@
 
 #include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
 
@@ -100,12 +99,11 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::ShaderInputConstantIndex, 6> m_shaderInputConstantIndices;
         AZ::RHI::ShaderInputImageIndex m_shaderInputImageIndex;
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 3> m_streamBufferViews;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 3> m_streamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
         AZ::RHI::AttachmentId m_depthMapID;
         AZ::RHI::AttachmentId m_depthStencilID;
         AZ::RHI::ClearValue m_depthClearValue;
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
 
         AZ::RHI::TransientImageDescriptor m_transientImageDescriptor;
     };

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -182,7 +182,7 @@ namespace AtomSampleViewer
             }
 
             m_quadStreamBufferView = {
-                *m_quadInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_quadInputAssemblyBuffer,
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -192,7 +192,7 @@ namespace AtomSampleViewer
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             m_quadInputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(m_quadInputStreamLayout, AZStd::span<const RHI::SingleDeviceStreamBufferView>(&m_quadStreamBufferView, 1));
+            RHI::ValidateStreamBufferViews(m_quadInputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView>(&m_quadStreamBufferView, 1));
         }
     }
 
@@ -447,7 +447,8 @@ namespace AtomSampleViewer
                 drawItem.m_pipelineState = m_quadPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
                 drawItem.m_indexBufferView = &quadIndexBufferView;
                 drawItem.m_streamBufferViewCount = 1;
-                drawItem.m_streamBufferViews = &m_quadStreamBufferView;
+                auto deviceStreamBufferView{m_quadStreamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = &deviceStreamBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
 

--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -18,11 +18,11 @@
 
 #include <Atom/RHI/MultiDeviceBuffer.h>
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 #include <Atom/RHI/MultiDeviceQueryPool.h>
 #include <Atom/RHI/MultiDeviceQuery.h>
-#include <Atom/RHI/SingleDeviceStreamBufferView.h>
+#include <Atom/RHI/MultiDeviceStreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
 #include <ExampleComponentBus.h>
@@ -100,7 +100,7 @@ namespace AtomSampleViewer
             AZStd::array<VertexPosition, 4> m_positions;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZ::RHI::SingleDeviceStreamBufferView m_quadStreamBufferView;
+        AZ::RHI::MultiDeviceStreamBufferView m_quadStreamBufferView;
         AZ::RHI::InputStreamLayout m_quadInputStreamLayout;
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, 3> m_shaderResourceGroups;

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -170,7 +170,7 @@ namespace AtomSampleViewer
 
         m_fullScreenStreamBufferViews[0] =
         {
-            *m_fullScreenInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_fullScreenInputAssemblyBuffer,
             offsetof(FullScreenBufferData, m_positions),
             sizeof(FullScreenBufferData::m_positions),
             sizeof(VertexPosition)
@@ -178,7 +178,7 @@ namespace AtomSampleViewer
 
         m_fullScreenStreamBufferViews[1] =
         {
-            *m_fullScreenInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_fullScreenInputAssemblyBuffer,
             offsetof(FullScreenBufferData, m_uvs),
             sizeof(FullScreenBufferData::m_uvs),
             sizeof(VertexUV)
@@ -186,7 +186,7 @@ namespace AtomSampleViewer
 
         m_fullScreenIndexBufferView =
         {
-            *m_fullScreenInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_fullScreenInputAssemblyBuffer,
             offsetof(FullScreenBufferData, m_indices),
             sizeof(FullScreenBufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -668,9 +668,12 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_drawPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_fullScreenIndexBufferView;
+            auto deviceIndexBufferView{m_fullScreenIndexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_fullScreenStreamBufferViews.size());
-            drawItem.m_streamBufferViews = m_fullScreenStreamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_fullScreenStreamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_fullScreenStreamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -134,14 +134,13 @@ namespace AtomSampleViewer
         };
 
         RHI::Ptr<RHI::MultiDeviceBuffer> m_fullScreenInputAssemblyBuffer;
-        AZStd::array<RHI::SingleDeviceStreamBufferView, 2> m_fullScreenStreamBufferViews;
-        RHI::SingleDeviceIndexBufferView m_fullScreenIndexBufferView;
+        AZStd::array<RHI::MultiDeviceStreamBufferView, 2> m_fullScreenStreamBufferViews;
+        RHI::MultiDeviceIndexBufferView m_fullScreenIndexBufferView;
         RHI::InputStreamLayout m_fullScreenInputStreamLayout;
 
         RHI::ConstPtr<RHI::MultiDevicePipelineState> m_drawPipelineState;
         Data::Instance<RPI::ShaderResourceGroup> m_drawSRG;
         RHI::ShaderInputConstantIndex m_drawDimensionConstantIndex;
-        RHI::SingleDeviceDrawItem m_drawItem;
 
         // time variable for moving the triangles and rectangle each frame
         float m_time = 0.0f;

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -143,14 +143,14 @@ namespace AtomSampleViewer
             }
 
             m_streamBufferViews[0] = {
-                *m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_positionBuffer,
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
             };
 
             m_streamBufferViews[1] = {
-                *m_uvBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_uvBuffer,
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
@@ -335,7 +335,9 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);
             };

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
@@ -13,7 +13,6 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
 #include <AzCore/Component/TickBus.h>
@@ -135,8 +134,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
         // ------------------------------------------------------------
 
         AZ::EntityId m_cameraEntityId;

--- a/Gem/Code/Source/RHI/StencilExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.cpp
@@ -106,7 +106,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -114,7 +114,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
@@ -217,7 +217,9 @@ namespace AtomSampleViewer
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)
                 {

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -13,7 +13,6 @@
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <Atom/RHI/Device.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 
 namespace AtomSampleViewer
@@ -61,8 +60,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, s_numberOfVertices> m_indices;
         };
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
 
         AZ::RHI::AttachmentId m_depthStencilID;
         AZ::RHI::ClearValue m_depthClearValue;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -14,7 +14,7 @@
 
 #include <Atom/Component/DebugCamera/ArcBallControllerComponent.h>
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/SingleDeviceIndirectBufferWriter.h>
+#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -407,14 +407,19 @@ namespace AtomSampleViewer
                 for (const auto& mesh : m_models[modelData.m_modelType]->GetLods()[0]->GetMeshes())
                 {
                     RHI::SingleDeviceDrawItem drawItem;
-                    drawItem.m_arguments = mesh.m_drawArguments;
+                    drawItem.m_arguments = mesh.m_drawArguments.GetDeviceDrawArguments(RHI::MultiDevice::DefaultDeviceIndex);
                     drawItem.m_pipelineState = modelData.m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
                     auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
                     drawItem.m_indexBufferView = &deviceIndexBufferView;
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(modelData.m_streamBufferList.size());
-                    drawItem.m_streamBufferViews = modelData.m_streamBufferList.data();
+                    AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView> deviceStreamBufferViews;
+                    for(const auto& streamBufferView : modelData.m_streamBufferList)
+                    {
+                        deviceStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                    }
+                    drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                     commandList->Submit(drawItem);
                 }

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -18,7 +18,7 @@
 #include <Atom/RPI.Public/Model/ModelLod.h>
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
@@ -72,7 +72,7 @@ namespace AtomSampleViewer
 
         struct ModelData
         {
-            AZ::RPI::ModelLod::TempStreamBufferViewList m_streamBufferList;
+            AZ::RPI::ModelLod::StreamBufferViewList m_streamBufferList;
             AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
             ModelType m_modelType = ModelType_ShaderBall;

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -13,7 +13,7 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
 #include <AzCore/Component/TickBus.h>

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -148,14 +148,14 @@ namespace AtomSampleViewer
             }
 
             m_rectangleStreamBufferViews[0u] = {
-                *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_rectangleInputAssemblyBuffer,
                 offsetof(RectangleBufferData, m_positions),
                 sizeof(RectangleBufferData::m_positions),
                 sizeof(VertexPosition)
             };
 
             m_rectangleStreamBufferViews[1u] = {
-                *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_rectangleInputAssemblyBuffer,
                 offsetof(RectangleBufferData, m_uvs),
                 sizeof(RectangleBufferData::m_uvs),
                 sizeof(VertexUV)
@@ -227,7 +227,9 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_rectangleStreamBufferViews.size());
-                drawItem.m_streamBufferViews = m_rectangleStreamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_rectangleStreamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_rectangleStreamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
@@ -41,7 +41,7 @@ namespace AtomSampleViewer
 
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_rectangleInputAssemblyBuffer;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
         AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
 

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -106,14 +106,14 @@ namespace AtomSampleViewer
             }
 
             m_streamBufferViews[0] = {
-                *m_positionBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_positionBuffer,
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
             };
 
             m_streamBufferViews[1] = {
-                *m_uvBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_uvBuffer,
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
@@ -245,7 +245,9 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);
             };

--- a/Gem/Code/Source/RHI/TextureExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.h
@@ -13,7 +13,6 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
 #include <AzCore/Component/TickBus.h>
@@ -69,7 +68,7 @@ namespace AtomSampleViewer
         };
 
         AZ::RHI::SingleDeviceDrawItem m_drawItem;
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
 
         AZ::RHI::SamplerState m_samplerState;
         bool m_useStaticSampler = true;

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -518,9 +518,12 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_targetPipelineStates[target]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_bufferViews[RenderTargetIndex::BufferViewIndex].m_indexBufferView;
+            auto deviceIndexBufferView{m_bufferViews[RenderTargetIndex::BufferViewIndex].m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 
@@ -595,9 +598,12 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_screenPipelineStates[target]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_bufferViews[target].m_indexBufferView;
+            auto deviceIndexBufferView{m_bufferViews[target].m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_bufferViews[target].m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_bufferViews[target].m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_bufferViews[target].m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_bufferViews[target].m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 
@@ -780,7 +786,7 @@ namespace AtomSampleViewer
 
         m_bufferViews[target].m_streamBufferViews[0] =
         {
-            *m_positionBuffer[target]->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_positionBuffer[target],
             0,
             posSize,
             sizeof(VertexPosition)
@@ -799,7 +805,7 @@ namespace AtomSampleViewer
 
         m_bufferViews[target].m_streamBufferViews[1] =
         {
-            *m_uvBuffer[target]->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_uvBuffer[target],
             0,
             uvSize,
             uvTypeSize
@@ -818,7 +824,7 @@ namespace AtomSampleViewer
 
         m_bufferViews[target].m_indexBufferView =
         {
-            *m_indexBuffer[target]->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_indexBuffer[target],
             0,
             indexSize,
             AZ::RHI::IndexFormat::Uint16

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -56,8 +56,8 @@ namespace AtomSampleViewer
 
         struct BufferViewData
         {
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-            AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+            AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+            AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
             AZ::RHI::InputStreamLayout m_inputStreamLayout;
         };
         

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -95,7 +95,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
@@ -103,7 +103,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
@@ -217,7 +217,9 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.h
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.h
@@ -13,7 +13,6 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
@@ -61,7 +60,6 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -146,7 +146,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[0] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(IABufferData, m_positions),
                 sizeof(IABufferData::m_positions),
                 sizeof(VertexPosition)
@@ -154,7 +154,7 @@ namespace AtomSampleViewer
 
             m_streamBufferViews[1] =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(IABufferData, m_colors),
                 sizeof(IABufferData::m_colors),
                 sizeof(VertexColor)
@@ -162,7 +162,7 @@ namespace AtomSampleViewer
 
             m_indexBufferView =
             {
-                *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+                *m_inputAssemblyBuffer,
                 offsetof(IABufferData, m_indices),
                 sizeof(IABufferData::m_indices),
                 RHI::IndexFormat::Uint16
@@ -265,11 +265,14 @@ namespace AtomSampleViewer
                 RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                drawItem.m_indexBufferView = &m_indexBufferView;
+                auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -18,7 +18,6 @@
 
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
@@ -77,8 +76,6 @@ namespace AtomSampleViewer
         void UploadDataToConstantBuffer(InstanceInfo* data, uint32_t elementSize, uint32_t elementCount);
         void CreateConstantBufferView();
         
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
-
         float m_time = 0.0f;
 
         // -------------------------------------------------
@@ -94,8 +91,8 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
 
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_constantBufferPool;
 

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
@@ -476,7 +476,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
@@ -484,7 +484,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
@@ -492,7 +492,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16
@@ -566,11 +566,14 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_modelPipelineState[useImageShadingRate ? 0 : 1]->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));;
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
 
@@ -739,11 +742,14 @@ namespace AtomSampleViewer
             RHI::SingleDeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_imagePipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-            drawItem.m_indexBufferView = &m_indexBufferView;
+            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            drawItem.m_streamBufferViews = m_streamBufferViews.data();
+            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
         };

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
@@ -21,7 +21,7 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/SingleDeviceCopyItem.h>
@@ -137,9 +137,9 @@ namespace AtomSampleViewer
         // Buffer for the IA of the full screen quad.
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
         // Bufferviews into the full screen quad IA
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
         // Indexview of the full screen quad index buffer
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
         // Layout of the full screen quad.
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -222,7 +222,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[0] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_positions),
             sizeof(SingleCubeBufferData::m_positions),
             sizeof(VertexPosition)
@@ -230,7 +230,7 @@ namespace AtomSampleViewer
 
         m_streamBufferViews[1] =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_colors),
             sizeof(SingleCubeBufferData::m_colors),
             sizeof(VertexColor)
@@ -238,7 +238,7 @@ namespace AtomSampleViewer
 
         m_indexBufferView =
         {
-            *m_inputAssemblyBuffer->GetDeviceBuffer(RHI::MultiDevice::DefaultDeviceIndex),
+            *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_indices),
             sizeof(SingleCubeBufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16
@@ -378,11 +378,14 @@ namespace AtomSampleViewer
                 AZ::RHI::SingleDeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
-                drawItem.m_indexBufferView = &m_indexBufferView;
+                auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                drawItem.m_streamBufferViews = m_streamBufferViews.data();
+                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex), 
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(RHI::MultiDevice::DefaultDeviceIndex)};
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);
             }

--- a/Gem/Code/Source/RHI/XRExampleComponent.h
+++ b/Gem/Code/Source/RHI/XRExampleComponent.h
@@ -14,7 +14,6 @@
 #include <Atom/RPI.Public/XR/XRSpaceNotificationBus.h>
 
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceDrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
@@ -95,7 +94,7 @@ namespace AtomSampleViewer
         void CreateScope();
 
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::SingleDeviceIndexBufferView m_indexBufferView;
+        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
         AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
         AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
         AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
@@ -107,8 +106,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
         float m_time = 0.0f;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumberOfCubes> m_shaderResourceGroups;
         AZStd::array<AZ::Matrix4x4, NumberOfCubes> m_modelMatrices;

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -20,8 +20,8 @@
 #include <Atom/Component/DebugCamera/NoClipControllerComponent.h>
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 
@@ -303,21 +303,21 @@ namespace AtomSampleViewer
                 auto const& mesh = meshes[i];
 
                 // Build draw packet and set the values of the inline constants.
-                RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+                RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
                 drawPacketBuilder.Begin(nullptr);
                 drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-                drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView.GetDeviceIndexBufferView(RHI::MultiDevice::DefaultDeviceIndex));
+                drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
                 drawPacketBuilder.SetRootConstants(m_rootConstantData.GetConstantData());
-                drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get());
+                drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup());
 
-                RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+                RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
                 drawRequest.m_listTag = m_drawListTag;
-                drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+                drawRequest.m_pipelineState = m_pipelineState.get();
                 drawRequest.m_streamBufferViews = m_modelStreamBufferViews[modelIndex][i];
                 drawRequest.m_sortKey = 0;
                 drawPacketBuilder.AddDrawItem(drawRequest);
 
-                AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket(drawPacketBuilder.End());
+                auto drawPacket{drawPacketBuilder.End()};
                 m_dynamicDraw->AddDrawPacket(m_scene, AZStd::move(drawPacket));
             }
         }

--- a/Gem/Code/Source/RootConstantsExampleComponent.h
+++ b/Gem/Code/Source/RootConstantsExampleComponent.h
@@ -12,7 +12,7 @@
 
 #include <Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h>
 
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 #include <Atom/RHI/DrawList.h>
 #include <Atom/RHI/ConstantsData.h>
@@ -68,7 +68,7 @@ namespace AtomSampleViewer
        
         // Models
         AZStd::vector<AZ::Data::Instance<AZ::RPI::Model>> m_models;
-        AZStd::vector<AZStd::vector<AZ::RPI::ModelLod::TempStreamBufferViewList>> m_modelStreamBufferViews;
+        AZStd::vector<AZStd::vector<AZ::RPI::ModelLod::StreamBufferViewList>> m_modelStreamBufferViews;
 
         // Cache interfaces
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <Atom/RHI/SingleDeviceDrawPacket.h>
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacket.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
@@ -490,22 +490,22 @@ namespace AtomSampleViewer
         for (Image3dToDraw& image3d : m_3dImages)
         {
             // Build draw packet...
-            RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+            RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
             drawPacketBuilder.Begin(nullptr);
             RHI::DrawLinear drawLinear;
             drawLinear.m_vertexCount = 4;
             drawLinear.m_instanceCount = image3d.m_sliceCount;
             drawPacketBuilder.SetDrawArguments(drawLinear);
 
-            RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+            RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
             drawRequest.m_listTag = m_image3dDrawListTag;
-            drawRequest.m_pipelineState = m_image3dPipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_pipelineState = m_image3dPipelineState.get();
             drawRequest.m_sortKey = 0;
-            drawRequest.m_uniqueShaderResourceGroup = image3d.m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+            drawRequest.m_uniqueShaderResourceGroup = image3d.m_srg->GetRHIShaderResourceGroup();
             drawPacketBuilder.AddDrawItem(drawRequest);
 
             // Submit draw packet...
-            AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket(drawPacketBuilder.End());
+            auto drawPacket{drawPacketBuilder.End()};
             m_dynamicDraw->AddDrawPacket(m_scene, AZStd::move(drawPacket));
         }
     }
@@ -513,22 +513,22 @@ namespace AtomSampleViewer
     void StreamingImageExampleComponent::DrawImage(const ImageToDraw* imageInfo)
     {
         // Build draw packet...
-        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
         RHI::DrawLinear drawLinear;
         drawLinear.m_vertexCount = 4;
         drawLinear.m_instanceCount = imageInfo->m_image->GetMipLevelCount();
         drawPacketBuilder.SetDrawArguments(drawLinear);
 
-        RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;
-        drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;
-        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup();
         drawPacketBuilder.AddDrawItem(drawRequest);
 
         // Submit draw packet...
-        AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket(drawPacketBuilder.End());
+        auto drawPacket{drawPacketBuilder.End()};
         m_dynamicDraw->AddDrawPacket(m_scene, AZStd::move(drawPacket));
     }
 

--- a/Gem/Code/Source/StreamingImageExampleComponent.h
+++ b/Gem/Code/Source/StreamingImageExampleComponent.h
@@ -10,7 +10,7 @@
 
 #include <CommonSampleComponentBase.h>
 
-#include <Atom/RHI/SingleDeviceIndexBufferView.h>
+#include <Atom/RHI/MultiDeviceIndexBufferView.h>
 #include <Atom/RHI/MultiDevicePipelineState.h>
 #include <Atom/RHI/DrawList.h>
 

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -20,7 +20,7 @@
 
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 
-#include <Atom/RHI/SingleDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
 
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -271,21 +271,21 @@ namespace AtomSampleViewer
     void TonemappingExampleComponent::DrawImage(const ImageToDraw* imageInfo)
     {
         // Build draw packet
-        RHI::SingleDeviceDrawPacketBuilder drawPacketBuilder;
+        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
         RHI::DrawLinear drawLinear;
         drawLinear.m_vertexCount = 4;
         drawPacketBuilder.SetDrawArguments(drawLinear);
 
-        RHI::SingleDeviceDrawPacketBuilder::SingleDeviceDrawRequest drawRequest;
+        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;
-        drawRequest.m_pipelineState = m_pipelineState->GetDevicePipelineState(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;
-        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(RHI::MultiDevice::DefaultDeviceIndex).get();
+        drawRequest.m_uniqueShaderResourceGroup = imageInfo->m_srg->GetRHIShaderResourceGroup();
         drawPacketBuilder.AddDrawItem(drawRequest);
 
         // Submit draw packet
-        AZStd::unique_ptr<const RHI::SingleDeviceDrawPacket> drawPacket(drawPacketBuilder.End());
+        auto drawPacket{drawPacketBuilder.End()};
         m_dynamicDraw->AddDrawPacket(m_scene, AZStd::move(drawPacket));
     }
 


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as some changes that have been introduced in the meantime.

This specifically introduces resources related to `MultiDeviceDrawItem` as well as `MultiDeviceIndexBufferView`, `MultiDeviceStreamBufferView` and resources related to `MultiDeviceIndirect*`.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [SRG-related resources](https://github.com/o3de/o3de/commit/b1c823cdfbc901fa2e6f3259cd55177f1d34b309).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|[#661](https://github.com/o3de/o3de-atom-sampleviewer/pull/661)|merged|
|`Image`|#662|merged|
|`Query`|#663|merged|
|`PipelineState`|#664|merged|
|`RayTracing`|#667|merged|
|`TransientAttachmentPool`|too small, together with SRG||
|`SwapChain`|nothing to do||
|`SRG`|#668|open|
|`DrawItem`|this PR|open|
|`FrameGraph`|||