### PR TITLE
Fix compile errors with Clang-17 on Windows

### DIFF
--- a/Gem/Code/Source/MultiSceneExampleComponent.cpp
+++ b/Gem/Code/Source/MultiSceneExampleComponent.cpp
@@ -311,7 +311,7 @@ namespace AtomSampleViewer
 
         // Release the probe
         m_reflectionProbeFeatureProcessor->RemoveReflectionProbe(m_reflectionProbeHandle);
-        m_reflectionProbeHandle = {};
+        m_reflectionProbeHandle = ReflectionProbeHandle::CreateNull();
 
         // Release all meshes
         for (auto& shaderBallMeshHandle : m_shaderBallMeshHandles)

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -87,8 +87,6 @@ namespace AtomSampleViewer
 
     void XRExampleComponent::OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder)
     {
-        AZ::Matrix4x4 projection = AZ::Matrix4x4::CreateIdentity();
-
         AZ::RPI::XRRenderingInterface* xrSystem = AZ::RPI::RPISystemInterface::Get()->GetXRSystem();
         if (xrSystem && xrSystem->ShouldRender())
         {

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -454,7 +454,7 @@ namespace AtomSampleViewer
 
             if (i < 9)
             {
-                printStr += AZStd::string::format("\tctrl+%lu", i + 1);
+                printStr += AZStd::string::format("\tctrl+%zu", i + 1);
             }
 
             printStr += "\n";

--- a/Gem/Code/Source/SponzaBenchmarkComponent.cpp
+++ b/Gem/Code/Source/SponzaBenchmarkComponent.cpp
@@ -379,7 +379,7 @@ namespace AtomSampleViewer
 
         FinalizeLoadBenchmarkData();
 
-        const AZStd::string unresolvedPath = AZStd::string::format("@user@/benchmarks/sponzaLoad_%ld.xml", time(0));
+        const AZStd::string unresolvedPath = "@user@/benchmarks/sponzaLoad_" + AZStd::to_string(time(0)) + ".xml";
         char sponzaLoadBenchmarkDataFilePath[AZ_MAX_PATH_LEN] = { 0 };
         AZ::IO::FileIOBase::GetInstance()->ResolvePath(unresolvedPath.c_str(), sponzaLoadBenchmarkDataFilePath, AZ_MAX_PATH_LEN);
 
@@ -477,7 +477,7 @@ namespace AtomSampleViewer
 
         FinalizeRunBenchmarkData();
 
-        const AZStd::string unresolvedPath = AZStd::string::format("@user@/benchmarks/sponzaRun_%ld.xml", time(0));
+        const AZStd::string unresolvedPath = "@user@/benchmarks/sponzaRun_" + AZStd::to_string(time(0)) + ".xml";
 
         char sponzaRunBenchmarkDataFilePath[AZ_MAX_PATH_LEN] = { 0 };
         AZ::IO::FileIOBase::GetInstance()->ResolvePath(unresolvedPath.c_str(), sponzaRunBenchmarkDataFilePath, AZ_MAX_PATH_LEN);


### PR DESCRIPTION
Fix some compile errors with Clang-17 on Windows.
The change for printing `time(0)` is necessary because the size of the `time_t` type is not fixed and there is also no format string placeholder for it.
The error message for the change in `MultiSceneExampleComponent` is `.../MultiSceneExampleComponent.cpp:314:33: error: use of overloaded operator '=' is ambiguous (with operand types 'ReflectionProbeHandle' (aka 'AZ::Uuid') and 'void')`