### PR TITLE
FrameGraph-related changes

### DIFF
--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -916,7 +916,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success || result == RHI::ResultCode::Unimplemented, "Failed to map object buffer]");
         if (!response.m_data.empty())
         {
-            for(auto& responseData : response.m_data)
+            for(auto& [_, responseData] : response.m_data)
             {
                 memcpy(responseData, data, mapRequest.m_byteCount);
             }

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -1030,7 +1030,7 @@ namespace AtomSampleViewer
         m_instancesBufferPool->MapBuffer(request, response);
         if (!response.m_data.empty())
         {
-            for(auto& responseData : response.m_data)
+            for(auto& [_, responseData] : response.m_data)
             {
                 ::memcpy(responseData, m_instancesData.data(), request.m_byteCount);
             }

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -286,7 +286,7 @@ namespace AtomSampleViewer
             AZ_Error(QueryExample::SampleName, result == RHI::ResultCode::Success, "Failed to import predication buffer with error %d", result);
 
             frameGraph.UseQueryPool(
-                m_occlusionQueryPool->GetDeviceQueryPool(RHI::MultiDevice::DefaultDeviceIndex),
+                m_occlusionQueryPool,
                 RHI::Interval(m_currentOcclusionQueryIndex, m_currentOcclusionQueryIndex),
                 RHI::QueryPoolScopeAttachmentType::Local,
                 RHI::ScopeAttachmentAccess::Read);
@@ -376,7 +376,7 @@ namespace AtomSampleViewer
             // Query pools
             {
                 frameGraph.UseQueryPool(
-                    m_occlusionQueryPool->GetDeviceQueryPool(RHI::MultiDevice::DefaultDeviceIndex),
+                    m_occlusionQueryPool,
                     RHI::Interval(m_currentOcclusionQueryIndex, m_currentOcclusionQueryIndex),
                     m_currentType == QueryType::Predication ? RHI::QueryPoolScopeAttachmentType::Local : RHI::QueryPoolScopeAttachmentType::Global, 
                     RHI::ScopeAttachmentAccess::Write);
@@ -384,7 +384,7 @@ namespace AtomSampleViewer
                 if (m_timestampEnabled)
                 {
                     frameGraph.UseQueryPool(
-                        m_timeStampQueryPool->GetDeviceQueryPool(RHI::MultiDevice::DefaultDeviceIndex),
+                        m_timeStampQueryPool,
                         RHI::Interval(m_currentTimestampQueryIndex, m_currentTimestampQueryIndex + 1),
                         RHI::QueryPoolScopeAttachmentType::Global,
                         RHI::ScopeAttachmentAccess::Write);
@@ -393,7 +393,7 @@ namespace AtomSampleViewer
                 if (m_pipelineStatisticsEnabled)
                 {
                     frameGraph.UseQueryPool(
-                        m_statisticsQueryPool->GetDeviceQueryPool(RHI::MultiDevice::DefaultDeviceIndex),
+                        m_statisticsQueryPool,
                         RHI::Interval(m_currentStatisticsQueryIndex, m_currentStatisticsQueryIndex),
                         RHI::QueryPoolScopeAttachmentType::Global,
                         RHI::ScopeAttachmentAccess::Write);

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -102,7 +102,7 @@ namespace AtomSampleViewer
         AZ::RHI::ResultCode resultCode = m_constantBufferPool->MapBuffer(mapRequest, mapResponse);
         if (resultCode == AZ::RHI::ResultCode::Success)
         {
-            for(const auto& bufferData : mapResponse.m_data)
+            for(const auto& [_, bufferData] : mapResponse.m_data)
             {
                 memcpy(bufferData, data, sizeof(InstanceInfo) * elementCount);
             }


### PR DESCRIPTION
This commit is, similar to the corresponding commit chain on [multi-device-resources|o3de](https://github.com/o3de/o3de/tree/multi-device-resources), one commit in a series of commits that introduces the usage of multi-device resources on the `RHI`-level as well as some changes that have been introduced in the meantime.

This specifically changes the handling of `Buffer.map()` calls and the introduction of the `MultiDeviceQueryPool` in the `FrameGraph`.

The goal of this integration is that each commit here runs in tandem with a commit on the corresponding `o3de` branch, in this case the commit in question is [FrameGraph Changes](<insert_here>).

| Name | Link | Status |
| --- | --- | --- |
|`Buffer`|[#661](https://github.com/o3de/o3de-atom-sampleviewer/pull/661)|merged|
|`Image`|#662|merged|
|`Query`|#663|merged|
|`PipelineState`|#664|merged|
|`RayTracing`|#667|merged|
|`TransientAttachmentPool`|too small, together with SRG||
|`SwapChain`|nothing to do||
|`SRG`|#668|merged|
|`DrawItem`|#669|merged|
|`FrameGraph Part I`|#670|merged|
|`FrameGraph Part II`|this PR|open|