### PR TITLE
Multi-GPU RHI & RPI samples

### DIFF
--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -19,7 +19,7 @@
 
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 
-#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
 
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -306,7 +306,7 @@ namespace AtomSampleViewer
             const char* srgName,
             Data::Asset<AZ::RPI::ShaderAsset>& shaderAsset,
             RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout>& srgLayout,
-            RHI::ConstPtr<RHI::MultiDevicePipelineState>& pipelineState,
+            RHI::ConstPtr<RHI::PipelineState>& pipelineState,
             RHI::DrawListTag& drawListTag,
             RPI::Scene* scene)
         {
@@ -372,13 +372,13 @@ namespace AtomSampleViewer
     void BloomExampleComponent::DrawImage(const ImageToDraw* imageInfo)
     {
         // Build draw packet
-        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
+        RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
         RHI::DrawLinear drawLinear;
         drawLinear.m_vertexCount = 4;
         drawPacketBuilder.SetDrawArguments(drawLinear);
 
-        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
+        RHI::DrawPacketBuilder::DrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;

--- a/Gem/Code/Source/BloomExampleComponent.h
+++ b/Gem/Code/Source/BloomExampleComponent.h
@@ -94,7 +94,7 @@ namespace AtomSampleViewer
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;
 
         // render related data
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::RHI::DrawListTag m_drawListTag;
         AZ::Data::Asset<AZ::RPI::ShaderAsset> m_shaderAsset;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout> m_srgLayout;

--- a/Gem/Code/Source/DynamicDrawExampleComponent.h
+++ b/Gem/Code/Source/DynamicDrawExampleComponent.h
@@ -16,9 +16,9 @@
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawContext.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/MultiDeviceStreamBufferView.h>
-#include <Atom/RHI/MultiDeviceIndexBufferView.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/StreamBufferView.h>
+#include <Atom/RHI/IndexBufferView.h>
+#include <Atom/RHI/PipelineState.h>
 #include <Atom/RHI/DrawList.h>
 
 #include <Utils/ImGuiSidebar.h>

--- a/Gem/Code/Source/MultiGPURPIExampleComponent.cpp
+++ b/Gem/Code/Source/MultiGPURPIExampleComponent.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AtomSampleViewerOptions.h>
+#include <MultiGPURPIExampleComponent.h>
+
+#include <Atom/Component/DebugCamera/CameraComponent.h>
+#include <Atom/Component/DebugCamera/NoClipControllerComponent.h>
+
+#include <Atom/RHI/RHISystemInterface.h>
+
+#include <Atom/RPI.Public/ViewProviderBus.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/RPISystemInterface.h>
+#include <Atom/RPI.Reflect/Asset/AssetUtils.h>
+#include <Atom/RPI.Reflect/Model/ModelAsset.h>
+
+#include <Atom/Feature/ImGui/ImGuiUtils.h>
+
+#include <AzCore/Math/MatrixUtils.h>
+
+#include <Automation/ScriptableImGui.h>
+#include <Automation/ScriptRunnerBus.h>
+
+#include <AzCore/Component/Entity.h>
+
+#include <AzFramework/Components/TransformComponent.h>
+#include <AzFramework/Scene/SceneSystemInterface.h>
+#include <AzFramework/Entity/GameEntityContextComponent.h>
+
+#include <EntityUtilityFunctions.h>
+#include <SampleComponentConfig.h>
+#include <SampleComponentManager.h>
+
+#include <Utils/Utils.h>
+
+#include <RHI/BasicRHIComponent.h>
+
+namespace AtomSampleViewer
+{
+    using namespace AZ;
+
+    void MultiGPURPIExampleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MultiGPURPIExampleComponent, AZ::Component>()
+                ->Version(0)
+                ;
+        }
+    }
+
+    MultiGPURPIExampleComponent::MultiGPURPIExampleComponent()
+    {
+    }
+
+    void MultiGPURPIExampleComponent::Activate()
+    {
+        AZ::TickBus::Handler::BusConnect();
+
+        AZ::Render::Bootstrap::DefaultWindowNotificationBus::Handler::BusConnect();
+
+        // preload assets
+        AZStd::vector<AssetCollectionAsyncLoader::AssetToLoadInfo> assetList = {
+            {CubeModelFilePath, azrtti_typeid<RPI::ModelAsset>()}
+        };
+
+        PreloadAssets(assetList);
+
+        // save original render pipeline first and remove it from the scene
+        m_originalPipeline = m_scene->GetDefaultRenderPipeline();
+        m_scene->RemoveRenderPipeline(m_originalPipeline->GetId());
+
+        // add the checker board pipeline
+        const AZStd::string pipelineName("MultiGPUPipeline");
+        AZ::RPI::RenderPipelineDescriptor pipelineDesc;
+        pipelineDesc.m_name = pipelineName;
+        pipelineDesc.m_rootPassTemplate = "MultiGPUPipeline";
+        m_pipeline = AZ::RPI::RenderPipeline::CreateRenderPipelineForWindow(pipelineDesc, *m_windowContext);
+        m_scene->AddRenderPipeline(m_pipeline);
+
+        m_imguiScope = AZ::Render::ImGuiActiveContextScope::FromPass({ "MultiGPUPipeline", "ImGuiPass" });
+    }
+
+    void MultiGPURPIExampleComponent::Deactivate()
+    {
+        // remove cb pipeline before adding original pipeline.
+        if (!m_pipeline)
+        {
+            return;
+        }
+
+        m_imguiScope = {}; // restores previous ImGui context.
+
+        m_scene->RemoveRenderPipeline(m_pipeline->GetId());
+        m_scene->AddRenderPipeline(m_originalPipeline);
+
+        m_pipeline = nullptr;
+
+        AZ::Render::Bootstrap::DefaultWindowNotificationBus::Handler::BusDisconnect();
+
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+
+    void MultiGPURPIExampleComponent::OnTick([[maybe_unused]] float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint timePoint)
+    {
+    }
+
+    void MultiGPURPIExampleComponent::OnAllAssetsReadyActivate()
+    {
+        auto meshFeatureProcessor = GetMeshFeatureProcessor();
+
+        /*
+        auto asset = RPI::AssetUtils::LoadAssetByProductPath<RPI::ModelAsset>(BunnyModelFilePath,
+                                                                              RPI::AssetUtils::TraceLevel::Assert); //*/
+        auto asset = RPI::AssetUtils::LoadAssetByProductPath<RPI::ModelAsset>(CubeModelFilePath,
+                                                                              RPI::AssetUtils::TraceLevel::Assert);
+        m_meshHandle = meshFeatureProcessor->AcquireMesh(Render::MeshHandleDescriptor(asset));
+
+        //const Vector3 nonUniformScale{ 12.f, 12.f, 0.1f };
+        const Vector3 translation{ 0.f, 0.f, -1.0f };
+        Transform transform = Transform::CreateTranslation(translation);
+        meshFeatureProcessor->SetTransform(m_meshHandle, transform);//, nonUniformScale);
+    }
+
+    void MultiGPURPIExampleComponent::DefaultWindowCreated()
+    {
+        AZ::Render::Bootstrap::DefaultWindowBus::BroadcastResult(m_windowContext,
+                                                                 &AZ::Render::Bootstrap::DefaultWindowBus::Events::GetDefaultWindowContext);
+    }
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/MultiGPURPIExampleComponent.h
+++ b/Gem/Code/Source/MultiGPURPIExampleComponent.h
@@ -68,10 +68,15 @@ namespace AtomSampleViewer
         AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
 
         AZ::RPI::RenderPipelinePtr m_pipeline;
+        AZ::RPI::RenderPipelinePtr m_copyPipeline;
         AZ::RPI::RenderPipelinePtr m_originalPipeline;
         AZStd::shared_ptr<AZ::RPI::WindowContext> m_windowContext;
 
         AZ::Render::ImGuiActiveContextScope m_imguiScope;
+        ImGuiSidebar m_imguiSidebar;
+
+        bool m_useCopyPipeline = false;
+        bool m_currentlyUsingCopyPipline = false;
     };
 
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/MultiGPURPIExampleComponent.h
+++ b/Gem/Code/Source/MultiGPURPIExampleComponent.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <CommonSampleComponentBase.h>
+
+#include <Atom/Bootstrap/DefaultWindowBus.h>
+#include <Atom/Feature/ImGui/ImGuiUtils.h>
+
+#include <Atom/RPI.Public/Base.h>
+#include <Atom/RPI.Public/WindowContext.h>
+
+#include <AzCore/Asset/AssetCommon.h>
+#include <AzCore/Component/TickBus.h>
+
+#include <AzFramework/Windowing/WindowBus.h>
+#include <AzFramework/Windowing/NativeWindow.h>
+
+#include <Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h>
+#include <Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h>
+#include <Atom/Feature/CoreLights/ShadowConstants.h>
+#include <Atom/Feature/SkyBox/SkyBoxFeatureProcessorInterface.h>
+#include <Atom/Feature/PostProcess/PostProcessFeatureProcessorInterface.h>
+
+#include <Utils/ImGuiSidebar.h>
+#include <Utils/Utils.h>
+
+struct ImGuiContext;
+
+namespace AtomSampleViewer
+{
+    //! A sample component which render the same scene with different render pipelines in different windows
+    //! It has a imgui menu to switch on/off the second render pipeline as well as turn on/off different graphics features
+    //! There is also an option to have the second render pipeline to use the second camera. 
+    class MultiGPURPIExampleComponent final
+        : public CommonSampleComponentBase
+        , public AZ::TickBus::Handler
+        , public AZ::Render::Bootstrap::DefaultWindowNotificationBus::Handler
+    {
+    public:
+        AZ_COMPONENT(MultiGPURPIExampleComponent, "{F7DD0D21-A0EF-4B66-98FA-2DB6B19A8C35}", CommonSampleComponentBase);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        MultiGPURPIExampleComponent();
+        ~MultiGPURPIExampleComponent() final = default;
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+        
+    private:
+        // AZ::TickBus::Handler overrides ...
+        void OnTick(float deltaTime, AZ::ScriptTimePoint timePoint) override;
+
+        // CommonSampleComponentBase overrides...
+        void OnAllAssetsReadyActivate() override;
+
+        // DefaultWindowNotificationBus::Handler overrides...
+        void DefaultWindowCreated() override;
+
+        AZ::Render::MeshFeatureProcessorInterface::MeshHandle m_meshHandle;
+
+        AZ::RPI::RenderPipelinePtr m_pipeline;
+        AZ::RPI::RenderPipelinePtr m_originalPipeline;
+        AZStd::shared_ptr<AZ::RPI::WindowContext> m_windowContext;
+
+        AZ::Render::ImGuiActiveContextScope m_imguiScope;
+    };
+
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -102,7 +102,7 @@ namespace AZ
 
             // create the ray tracing pipeline state object
             m_rayTracingPipelineState = aznew RHI::MultiDeviceRayTracingPipelineState;
-            m_rayTracingPipelineState->Init(RHI::MultiDevice::DefaultDevice, descriptor);
+            m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
         }
 
         void RayTracingAmbientOcclusionPass::FrameBeginInternal(FramePrepareParams params)
@@ -122,7 +122,7 @@ namespace AZ
 
                 // Build shader table once. Since we are not using local srg so we don't need to rebuild it even when scene changed 
                 m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;
-                m_rayTracingShaderTable->Init(RHI::MultiDevice::DefaultDevice, rayTracingBufferPools);
+                m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, rayTracingBufferPools);
 
                 AZStd::shared_ptr<RHI::MultiDeviceRayTracingShaderTableDescriptor> descriptor = AZStd::make_shared<RHI::MultiDeviceRayTracingShaderTableDescriptor>();
                 descriptor->Build(AZ::Name("RayTracingAOShaderTable"), m_rayTracingPipelineState)

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
@@ -10,9 +10,9 @@
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
-#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
-#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
+#include <Atom/RHI/RayTracingBufferPools.h>
+#include <Atom/RHI/RayTracingPipelineState.h>
+#include <Atom/RHI/RayTracingShaderTable.h>
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -63,13 +63,13 @@ namespace AZ
             Data::Instance<RPI::Shader> m_rayGenerationShader;
             Data::Instance<RPI::Shader> m_missShader;
             Data::Instance<RPI::Shader> m_hitShader;
-            RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+            RHI::Ptr<RHI::RayTracingPipelineState> m_rayTracingPipelineState;
 
             // ray tracing shader table
-            RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+            RHI::Ptr<RHI::RayTracingShaderTable> m_rayTracingShaderTable;
 
             // ray tracing global pipeline state
-            RHI::ConstPtr<RHI::MultiDevicePipelineState> m_globalPipelineState;
+            RHI::ConstPtr<RHI::PipelineState> m_globalPipelineState;
 
             Render::RayTracingFeatureProcessor* m_rayTracingFeatureProcessor = nullptr;
 

--- a/Gem/Code/Source/ProceduralSkinnedMeshUtils.cpp
+++ b/Gem/Code/Source/ProceduralSkinnedMeshUtils.cpp
@@ -12,6 +12,7 @@
 #include <Atom/RPI.Reflect/Buffer/BufferAssetCreator.h>
 #include <Atom/RPI.Reflect/ResourcePoolAssetCreator.h>
 #include <Atom/RPI.Reflect/Model/ModelAssetCreator.h>
+#include <Atom/RPI.Reflect/Model/ModelAssetHelpers.h>
 #include <Atom/RPI.Reflect/Model/ModelLodAssetCreator.h>
 #include <Atom/RPI.Reflect/Model/SkinJointIdPadding.h>
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h>

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.cpp
@@ -55,7 +55,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         m_depthImageAttachmentId = RHI::AttachmentId("A2C_Depth");
         m_multisamleDepthImageAttachmentId = RHI::AttachmentId("A2C_MSAA_Depth");

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
@@ -18,11 +18,11 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/ScopeId.h>
 
-#include <Atom/RHI/MultiDeviceBuffer.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/StreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -91,9 +91,9 @@ namespace AtomSampleViewer
             AZStd::array<VertexUV, 4> m_uvs;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_rectangleInputAssemblyBuffer;
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_rectangleInputAssemblyBuffer;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
 
         // Shader Resource
@@ -105,7 +105,7 @@ namespace AtomSampleViewer
         AZStd::array<AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numRectangles>, s_numBlendTypes> m_shaderResourceGroups;
 
         // Pipeline State and Shader
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, s_numBlendTypes> m_pipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, s_numBlendTypes> m_pipelineStates;
         AZ::Data::Instance<AZ::RPI::Shader> m_shader;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.cpp
@@ -147,7 +147,7 @@ namespace AtomSampleViewer
         m_imagePool = aznew RHI::MultiDeviceImagePool();
         RHI::ImagePoolDescriptor imagePoolDesc;
         imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite;
-        m_imagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
+        m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
 
         for (auto& image : m_sceneImages)
         {
@@ -171,7 +171,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_quadBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_quadBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         struct BufferData
         {

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
@@ -120,30 +120,30 @@ namespace AtomSampleViewer
         };
        
         // Quad related variables
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_quadBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
-        AZ::RHI::MultiDeviceIndexBufferView m_quadIndexBufferView;
-        AZStd::array<AZStd::vector<AZ::RHI::MultiDeviceStreamBufferView>, NumScopes> m_quadStreamBufferViews;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_quadBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_quadInputAssemblyBuffer;
+        AZ::RHI::IndexBufferView m_quadIndexBufferView;
+        AZStd::array<AZStd::vector<AZ::RHI::StreamBufferView>, NumScopes> m_quadStreamBufferViews;
 
         // Terrain related variables
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, NumScopes> m_terrainPipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, NumScopes> m_terrainPipelineStates;
 
         // Model related variables
         AZStd::array<AZ::RPI::ModelLod::StreamBufferViewList, NumScopes> m_modelStreamBufferViews;
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, NumScopes> m_modelPipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, NumScopes> m_modelPipelineStates;
         AZ::Data::Instance<AZ::RPI::Model> m_model;
 
         // Copy Texture related variables
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_copyTexturePipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_copyTexturePipelineState;
 
         // Luminance map related variables
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_luminancePipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_luminancePipelineState;
         
         // Luminance reduce related variables
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_luminanceReducePipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_luminanceReducePipelineState;
 
         // Tonemapping related variables
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_tonemappingPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_tonemappingPipelineState;
 
         // Camera projection matrix
         AZ::Matrix4x4 m_projectionMatrix;
@@ -165,8 +165,8 @@ namespace AtomSampleViewer
         // Scene images
         static constexpr uint32_t NumSceneImages = 2;
         AZStd::array<AZ::RHI::AttachmentId, NumSceneImages> m_sceneIds = { { AZ::RHI::AttachmentId("SceneId1"), AZ::RHI::AttachmentId("SceneId2") } };
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool;
-        AZStd::array<AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage>, NumSceneImages> m_sceneImages;
+        AZ::RHI::Ptr<AZ::RHI::ImagePool> m_imagePool;
+        AZStd::array<AZ::RHI::Ptr<AZ::RHI::Image>, NumSceneImages> m_sceneImages;
         uint32_t m_currentSceneImageIndex = 0;
         uint32_t m_previousSceneImageIndex = 1;
 

--- a/Gem/Code/Source/RHI/BasicRHIComponent.cpp
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.cpp
@@ -511,7 +511,11 @@ namespace AtomSampleViewer
         return image;
     }
 
-    void BasicRHIComponent::CreateImage3dData(AZStd::vector<uint8_t>& data, AZ::RHI::SingleDeviceImageSubresourceLayout& layout, AZ::RHI::Format& format, AZStd::vector<const char*>&& imageAssetPaths)
+    void BasicRHIComponent::CreateImage3dData(
+        AZStd::vector<uint8_t>& data,
+        AZ::RHI::DeviceImageSubresourceLayout& layout,
+        AZ::RHI::Format& format,
+        AZStd::vector<const char*>&& imageAssetPaths)
     {
         using namespace AZ;
 
@@ -532,7 +536,7 @@ namespace AtomSampleViewer
         AZStd::vector<RHI::ImageDescriptor> imageDescriptors;
         imageDescriptors.reserve(imageAssetPaths.size());
 
-        AZStd::vector<RHI::SingleDeviceImageSubresourceLayout> imageSubresourceLayouts;
+        AZStd::vector<RHI::DeviceImageSubresourceLayout> imageSubresourceLayouts;
         imageSubresourceLayouts.reserve(imageAssetPaths.size());
 
         AZStd::vector<Data::Asset<RPI::ImageMipChainAsset>> imageMipAssets;

--- a/Gem/Code/Source/RHI/BasicRHIComponent.h
+++ b/Gem/Code/Source/RHI/BasicRHIComponent.h
@@ -100,7 +100,11 @@ namespace AtomSampleViewer
         ~BasicRHIComponent() override = default;
 
         // Creates a 3D image from 2D images. All 2D images are required to have the same format and layout
-        static void CreateImage3dData(AZStd::vector<uint8_t>& data, AZ::RHI::SingleDeviceImageSubresourceLayout& layout, AZ::RHI::Format& format, AZStd::vector<const char*>&& imageAssetPaths);
+        static void CreateImage3dData(
+            AZStd::vector<uint8_t>& data,
+            AZ::RHI::DeviceImageSubresourceLayout& layout,
+            AZ::RHI::Format& format,
+            AZStd::vector<const char*>&& imageAssetPaths);
 
         void SetOutputInfo(uint32_t width, uint32_t height, AZ::RHI::Format format, AZ::RHI::AttachmentId attachmentId);
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -226,7 +226,7 @@ namespace AtomSampleViewer
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
             bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
             bufferPoolDesc.m_budgetInBytes = m_poolSizeInBytes;
-            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            [[maybe_unused]] RHI::ResultCode resultCode = m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "Failed to create Material Buffer Pool");
         }
 
@@ -237,7 +237,7 @@ namespace AtomSampleViewer
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
             bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
-            [[maybe_unused]] RHI::ResultCode result = m_computeBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            [[maybe_unused]] RHI::ResultCode result = m_computeBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialized compute buffer pool");
         }
 
@@ -246,7 +246,7 @@ namespace AtomSampleViewer
             RHI::ImagePoolDescriptor imagePoolDesc;
             imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
             m_rwImagePool = aznew RHI::MultiDeviceImagePool();
-            [[maybe_unused]] RHI::ResultCode result = m_rwImagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
+            [[maybe_unused]] RHI::ResultCode result = m_rwImagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image pool");
         }
     }

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -219,7 +219,7 @@ namespace AtomSampleViewer
     {
         //Create Buffer pool for read only buffers
         {
-            m_bufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_bufferPool = aznew RHI::BufferPool();
             m_bufferPool->SetName(Name("BindlessBufferPool"));
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderRead;
@@ -232,7 +232,7 @@ namespace AtomSampleViewer
 
         // Create Buffer pool for read write buffers
         {
-            m_computeBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_computeBufferPool = aznew RHI::BufferPool();
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderReadWrite;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
@@ -245,7 +245,7 @@ namespace AtomSampleViewer
         {
             RHI::ImagePoolDescriptor imagePoolDesc;
             imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
-            m_rwImagePool = aznew RHI::MultiDeviceImagePool();
+            m_rwImagePool = aznew RHI::ImagePool();
             [[maybe_unused]] RHI::ResultCode result = m_rwImagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image pool");
         }
@@ -253,9 +253,9 @@ namespace AtomSampleViewer
 
     void BindlessPrototypeExampleComponent::FloatBuffer::CreateBufferFromPool(const uint32_t byteCount)
     {
-        m_buffer = aznew RHI::MultiDeviceBuffer();
+        m_buffer = aznew RHI::Buffer();
         m_buffer->SetName(Name("FloatBuffer"));
-        RHI::MultiDeviceBufferInitRequest bufferRequest;
+        RHI::BufferInitRequest bufferRequest;
         bufferRequest.m_descriptor.m_bindFlags = RHI::BufferBindFlags::ShaderRead;
         bufferRequest.m_descriptor.m_byteCount = byteCount;
         bufferRequest.m_buffer = m_buffer.get();
@@ -266,13 +266,13 @@ namespace AtomSampleViewer
 
     void BindlessPrototypeExampleComponent::CreateIndirectBuffer(
         const Name& bufferName,
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>& indirectionBuffer,
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView>& bufferView, 
+        AZ::RHI::Ptr<AZ::RHI::Buffer>& indirectionBuffer,
+        AZ::RHI::Ptr<AZ::RHI::BufferView>& bufferView, 
         size_t byteSize)
     {
-        indirectionBuffer = aznew RHI::MultiDeviceBuffer();
+        indirectionBuffer = aznew RHI::Buffer();
         indirectionBuffer->SetName(bufferName);
-        RHI::MultiDeviceBufferInitRequest bufferRequest;
+        RHI::BufferInitRequest bufferRequest;
         bufferRequest.m_descriptor.m_bindFlags = RHI::BufferBindFlags::ShaderRead;
         bufferRequest.m_descriptor.m_byteCount = byteSize;
         bufferRequest.m_buffer = indirectionBuffer.get();
@@ -287,8 +287,8 @@ namespace AtomSampleViewer
     void BindlessPrototypeExampleComponent::CreateColorBuffer(
         const Name& bufferName,
         const AZ::Vector4& colorVal, 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>& buffer, 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView>& bufferView)
+        AZ::RHI::Ptr<AZ::RHI::Buffer>& buffer, 
+        AZ::RHI::Ptr<AZ::RHI::BufferView>& bufferView)
     {
         AZStd::array<float, 4> randColors;
         randColors[0] = colorVal.GetX();
@@ -296,9 +296,9 @@ namespace AtomSampleViewer
         randColors[2] = colorVal.GetZ();
         randColors[3] = colorVal.GetW();
 
-        buffer = aznew RHI::MultiDeviceBuffer();
+        buffer = aznew RHI::Buffer();
         buffer->SetName(bufferName);
-        RHI::MultiDeviceBufferInitRequest bufferRequest;
+        RHI::BufferInitRequest bufferRequest;
         bufferRequest.m_descriptor.m_bindFlags = RHI::BufferBindFlags::ShaderRead;
         bufferRequest.m_descriptor.m_byteCount = sizeof(float) * 4;
         bufferRequest.m_buffer = buffer.get();
@@ -507,7 +507,7 @@ namespace AtomSampleViewer
             m_floatBuffer = std::make_unique<FloatBuffer>(FloatBuffer(m_bufferPool, byteCount));
 
             RHI::BufferViewDescriptor bufferViewDesc = RHI::BufferViewDescriptor::CreateStructured(0u, m_bufferFloatCount, sizeof(float));
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> bufferView = m_floatBuffer->m_buffer->BuildBufferView(bufferViewDesc);
+            AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = m_floatBuffer->m_buffer->BuildBufferView(bufferViewDesc);
             bufferView->SetName(Name(m_floatBufferSrgName));
             m_bindlessSrg->SetBufferView(m_floatBufferSrgName, floatBufferId, bufferView.get());
 
@@ -580,11 +580,11 @@ namespace AtomSampleViewer
 
         // Set the color multiplier buffer
         {
-            m_computeBuffer = aznew RHI::MultiDeviceBuffer();
+            m_computeBuffer = aznew RHI::Buffer();
             m_computeBuffer->SetName(Name("m_colorBufferMultiplier"));
             uint32_t bufferSize = sizeof(uint32_t);//RHI ::GetFormatSize(RHI::Format::R32G32B32A32_FLOAT);
 
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_computeBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::ShaderReadWrite, bufferSize };
             [[maybe_unused]] RHI::ResultCode result = m_computeBufferPool->InitBuffer(request);
@@ -596,9 +596,9 @@ namespace AtomSampleViewer
 
         // Set the image version of color multiplier buffer
         {
-            m_computeImage = aznew RHI::MultiDeviceImage();
+            m_computeImage = aznew RHI::Image();
 
-            RHI::MultiDeviceImageInitRequest request;
+            RHI::ImageInitRequest request;
             request.m_image = m_computeImage.get();
             request.m_descriptor =
                 RHI::ImageDescriptor::Create2D(RHI::ImageBindFlags::ShaderReadWrite, 1, 1, RHI::Format::R32G32B32A32_FLOAT);
@@ -741,12 +741,12 @@ namespace AtomSampleViewer
         // Indirect buffer that will contain indices for all read only textures and read write textures within the bindless heap
         {
             //Read only textures = InternalBP::Images , InternalBP::CubeMapImages, m_computeImageView
-            RHI::MultiDeviceBufferMapRequest mapRequest{ *m_imageIndirectionBuffer, 0,
+            RHI::BufferMapRequest mapRequest{ *m_imageIndirectionBuffer, 0,
                                               sizeof(uint32_t) * (InternalBP::ImageCount + InternalBP::CubeMapImageCount + 1) };
-            RHI::MultiDeviceBufferMapResponse mapResponse;
+            RHI::BufferMapResponse mapResponse;
             m_bufferPool->MapBuffer(mapRequest, mapResponse);
 
-            AZStd::vector<const RHI::MultiDeviceImageView*> views;
+            AZStd::vector<const RHI::ImageView*> views;
             AZStd::vector<bool> isViewReadOnly;
 
             //Add read only 2d texture views
@@ -779,11 +779,11 @@ namespace AtomSampleViewer
 
         // Indirect buffer that will contain indices for all read only buffers and read write buffers within the bindless heap
         {
-            RHI::MultiDeviceBufferMapRequest mapRequest{ *m_bufferIndirectionBuffer, 0, sizeof(uint32_t) * 3 };
-            RHI::MultiDeviceBufferMapResponse mapResponse;
+            RHI::BufferMapRequest mapRequest{ *m_bufferIndirectionBuffer, 0, sizeof(uint32_t) * 3 };
+            RHI::BufferMapResponse mapResponse;
             m_bufferPool->MapBuffer(mapRequest, mapResponse);
 
-            AZStd::vector<const RHI::MultiDeviceBufferView*> views;
+            AZStd::vector<const RHI::BufferView*> views;
             AZStd::vector<bool> isViewReadOnly;
            
             // Add read only buffer views
@@ -841,7 +841,7 @@ namespace AtomSampleViewer
         srg->Compile();
     }
 
-    bool BindlessPrototypeExampleComponent::BindlessSrg::SetBufferView(const AZStd::string srgName, const AZStd::string srgId, const AZ::RHI::MultiDeviceBufferView* bufferView)
+    bool BindlessPrototypeExampleComponent::BindlessSrg::SetBufferView(const AZStd::string srgName, const AZStd::string srgId, const AZ::RHI::BufferView* bufferView)
     {
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> srg = GetSrg(srgName);
         const AZ::RHI::ShaderInputBufferIndex inputIndex = srg->FindShaderInputBufferIndex(AZ::Name(srgId));
@@ -851,7 +851,7 @@ namespace AtomSampleViewer
         return false;
     }
 
-    BindlessPrototypeExampleComponent::FloatBuffer::FloatBuffer(RHI::Ptr<RHI::MultiDeviceBufferPool> bufferPool, const uint32_t sizeInBytes)
+    BindlessPrototypeExampleComponent::FloatBuffer::FloatBuffer(RHI::Ptr<RHI::BufferPool> bufferPool, const uint32_t sizeInBytes)
     {
         m_bufferPool = bufferPool;
 
@@ -889,7 +889,7 @@ namespace AtomSampleViewer
         const uint32_t alignedDataSize = RHI::AlignUp(sizeInBytes, FloatSizeInBytes);
         AZ_Assert(m_allocatedInBytes + alignedDataSize < m_totalSizeInBytes, "Allocating too much data in the FLoatBuffer");
 
-        const RHI::MultiDeviceBufferMapRequest mapRequest(*m_buffer, m_allocatedInBytes, sizeInBytes);
+        const RHI::BufferMapRequest mapRequest(*m_buffer, m_allocatedInBytes, sizeInBytes);
         MapData(mapRequest, data);
 
         // Create the handle
@@ -904,13 +904,13 @@ namespace AtomSampleViewer
 
     bool BindlessPrototypeExampleComponent::FloatBuffer::UpdateBuffer(const FloatBufferHandle& handle, const void* data, const uint32_t sizeInBytes)
     {
-        const RHI::MultiDeviceBufferMapRequest mapRequest(*m_buffer, handle.GetIndex() * FloatSizeInBytes, sizeInBytes);
+        const RHI::BufferMapRequest mapRequest(*m_buffer, handle.GetIndex() * FloatSizeInBytes, sizeInBytes);
         return MapData(mapRequest, data);
     }
 
-    bool BindlessPrototypeExampleComponent::FloatBuffer::MapData(const RHI::MultiDeviceBufferMapRequest& mapRequest, const void* data)
+    bool BindlessPrototypeExampleComponent::FloatBuffer::MapData(const RHI::BufferMapRequest& mapRequest, const void* data)
     {
-        RHI::MultiDeviceBufferMapResponse response;
+        RHI::BufferMapResponse response;
         [[maybe_unused]] RHI::ResultCode result = m_bufferPool->MapBuffer(mapRequest, response);
         // ResultCode::Unimplemented is used by Null Renderer and hence is a valid use case
         AZ_Assert(result == RHI::ResultCode::Success || result == RHI::ResultCode::Unimplemented, "Failed to map object buffer]");
@@ -1048,10 +1048,10 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            AZStd::array<const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups;
+            AZStd::array<const RHI::DeviceShaderResourceGroup*, 8> shaderResourceGroups;
             shaderResourceGroups[0] = m_bufferDispatchSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get();
 
-            RHI::SingleDeviceDispatchItem dispatchItem;
+            RHI::DeviceDispatchItem dispatchItem;
             RHI::DispatchDirect dispatchArgs;
 
             dispatchArgs.m_threadsPerGroupX = aznumeric_cast<uint16_t>(m_bufferNumThreadsX);
@@ -1121,10 +1121,10 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            AZStd::array<const RHI::SingleDeviceShaderResourceGroup*, 8> shaderResourceGroups;
+            AZStd::array<const RHI::DeviceShaderResourceGroup*, 8> shaderResourceGroups;
             shaderResourceGroups[0] = m_imageDispatchSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get();
 
-            RHI::SingleDeviceDispatchItem dispatchItem;
+            RHI::DeviceDispatchItem dispatchItem;
             RHI::DispatchDirect dispatchArgs;
 
             dispatchArgs.m_threadsPerGroupX = aznumeric_cast<uint16_t>(m_imageNumThreadsX);
@@ -1256,17 +1256,28 @@ namespace AtomSampleViewer
                 {
                     const SubMeshInstance& subMesh = m_subMeshInstanceArray[instanceIdx];
 
-                    const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
-                    {
-                        m_bindlessSrg->GetSrg(m_samplerSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                    const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                        m_bindlessSrg->GetSrg(m_samplerSrgName)
+                            ->GetRHIShaderResourceGroup()
+                            ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                            .get(),
                         subMesh.m_perSubMeshSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
-                        m_bindlessSrg->GetSrg(m_floatBufferSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                        m_bindlessSrg->GetSrg(m_floatBufferSrgName)
+                            ->GetRHIShaderResourceGroup()
+                            ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                            .get(),
 #if ATOMSAMPLEVIEWER_TRAIT_BINDLESS_PROTOTYPE_SUPPORTS_DIRECT_BOUND_UNBOUNDED_ARRAY
-                        m_bindlessSrg->GetSrg(m_imageSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                        m_bindlessSrg->GetSrg(m_imageSrgName)
+                            ->GetRHIShaderResourceGroup()
+                            ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                            .get(),
 #endif
-                        m_bindlessSrg->GetSrg(m_indirectionBufferSrgName)->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                        m_bindlessSrg->GetSrg(m_indirectionBufferSrgName)
+                            ->GetRHIShaderResourceGroup()
+                            ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                            .get(),
                     };
-                    RHI::SingleDeviceDrawItem drawItem;
+                    RHI::DeviceDrawItem drawItem;
                     drawItem.m_arguments = subMesh.m_mesh->m_drawArguments.GetDeviceDrawArguments(context.GetDeviceIndex());
                     drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                     auto deviceIndexBufferView{subMesh.m_mesh->m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -1274,7 +1285,7 @@ namespace AtomSampleViewer
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(subMesh.bufferStreamViewArray.size());
-                    AZStd::vector<RHI::SingleDeviceStreamBufferView> deviceQuadStreamBufferViews;
+                    AZStd::vector<RHI::DeviceStreamBufferView> deviceQuadStreamBufferViews;
                     for(const auto& streamBufferView : subMesh.bufferStreamViewArray)
                     {
                         deviceQuadStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(context.GetDeviceIndex()));

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <Atom/RHI.Reflect/Handle.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 
 #include <Atom/RPI.Public/Model/ModelLod.h>
 #include <Atom/RPI.Public/Model/Model.h>
@@ -59,7 +59,7 @@ namespace AtomSampleViewer
 
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> GetSrg(const AZStd::string srgName);
             void CompileSrg(const AZStd::string srgName);
-            bool SetBufferView(const AZStd::string srgName, const AZStd::string srgId, const AZ::RHI::MultiDeviceBufferView* bufferView);
+            bool SetBufferView(const AZStd::string srgName, const AZStd::string srgId, const AZ::RHI::BufferView* bufferView);
 
         private:
             AZStd::unordered_map<AZ::Name, AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>> m_srgMap;
@@ -90,7 +90,7 @@ namespace AtomSampleViewer
         {
             static const uint32_t FloatSizeInBytes = static_cast<uint32_t>(sizeof(float));
         public:
-            FloatBuffer(AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> bufferPool, const uint32_t sizeInBytes);
+            FloatBuffer(AZ::RHI::Ptr<AZ::RHI::BufferPool> bufferPool, const uint32_t sizeInBytes);
             ~FloatBuffer();
 
             // Allocates data if the provided handle is empty, else it updates it
@@ -103,14 +103,14 @@ namespace AtomSampleViewer
             bool UpdateBuffer(const FloatBufferHandle& handle, const void* data, const uint32_t sizeInBytes);
 
             // Maps host data to the device
-            bool MapData(const AZ::RHI::MultiDeviceBufferMapRequest& mapRequest, const void* data);
+            bool MapData(const AZ::RHI::BufferMapRequest& mapRequest, const void* data);
 
             // Create the buffer
             void CreateBufferFromPool(const uint32_t byteCount);
 
             // Buffer resource
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool = nullptr;
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_buffer = nullptr;
+            AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool = nullptr;
+            AZ::RHI::Ptr<AZ::RHI::Buffer> m_buffer = nullptr;
 
             // Number of bytes that are allocated
             uint32_t m_allocatedInBytes = 0;
@@ -180,14 +180,14 @@ namespace AtomSampleViewer
         void CreateColorBuffer(
             const AZ::Name& bufferName,
             const AZ::Vector4& colorVal,
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>& buffer,
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView>& bufferView);
+            AZ::RHI::Ptr<AZ::RHI::Buffer>& buffer,
+            AZ::RHI::Ptr<AZ::RHI::BufferView>& bufferView);
 
         // Create indirect buffer that will contain index of the view into the bindless heap
         void CreateIndirectBuffer(
             const AZ::Name& bufferName,
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>& indirectionBuffer,
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView>& bufferView,
+            AZ::RHI::Ptr<AZ::RHI::Buffer>& indirectionBuffer,
+            AZ::RHI::Ptr<AZ::RHI::BufferView>& bufferView,
             size_t byteSize);
 
         // Helper function to allocate or update data in the FloatBuffer
@@ -241,7 +241,7 @@ namespace AtomSampleViewer
         AZStd::vector<ObjectInterval> m_objectIntervalArray;
 
         // NOTE: Assume the same pipeline for every draw item
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
 
         // Handle holding the world matrix
         FloatBufferHandle m_worldToClipHandle;
@@ -254,7 +254,7 @@ namespace AtomSampleViewer
         // Image array holding all of the Stream cubemap images
         AZStd::vector<AZ::Data::Instance<AZ::RPI::StreamingImage>> m_cubemapImages;
 
-        AZStd::vector<const AZ::RHI::MultiDeviceImageView*> m_imageViews;
+        AZStd::vector<const AZ::RHI::ImageView*> m_imageViews;
 
         // Light direction handle
         FloatBufferHandle m_lightDirectionHandle;
@@ -276,23 +276,23 @@ namespace AtomSampleViewer
         AZ::Data::Instance<AZ::RPI::Model> m_model = nullptr;
 
         // BufferPool used to allocate buffers in this example
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool = nullptr;
 
         // Indirection buffer holding uint indices of texture resources
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_imageIndirectionBuffer = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_imageIndirectionBuffer = nullptr;
         // Indirection buffer holding uint indices of buffer resources
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_bufferIndirectionBuffer = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_bufferIndirectionBuffer = nullptr;
         // View associated with the buffer holding indices to bindless images
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_imageIndirectionBufferView = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_imageIndirectionBufferView = nullptr;
         // View associated with the buffer holding indices to bindless buffers
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_bufferIndirectionBufferView = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_bufferIndirectionBufferView = nullptr;
 
         // Color buffer holding color related floats
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_colorBuffer1 = nullptr;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_colorBuffer2 = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_colorBuffer1 = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_colorBuffer2 = nullptr;
         // Views related to the buffers declared above
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_colorBuffer1View = nullptr;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_colorBuffer2View = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_colorBuffer1View = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_colorBuffer2View = nullptr;
 
         // Thread count for compute shaders.
         int m_bufferNumThreadsX = 1;
@@ -328,19 +328,19 @@ namespace AtomSampleViewer
         static constexpr uint32_t m_objectCount = m_maxObjectPerAxis * m_maxObjectPerAxis * m_maxObjectPerAxis;
 
         // Compute pass related PSOs
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_bufferDispatchPipelineState;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_imageDispatchPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_bufferDispatchPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_imageDispatchPipelineState;
         
         // Compute pass related buffer pool which will create a rwbuffer
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_computeBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_computeBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_computeBufferView;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_computeBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_computeBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_computeBufferView;
         AZ::RHI::BufferViewDescriptor m_rwBufferViewDescriptor;
 
          // Compute pass related image pool which will create a rwimage
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_rwImagePool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_computeImage;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImageView> m_computeImageView;
+        AZ::RHI::Ptr<AZ::RHI::ImagePool> m_rwImagePool;
+        AZ::RHI::Ptr<AZ::RHI::Image> m_computeImage;
+        AZ::RHI::Ptr<AZ::RHI::ImageView> m_computeImageView;
         AZ::RHI::ImageViewDescriptor m_rwImageViewDescriptor;
 
         // Compute pass related SRGs

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -106,7 +106,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         BufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
@@ -240,7 +240,7 @@ namespace AtomSampleViewer
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
         bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
 
-        result = m_computeBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        result = m_computeBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialized compute buffer pool");
 
         m_computeBuffer = aznew RHI::MultiDeviceBuffer();

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.h
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
@@ -80,19 +80,19 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::IndexBufferView m_indexBufferView;
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // ----------------------------
         // Compute Buffer
         // ----------------------------
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_computeBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_computeBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_computeBufferView;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_computeBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_computeBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_computeBufferView;
         AZ::RHI::BufferViewDescriptor m_bufferViewDescriptor;
         AZ::RHI::AttachmentId m_bufferAttachmentId = AZ::RHI::AttachmentId("bufferAttachmentId");
 
@@ -101,13 +101,13 @@ namespace AtomSampleViewer
         // ----------------------
 
         // Dispatch pipeline
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_dispatchPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_dispatchPipelineState;
         AZStd::array< AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numberOfSRGs> m_dispatchSRGs;
         AZ::RHI::ShaderInputConstantIndex m_dispatchDimensionConstantIndex;
         AZ::RHI::ShaderInputConstantIndex m_dispatchSeedConstantIndex;
 
         // Draw pipeline
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_drawPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_drawPipelineState;
         AZStd::array< AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numberOfSRGs> m_drawSRGs;
         AZ::RHI::ShaderInputConstantIndex m_drawDimensionConstantIndex;
 

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -83,7 +83,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             UpdateVertexPositions(0);
 

--- a/Gem/Code/Source/RHI/CopyQueueComponent.h
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.h
@@ -13,12 +13,12 @@
 #include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/Device.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -60,12 +60,12 @@ namespace AtomSampleViewer
 
         AZ::RHI::ShaderInputImageIndex m_textureInputIndex;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indexBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_uvBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_indexBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_positionBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_uvBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
 
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixConstantIndex;
@@ -93,7 +93,7 @@ namespace AtomSampleViewer
 
         BufferData m_bufferData;
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
 
         static const int numberOfPaths = 3;
         const char* m_filePaths[numberOfPaths] = {

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -79,7 +79,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         BufferData bufferData;
         SetVertexPosition(bufferData.m_positions.data(), 0, -1.0f, -1.0f, 0.0f);

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.cpp
@@ -74,7 +74,7 @@ namespace AtomSampleViewer
         using namespace AZ;
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -91,9 +91,9 @@ namespace AtomSampleViewer
         SetVertexColor(bufferData.m_colors.data(), 2, 0.0, 0.0, 1.0, 1.0);
 
         SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
-        m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+        m_inputAssemblyBuffer = aznew RHI::Buffer();
 
-        RHI::MultiDeviceBufferInitRequest request;
+        RHI::BufferInitRequest request;
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
         request.m_initialData = &bufferData;
@@ -204,16 +204,20 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 3;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            RHI::SingleDeviceDrawItem drawItem;
+            RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
             drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/Component/TickBus.h>
 
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 #include <RHI/BasicRHIComponent.h>
 
 namespace AtomSampleViewer
@@ -60,17 +60,17 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, geometryIndexCount> m_indices;
         };
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::IndexBufferView m_indexBufferView;
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // ----------------------------------
         // Pipeline and Shader Resource Group
         // ----------------------------------
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance < AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
         AZ::RHI::ShaderInputConstantIndex m_blendFactorIndex;
 

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -139,7 +139,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         {
             BufferData bufferData;
@@ -337,7 +337,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderRead | RHI::BufferBindFlags::Indirect;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_shaderBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_shaderBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         // Create the layout depending on which commands are supported by the device.
         m_indirectDrawBufferLayout = RHI::IndirectBufferLayout();
@@ -361,7 +361,7 @@ namespace AtomSampleViewer
         RHI::MultiDeviceIndirectBufferSignatureDescriptor signatureDescriptor;
         signatureDescriptor.m_layout = m_indirectDrawBufferLayout;
         signatureDescriptor.m_pipelineState = m_drawPipelineState.get();
-        result = m_indirectDrawBufferSignature->Init(RHI::MultiDevice::DefaultDevice, signatureDescriptor);
+        result = m_indirectDrawBufferSignature->Init(RHI::MultiDevice::AllDevices, signatureDescriptor);
 
         if (result != RHI::ResultCode::Success)
         {
@@ -472,7 +472,7 @@ namespace AtomSampleViewer
             m_indirectDispatchBufferSignature = aznew RHI::MultiDeviceIndirectBufferSignature;
             signatureDescriptor = {};
             signatureDescriptor.m_layout = m_indirectDispatchBufferLayout;
-            result = m_indirectDispatchBufferSignature->Init(RHI::MultiDevice::DefaultDevice, signatureDescriptor);
+            result = m_indirectDispatchBufferSignature->Init(RHI::MultiDevice::AllDevices, signatureDescriptor);
 
             if (result != RHI::ResultCode::Success)
             {
@@ -530,7 +530,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderRead;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
-        m_instancesBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_instancesBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         m_instancesDataBuffer = aznew RHI::MultiDeviceBuffer();
 
@@ -561,7 +561,7 @@ namespace AtomSampleViewer
             bufferPoolDesc = {};
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::CopyRead;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
-            m_copyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_copyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             m_resetCounterBuffer = aznew RHI::MultiDeviceBuffer();
 
@@ -847,7 +847,7 @@ namespace AtomSampleViewer
                 drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
+                drawItem.m_streamBufferViewCount = 2;
                 AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
                     m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -12,7 +12,7 @@
 #include <SampleComponentManager.h>
 
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
+#include <Atom/RHI/IndirectBufferWriter.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -116,12 +116,12 @@ namespace AtomSampleViewer
     {
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        RHI::MultiDeviceStreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
-        RHI::MultiDeviceStreamBufferView& instancesIndicesStreamBufferView = m_streamBufferViews[1];
-        RHI::MultiDeviceStreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
+        RHI::StreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
+        RHI::StreamBufferView& instancesIndicesStreamBufferView = m_streamBufferViews[1];
+        RHI::StreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
 
-        RHI::MultiDeviceIndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
-        RHI::MultiDeviceIndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
+        RHI::IndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
+        RHI::IndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
 
         // We use an index to identify an object at draw time.
         // On platforms that support setting inline constant through indirect commands we use an inline constant to set
@@ -134,7 +134,7 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer(RHI::StreamStepFunction::PerInstance)->Channel("BLENDINDICES0", RHI::Format::R32_UINT);
         m_inputStreamLayout = layoutBuilder.End();
 
-        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -158,9 +158,9 @@ namespace AtomSampleViewer
                 bufferData.m_instanceIndices[i] = i;
             }
 
-            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+            m_inputAssemblyBuffer = aznew RHI::Buffer();
 
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -239,7 +239,7 @@ namespace AtomSampleViewer
                 sizeof(uint32_t)
             };
 
-            RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::MultiDeviceStreamBufferView>(m_streamBufferViews.data(), 2));
+            RHI::ValidateStreamBufferViews(m_inputStreamLayout, AZStd::span<const RHI::StreamBufferView>(m_streamBufferViews.data(), 2));
         }
     }
 
@@ -332,7 +332,7 @@ namespace AtomSampleViewer
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
         RHI::ResultCode result;
 
-        m_shaderBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_shaderBufferPool = aznew RHI::BufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderRead | RHI::BufferBindFlags::Indirect;
@@ -357,8 +357,8 @@ namespace AtomSampleViewer
 
         // Create the signature and pass the pipeline state since we may have
         // an inline constants command.
-        m_indirectDrawBufferSignature = aznew RHI::MultiDeviceIndirectBufferSignature;
-        RHI::MultiDeviceIndirectBufferSignatureDescriptor signatureDescriptor;
+        m_indirectDrawBufferSignature = aznew RHI::IndirectBufferSignature;
+        RHI::IndirectBufferSignatureDescriptor signatureDescriptor;
         signatureDescriptor.m_layout = m_indirectDrawBufferLayout;
         signatureDescriptor.m_pipelineState = m_drawPipelineState.get();
         result = m_indirectDrawBufferSignature->Init(RHI::MultiDevice::AllDevices, signatureDescriptor);
@@ -369,10 +369,10 @@ namespace AtomSampleViewer
             return;
         }
 
-        m_sourceIndirectBuffer = aznew RHI::MultiDeviceBuffer();
+        m_sourceIndirectBuffer = aznew RHI::Buffer();
 
         uint32_t commandsStride = m_indirectDrawBufferSignature->GetByteStride();
-        RHI::MultiDeviceBufferInitRequest request;
+        RHI::BufferInitRequest request;
         request.m_buffer = m_sourceIndirectBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor(
             bufferPoolDesc.m_bindFlags,
@@ -380,7 +380,7 @@ namespace AtomSampleViewer
         m_shaderBufferPool->InitBuffer(request);
 
         // Create a writer to populate the buffer with the commands.
-        RHI::Ptr<RHI::MultiDeviceIndirectBufferWriter> indirectBufferWriter = aznew RHI::MultiDeviceIndirectBufferWriter;
+        RHI::Ptr<RHI::IndirectBufferWriter> indirectBufferWriter = aznew RHI::IndirectBufferWriter;
         result = indirectBufferWriter->Init(*m_sourceIndirectBuffer, 0, commandsStride, s_maxNumberOfObjects, *m_indirectDrawBufferSignature);
         if (result != RHI::ResultCode::Success)
         {
@@ -388,11 +388,11 @@ namespace AtomSampleViewer
             return;
         }
 
-        RHI::MultiDeviceStreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
-        RHI::MultiDeviceStreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
+        RHI::StreamBufferView& triangleStreamBufferView = m_streamBufferViews[0];
+        RHI::StreamBufferView& quadStreamBufferView = m_streamBufferViews[2];
 
-        RHI::MultiDeviceIndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
-        RHI::MultiDeviceIndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
+        RHI::IndexBufferView& triangleIndexBufferView = m_indexBufferViews[0];
+        RHI::IndexBufferView& quadIndexBufferView = m_indexBufferViews[1];
 
         // Write the commands using the IndirectBufferWriter
         // We alternate between drawing a triangle and a quad.
@@ -459,7 +459,7 @@ namespace AtomSampleViewer
         }
 
         // Create the buffer that will contain the compute dispatch arguments.
-        m_indirectDispatchBuffer = aznew RHI::MultiDeviceBuffer();
+        m_indirectDispatchBuffer = aznew RHI::Buffer();
         {
             m_indirectDispatchBufferLayout = RHI::IndirectBufferLayout();
             m_indirectDispatchBufferLayout.AddIndirectCommand(RHI::IndirectCommandDescriptor(RHI::IndirectCommandType::Dispatch));
@@ -469,7 +469,7 @@ namespace AtomSampleViewer
                 return;
             }
 
-            m_indirectDispatchBufferSignature = aznew RHI::MultiDeviceIndirectBufferSignature;
+            m_indirectDispatchBufferSignature = aznew RHI::IndirectBufferSignature;
             signatureDescriptor = {};
             signatureDescriptor.m_layout = m_indirectDispatchBufferLayout;
             result = m_indirectDispatchBufferSignature->Init(RHI::MultiDevice::AllDevices, signatureDescriptor);
@@ -497,7 +497,7 @@ namespace AtomSampleViewer
                 indirectDispatchStride
             };
 
-            m_indirectDispatchWriter = aznew RHI::MultiDeviceIndirectBufferWriter;
+            m_indirectDispatchWriter = aznew RHI::IndirectBufferWriter;
             result = m_indirectDispatchWriter->Init(*m_indirectDispatchBuffer, 0, indirectDispatchStride, 1, *m_indirectDispatchBufferSignature);
             if (result != RHI::ResultCode::Success)
             {
@@ -525,16 +525,16 @@ namespace AtomSampleViewer
             data.m_velocity.Set(GetRandomFloat(IndirectRendering::VelocityRange.GetX(), IndirectRendering::VelocityRange.GetY()));
         }
 
-        m_instancesBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_instancesBufferPool = aznew RHI::BufferPool();
 
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::ShaderRead;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
         m_instancesBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
-        m_instancesDataBuffer = aznew RHI::MultiDeviceBuffer();
+        m_instancesDataBuffer = aznew RHI::Buffer();
 
-        RHI::MultiDeviceBufferInitRequest request;
+        RHI::BufferInitRequest request;
         request.m_buffer = m_instancesDataBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{
             RHI::BufferBindFlags::ShaderRead,
@@ -556,14 +556,14 @@ namespace AtomSampleViewer
         // the compute shader has culled the commands.
         if (m_deviceSupportsCountBuffer)
         {
-            m_copyBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_copyBufferPool = aznew RHI::BufferPool();
 
             bufferPoolDesc = {};
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::CopyRead;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
             m_copyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
-            m_resetCounterBuffer = aznew RHI::MultiDeviceBuffer();
+            m_resetCounterBuffer = aznew RHI::Buffer();
 
             AZStd::vector<uint32_t> initData;
             initData.assign(static_cast<size_t>(std::ceil(float(s_maxNumberOfObjects) / maxIndirectDrawCount)), 0);
@@ -620,16 +620,16 @@ namespace AtomSampleViewer
         const auto compileFunction = [this](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
             const auto* countBufferView = context.GetBufferView(RHI::AttachmentId{ IndirectRendering::CountBufferAttachmentId });
-            m_copyDescriptor.m_mdSourceBuffer = m_resetCounterBuffer.get();
+            m_copyDescriptor.m_SourceBuffer = m_resetCounterBuffer.get();
             m_copyDescriptor.m_sourceOffset = 0;
-            m_copyDescriptor.m_mdDestinationBuffer = countBufferView->GetBuffer();
+            m_copyDescriptor.m_DestinationBuffer = countBufferView->GetBuffer();
             m_copyDescriptor.m_destinationOffset = 0;
             m_copyDescriptor.m_size = static_cast<uint32_t>(m_resetCounterBuffer->GetDescriptor().m_byteCount);
         };
 
         const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
         {
-            RHI::SingleDeviceCopyItem copyItem(m_copyDescriptor.GetDeviceCopyBufferDescriptor(context.GetDeviceIndex()));
+            RHI::DeviceCopyItem copyItem(m_copyDescriptor.GetDeviceCopyBufferDescriptor(context.GetDeviceIndex()));
             context.GetCommandList()->Submit(copyItem);
         };
 
@@ -724,7 +724,7 @@ namespace AtomSampleViewer
         {
             RHI::CommandList* commandList = context.GetCommandList();
 
-            RHI::SingleDeviceDispatchItem dispatchItem;
+            RHI::DeviceDispatchItem dispatchItem;
             uint32_t numSrgs = 0;
             dispatchItem.m_shaderResourceGroups[numSrgs++] = m_cullShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get();
             dispatchItem.m_shaderResourceGroups[numSrgs++] = m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get();
@@ -826,7 +826,9 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
             // In case multi indirect drawing is not supported
             // we need to emit multiple indirect draw calls.
@@ -840,16 +842,18 @@ namespace AtomSampleViewer
                 m_drawIndirect.m_indirectBufferByteOffset = i * m_indirectDrawBufferView.GetByteStride();
                 m_drawIndirect.m_indirectBufferView = &m_indirectDrawBufferView;
 
-                RHI::SingleDeviceDrawItem drawItem;
-                drawItem.m_arguments = AZ::RHI::MultiDeviceDrawArguments(m_drawIndirect).GetDeviceDrawArguments(context.GetDeviceIndex());
+                RHI::DeviceDrawItem drawItem;
+                drawItem.m_arguments = AZ::RHI::DrawArguments(m_drawIndirect).GetDeviceDrawArguments(context.GetDeviceIndex());
                 drawItem.m_pipelineState = m_drawPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 auto deviceIndexBufferView{m_indexBufferViews[0].GetDeviceIndexBufferView(context.GetDeviceIndex())};
                 drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = 2;
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the indirect draw item.
@@ -1024,8 +1028,8 @@ namespace AtomSampleViewer
             }
         }
 
-        RHI::MultiDeviceBufferMapRequest request(*m_instancesDataBuffer, 0, sizeof(InstanceData) * m_numObjects);
-        RHI::MultiDeviceBufferMapResponse response;
+        RHI::BufferMapRequest request(*m_instancesDataBuffer, 0, sizeof(InstanceData) * m_numObjects);
+        RHI::BufferMapResponse response;
 
         m_instancesBufferPool->MapBuffer(request, response);
         if (!response.m_data.empty())

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
@@ -19,15 +19,15 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/ShaderReloadNotificationBus.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDeviceCopyItem.h>
+#include <Atom/RHI/CopyItem.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/MultiDeviceIndirectBufferSignature.h>
-#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/IndirectBufferSignature.h>
+#include <Atom/RHI/IndirectBufferWriter.h>
+#include <Atom/RHI/PipelineState.h>
 
 #include <Atom/RHI.Reflect/IndirectBufferLayout.h>
 
@@ -152,37 +152,37 @@ namespace AtomSampleViewer
 
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_shaderBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_instancesBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_copyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_shaderBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_instancesBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_copyBufferPool;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_sourceIndirectBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_instancesDataBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_resetCounterBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indirectDispatchBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_sourceIndirectBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_instancesDataBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_resetCounterBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_indirectDispatchBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_drawPipelineState;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_cullPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_drawPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_cullPipelineState;
 
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_sceneShaderResourceGroup;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_cullShaderResourceGroup;
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumSequencesType> m_indirectCommandsShaderResourceGroups;
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 3> m_streamBufferViews;
-        AZStd::array<AZ::RHI::MultiDeviceIndexBufferView, 2> m_indexBufferViews;
-        AZ::RHI::MultiDeviceIndirectBufferView m_indirectDrawBufferView;
-        AZ::RHI::MultiDeviceIndirectBufferView m_indirectDispatchBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 3> m_streamBufferViews;
+        AZStd::array<AZ::RHI::IndexBufferView, 2> m_indexBufferViews;
+        AZ::RHI::IndirectBufferView m_indirectDrawBufferView;
+        AZ::RHI::IndirectBufferView m_indirectDispatchBufferView;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_sourceIndirectBufferView;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_instancesDataBufferView;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_sourceIndirectBufferView;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_instancesDataBufferView;
 
         AZ::RHI::IndirectBufferLayout m_indirectDrawBufferLayout;
         AZ::RHI::IndirectBufferLayout m_indirectDispatchBufferLayout;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> m_indirectDrawBufferSignature;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferSignature> m_indirectDispatchBufferSignature;
+        AZ::RHI::Ptr<AZ::RHI::IndirectBufferSignature> m_indirectDrawBufferSignature;
+        AZ::RHI::Ptr<AZ::RHI::IndirectBufferSignature> m_indirectDispatchBufferSignature;
 
         AZ::RHI::ShaderInputBufferIndex m_sceneInstancesDataBufferIndex;
         AZ::RHI::ShaderInputConstantIndex m_sceneMatrixInputIndex;
@@ -194,10 +194,10 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::ShaderInputBufferIndex, NumSequencesType> m_cullingInputIndirectBufferIndices;
         AZStd::array<AZ::RHI::ShaderInputBufferIndex, NumSequencesType> m_cullingOutputIndirectBufferIndices;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceIndirectBufferWriter> m_indirectDispatchWriter;
+        AZ::RHI::Ptr<AZ::RHI::IndirectBufferWriter> m_indirectDispatchWriter;
 
         AZ::RHI::MultiDeviceDrawIndirect m_drawIndirect;
-        AZ::RHI::MultiDeviceCopyBufferDescriptor m_copyDescriptor;
+        AZ::RHI::CopyBufferDescriptor m_copyDescriptor;
 
         ImGuiSidebar m_imguiSidebar;
         float m_cullOffset = 1.0f;

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.cpp
@@ -150,7 +150,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly | RHI::BufferBindFlags::ShaderReadWrite;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RHI/RHISystemInterface.h>
@@ -65,24 +65,24 @@ namespace AtomSampleViewer
         // -------------------------------------------------
         // Input Assembly buffer and its Streams/Index Views
         // -------------------------------------------------
-        AZ::RHI::MultiDeviceStreamBufferView m_streamBufferView[2];
+        AZ::RHI::StreamBufferView m_streamBufferView[2];
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
         // ----------------------
         // Pipeline state and SRG
         // ----------------------
 
         // Dispatch pipeline
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_dispatchPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_dispatchPipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_dispatchSRG[2];
         AZ::RHI::ShaderInputConstantIndex m_dispatchTimeConstantIndex;
         AZ::RHI::ShaderInputBufferIndex m_dispatchIABufferIndex;
 
         // Draw pipeline
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_drawPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_drawPipelineState;
         AZ::RHI::ShaderInputConstantIndex m_drawMatrixIndex;
         AZ::RHI::ShaderInputConstantIndex m_drawColorIndex;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_drawSRG[2];

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -170,7 +170,7 @@ namespace AtomSampleViewer
         using namespace AZ;
         const RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
 
-        m_bufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_bufferPool = aznew RHI::BufferPool();
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
@@ -179,9 +179,9 @@ namespace AtomSampleViewer
         BufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-        m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+        m_inputAssemblyBuffer = aznew RHI::Buffer();
         RHI::ResultCode result = RHI::ResultCode::Success;
-        RHI::MultiDeviceBufferInitRequest request;
+        RHI::BufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -290,9 +290,11 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            RHI::SingleDeviceDrawItem drawItem;
+            RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[0]->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -300,8 +302,10 @@ namespace AtomSampleViewer
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
@@ -367,9 +371,11 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            RHI::SingleDeviceDrawItem drawItem;
+            RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[1]->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -377,8 +383,10 @@ namespace AtomSampleViewer
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/MRTExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.cpp
@@ -174,7 +174,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         BufferData bufferData;
         SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());

--- a/Gem/Code/Source/RHI/MRTExampleComponent.h
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/ScopeProducer.h>
 
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
@@ -56,13 +56,13 @@ namespace AtomSampleViewer
         void ReadRenderTargetShader();
         void ReadScreenShader();
         
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
         AZStd::array<AZ::RHI::TransientImageDescriptor, 3> m_renderTargetImageDescriptors;
 
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>,2> m_pipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>,2> m_pipelineStates;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, 2> m_shaderResourceGroups;
 
         AZStd::array<AZ::RHI::ShaderInputConstantIndex, 3> m_shaderInputConstantIndices;
@@ -79,8 +79,8 @@ namespace AtomSampleViewer
             AZStd::array<VertexUV, 4> m_uvs;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::IndexBufferView m_indexBufferView;
 
         AZStd::array<AZ::RHI::AttachmentId, 3> m_attachmentID;
         AZ::RHI::ClearValue m_clearValue;

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.cpp
@@ -53,7 +53,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         AZStd::vector<RHI::SamplePosition> emptySamplePositions;
         AZStd::vector<RHI::SamplePosition> customSamplePositions = { RHI::SamplePosition(3, 3), RHI::SamplePosition(11, 3), RHI::SamplePosition(3, 11), RHI::SamplePosition(11, 11) };

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.h
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.h
@@ -18,11 +18,11 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/ScopeId.h>
 
-#include <Atom/RHI/MultiDeviceBuffer.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/StreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -103,12 +103,12 @@ namespace AtomSampleViewer
         void CreateCustomMSAAResolveScope();
 
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_triangleInputAssemblyBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_triangleInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_quadInputAssemblyBuffer;
         
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, s_numMSAAExamples> m_pipelineStates;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_customResolveMSAAPipelineState;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, s_numMSAAExamples> m_pipelineStates;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_customResolveMSAAPipelineState;
 
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_triangleShaderResourceGroup;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_customMSAAResolveShaderResourceGroup;
@@ -133,8 +133,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_triangleStreamBufferViews;
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_quadStreamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_triangleStreamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_quadStreamBufferViews;
         AZ::RHI::InputStreamLayout m_triangleInputStreamLayout;
         AZ::RHI::InputStreamLayout m_quadInputStreamLayout;
 

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -224,7 +224,7 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -241,9 +241,9 @@ namespace AtomSampleViewer
             SetVertexColor(bufferData.m_colors.data(), 2, 0.0, 0.0, 1.0, 1.0);
             SetVertexColor(bufferData.m_colors.data(), 3, 0.0, 0.0, 1.0, 1.0);
 
-            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+            m_inputAssemblyBuffer = aznew RHI::Buffer();
 
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -457,29 +457,29 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::SingleDeviceIndexBufferView indexBufferView =
-                {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                    offsetof(BufferData, m_indices),
-                    sizeof(BufferData::m_indices),
-                    RHI::IndexFormat::Uint16
-                };
+                const RHI::DeviceIndexBufferView indexBufferView = { *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
+                                                                     offsetof(BufferData, m_indices), sizeof(BufferData::m_indices),
+                                                                     RHI::IndexFormat::Uint16 };
 
                 RHI::DrawIndexed drawIndexed;
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 2;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.cpp
@@ -229,7 +229,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             BufferData bufferData;
 

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
@@ -16,8 +16,8 @@
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
 
 #include <RHI/BasicRHIComponent.h>
 
@@ -81,10 +81,10 @@ namespace AtomSampleViewer
             const AZ::RHI::ShaderInputConstantIndex& matrixConstantId);
 
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
 
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
 
@@ -175,7 +175,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
 
         // ImGui stuff.
         ImGuiSidebar m_imguiSidebar;

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -1,0 +1,711 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <RHI/MultiGPUExampleComponent.h>
+#include <Utils/Utils.h>
+
+#include <SampleComponentManager.h>
+
+#include <Atom/RHI/CommandList.h>
+#include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
+#include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RHI.Reflect/ImageScopeAttachmentDescriptor.h>
+#include <Atom/RPI.Reflect/Shader/ShaderAsset.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/MultiDeviceCopyItem.h>
+#include <Atom/RHI.Reflect/BufferDescriptor.h>
+
+using namespace AZ;
+
+namespace AtomSampleViewer
+{
+    void MultiGPUExampleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<MultiGPUExampleComponent, AZ::Component>()
+                ->Version(0)
+                ;
+        }
+    }
+
+    void MultiGPUExampleComponent::OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder)
+    {
+        static float time = 0.0f;
+        time += 0.005f;
+
+        // Move the triangle around.
+        AZ::Vector3 translation(
+            sinf(time) * 0.25f,
+            cosf(time) * 0.25f,
+            0.0f);
+
+        if (m_shaderResourceGroupShared)
+        {
+            [[maybe_unused]] bool success =
+                m_shaderResourceGroupShared->SetConstant(m_objectMatrixConstantIndex, AZ::Matrix4x4::CreateTranslation(translation));
+            AZ_Warning("MultiGPUExampleComponent", success, "Failed to set SRG Constant m_objectMatrix");
+            m_shaderResourceGroupShared->Compile();
+        }
+
+        BasicRHIComponent::OnFramePrepare(frameGraphBuilder);
+    }
+
+    void MultiGPUExampleComponent::FrameBeginInternal(AZ::RHI::FrameGraphBuilder& frameGraphBuilder)
+    {
+        if (m_outputWidth != m_imageWidth || m_outputHeight != m_imageHeight)
+        {
+            // MultiDeviceImage used as color attachment
+            {
+                m_image = aznew RHI::MultiDeviceImage;
+                RHI::MultiDeviceImageInitRequest initImageRequest;
+                initImageRequest.m_image = m_image.get();
+                initImageRequest.m_descriptor = RHI::ImageDescriptor::Create2D(
+                    RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead, m_outputWidth, m_outputHeight, m_outputFormat);
+                m_imagePool->InitImage(initImageRequest);
+            }
+
+            // MultiDeviceImage holds rendered texture from GPU1 (on GPU0)
+            {
+                m_transferImage = aznew RHI::MultiDeviceImage;
+                RHI::MultiDeviceImageInitRequest initImageRequest;
+                initImageRequest.m_image = m_transferImage.get();
+                initImageRequest.m_descriptor = RHI::ImageDescriptor::Create2D(
+                    RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderRead | RHI::ImageBindFlags::CopyWrite, m_outputWidth, m_outputHeight,
+                    m_outputFormat);
+                m_transferImagePool->InitImage(initImageRequest);
+            }
+
+            RHI::BufferBindFlags stagingBufferBindFlags{ RHI::BufferBindFlags::CopyWrite | RHI::BufferBindFlags::CopyRead };
+
+            {
+                m_stagingBufferToGPU = aznew RHI::MultiDeviceBuffer;
+                AZStd::vector<unsigned int> initialData(m_outputWidth * m_outputHeight, 0xFFFF00FFu);
+
+                RHI::MultiDeviceBufferInitRequest request;
+                request.m_buffer = m_stagingBufferToGPU.get();
+                request.m_descriptor = RHI::BufferDescriptor{stagingBufferBindFlags, initialData.size() * sizeof(unsigned int)};
+                //? Check BindFlags
+                request.m_initialData = initialData.data();
+                if (m_stagingBufferPoolToGPU->InitBuffer(request) != RHI::ResultCode::Success)
+                {
+                    AZ_Error("MultiGPUExampleComponent", false, "StagingBufferToGPU was not created");
+                }
+            }
+
+            {
+                m_stagingBufferToCPU = aznew RHI::MultiDeviceBuffer;
+                RHI::MultiDeviceBufferInitRequest request;
+                request.m_buffer = m_stagingBufferToCPU.get();
+                request.m_descriptor =
+                    RHI::BufferDescriptor{ stagingBufferBindFlags, m_outputWidth * m_outputHeight * sizeof(unsigned int) }; //? Check BindFlags
+                if (m_stagingBufferPoolToCPU->InitBuffer(request) != RHI::ResultCode::Success)
+                {
+                    AZ_Error("MultiGPUExampleComponent", false, "StagingBufferToCPU was not created");
+                }
+            }
+
+            m_scissors[0].m_maxX = m_outputWidth / 2 + 1;
+            m_scissors[1].m_minX = m_outputWidth / 2;
+            m_scissors[1].m_maxX = m_outputWidth;
+
+            m_imageWidth = m_outputWidth;
+            m_imageHeight = m_outputHeight;
+        }
+
+        frameGraphBuilder.GetAttachmentDatabase().ImportImage(
+            m_imageAttachmentIds[0], m_image);
+
+        frameGraphBuilder.GetAttachmentDatabase().ImportImage(
+            m_imageAttachmentIds[1], m_transferImage);
+
+        frameGraphBuilder.GetAttachmentDatabase().ImportBuffer(
+            m_bufferAttachmentIds[0], m_stagingBufferToGPU);
+
+        frameGraphBuilder.GetAttachmentDatabase().ImportBuffer(
+            m_bufferAttachmentIds[1], m_stagingBufferToCPU);
+
+        RHI::SingleDeviceBufferMapRequest request{};
+        request.m_buffer = m_stagingBufferToCPU->GetDeviceBuffer(1).get();
+        request.m_byteCount = m_imageWidth * m_imageHeight * sizeof(uint32_t);
+
+        RHI::SingleDeviceBufferMapResponse response{};
+
+        m_stagingBufferPoolToCPU->GetDeviceBufferPool(1)->MapBuffer(request, response);
+
+        [[maybe_unused]] uint32_t* source = reinterpret_cast<uint32_t*>(response.m_data);
+
+        request.m_buffer = m_stagingBufferToGPU->GetDeviceBuffer(0).get();
+
+        m_stagingBufferPoolToGPU->GetDeviceBufferPool(0)->MapBuffer(request, response);
+
+        uint32_t* destination = reinterpret_cast<uint32_t*>(response.m_data);
+
+        //memset(destination, 0x80, request.m_byteCount);
+
+        memcpy(destination, source, request.m_byteCount);
+
+        /*for (auto i= 0 ; i < 1920 * 8; i++)
+            destination[i + 1080/2*1920] = 0xFFFFFFFF;*/
+
+        m_stagingBufferPoolToCPU->GetDeviceBufferPool(1)->UnmapBuffer(*m_stagingBufferToCPU->GetDeviceBuffer(1));
+        m_stagingBufferPoolToGPU->GetDeviceBufferPool(0)->UnmapBuffer(*m_stagingBufferToGPU->GetDeviceBuffer(0));
+    }
+
+    MultiGPUExampleComponent::MultiGPUExampleComponent()
+    {
+        m_supportRHISamplePipeline = true;
+    }
+
+    void MultiGPUExampleComponent::Activate()
+    {
+        AZ_Error("MultiGPUExampleComponent", RHI::RHISystemInterface::Get()->GetDeviceCount() >= 2, "At least 2 devices required to run this sample");
+
+        m_device_1 = RHI::RHISystemInterface::Get()->GetDevice(0);
+        m_device_2 = RHI::RHISystemInterface::Get()->GetDevice(1);
+
+        m_deviceMask_1 = RHI::MultiDevice::DeviceMask{ 1u << 0 };
+        m_deviceMask_2 = RHI::MultiDevice::DeviceMask{ 1u << 1 };
+        m_deviceMask = m_deviceMask_1 | m_deviceMask_2;
+
+        // Create multi-device resources
+
+        // MultiDeviceImagePool for the render target texture
+        {
+            m_imagePool = aznew RHI::MultiDeviceImagePool;
+            m_imagePool->SetName(Name("RenderTexturePool"));
+
+            RHI::ImagePoolDescriptor imagePoolDescriptor{};
+            imagePoolDescriptor.m_bindFlags =
+                RHI::ImageBindFlags::Color | RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead | RHI::ImageBindFlags::CopyWrite;
+
+            if (m_imagePool->Init(m_deviceMask, imagePoolDescriptor) != RHI::ResultCode::Success)
+            {
+                AZ_Error("MultiGPUExampleComponent", false, "Failed to initialize render texture image pool.");
+                return;
+            }
+        }
+
+        // MultiDeviceImagePool used to transfer the rendered texture from GPU 1 -> GPU 0
+        {
+            m_transferImagePool = aznew RHI::MultiDeviceImagePool;
+            m_transferImagePool->SetName(Name("TransferImagePool"));
+
+            RHI::ImagePoolDescriptor imagePoolDescriptor{};
+            imagePoolDescriptor.m_bindFlags =
+                RHI::ImageBindFlags::ShaderReadWrite | RHI::ImageBindFlags::CopyRead | RHI::ImageBindFlags::CopyWrite;
+
+            if (m_transferImagePool->Init(m_deviceMask_1, imagePoolDescriptor) != RHI::ResultCode::Success)
+            {
+                AZ_Error("MultiGPUExampleComponent", false, "Failed to initialize transfer image pool.");
+                return;
+            }
+        }
+
+        RHI::BufferBindFlags stagingBufferBindFlags{ RHI::BufferBindFlags::CopyWrite | RHI::BufferBindFlags::CopyRead };
+
+        // Create staging buffer pool for buffer copy to the GPU
+        {
+            m_stagingBufferPoolToGPU = aznew RHI::MultiDeviceBufferPool;
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = stagingBufferBindFlags;
+            bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
+            bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
+            if (m_stagingBufferPoolToGPU->Init(m_deviceMask_1, bufferPoolDesc) != RHI::ResultCode::Success)
+            {
+                AZ_Error("MultiGPUExampleComponent", false, "StagingBufferPoolToGPU was not initialized");
+            }
+        }
+
+        // Create staging buffer pools for buffer copy to the CPU
+        {
+            m_stagingBufferPoolToCPU = aznew RHI::MultiDeviceBufferPool;
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = stagingBufferBindFlags;
+            bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
+            bufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Read;
+            if (m_stagingBufferPoolToCPU->Init(m_deviceMask_2, bufferPoolDesc) != RHI::ResultCode::Success)
+            {
+                AZ_Error("MultiGPUExampleComponent", false, "StagingBufferPoolToCPU was not created");
+            }
+        }
+
+        // Setup main and secondary pipeline
+        CreateRenderScopeProducer();
+        CreateCopyToCPUScopeProducer();
+        CreateCopyToGPUScopeProducer();
+        CreateCompositeScopeProducer();
+
+        RHI::RHISystemNotificationBus::Handler::BusConnect();
+    }
+
+    void MultiGPUExampleComponent::Deactivate()
+    {
+        m_inputAssemblyBuffer = nullptr;
+        m_inputAssemblyBufferPool = nullptr;
+        m_pipelineState = nullptr;
+        m_shaderResourceGroupShared = nullptr;
+
+        m_stagingBufferPoolToGPU = nullptr;
+        m_stagingBufferToGPU = nullptr;
+        m_inputAssemblyBufferPoolComposite = nullptr;
+        m_inputAssemblyBufferComposite = nullptr;
+        m_pipelineStateComposite = nullptr;
+        m_shaderResourceGroupComposite = nullptr;
+        m_shaderResourceGroupDataComposite = RHI::MultiDeviceShaderResourceGroupData{};
+        m_shaderResourceGroupPoolComposite = nullptr;
+
+        m_stagingBufferPoolToCPU = nullptr;
+        m_stagingBufferToCPU = nullptr;
+
+        RHI::RHISystemNotificationBus::Handler::BusDisconnect();
+        m_windowContext = nullptr;
+        m_scopeProducers.clear();
+        m_secondaryScopeProducers.clear();
+    }
+
+    void MultiGPUExampleComponent::CreateRenderScopeProducer()
+    {
+        RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
+
+        {
+            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool;
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
+            bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
+            m_inputAssemblyBufferPool->Init(m_deviceMask, bufferPoolDesc);
+
+            BufferDataTrianglePass bufferData;
+
+            SetVertexPosition(bufferData.m_positions.data(), 0,  0.0,  0.5, 0.0);
+            SetVertexPosition(bufferData.m_positions.data(), 1, -0.5, -0.5, 0.0);
+            SetVertexPosition(bufferData.m_positions.data(), 2,  0.5, -0.5, 0.0);
+
+            SetVertexColor(bufferData.m_colors.data(), 0, 1.0, 0.0, 0.0, 1.0);
+            SetVertexColor(bufferData.m_colors.data(), 1, 0.0, 1.0, 0.0, 1.0);
+            SetVertexColor(bufferData.m_colors.data(), 2, 0.0, 0.0, 1.0, 1.0);
+
+            SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
+
+            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer;
+
+            RHI::MultiDeviceBufferInitRequest request;
+            request.m_buffer = m_inputAssemblyBuffer.get();
+            request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
+            request.m_initialData = &bufferData;
+            m_inputAssemblyBufferPool->InitBuffer(request);
+
+            m_streamBufferViews[0] = { *m_inputAssemblyBuffer,
+                                       offsetof(BufferDataTrianglePass, m_positions), sizeof(BufferDataTrianglePass::m_positions),
+                                       sizeof(VertexPosition) };
+
+            m_streamBufferViews[1] = { *m_inputAssemblyBuffer,
+                                       offsetof(BufferDataTrianglePass, m_colors), sizeof(BufferDataTrianglePass::m_colors),
+                                       sizeof(VertexColor) };
+
+            RHI::InputStreamLayoutBuilder layoutBuilder;
+            layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
+            layoutBuilder.AddBuffer()->Channel("COLOR", RHI::Format::R32G32B32A32_FLOAT);
+            pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
+
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+        }
+
+        {
+            const char* triangleShaderFilePath = "Shaders/RHI/triangle.azshader";
+            const char* sampleName = "MultiGPUExample";
+
+            auto shader = LoadShader(triangleShaderFilePath, sampleName);
+            if (shader == nullptr)
+                return;
+
+            auto shaderOptionGroup = shader->CreateShaderOptionGroup();
+            shaderOptionGroup.SetUnspecifiedToDefaultValues();
+
+            // This is an example of how to set different shader options when searching for the shader variant you want to display
+            // Searching by id is simple, but suboptimal. Here it's only used to demonstrate the principle,
+            // but in practice the ShaderOptionIndex and the ShaderOptionValue should be cached for better performance
+            // You can also try DrawMode::Green, DrawMode::Blue or DrawMode::White. The specified color will appear on top of the triangle.
+            shaderOptionGroup.SetValue(AZ::Name("o_drawMode"),  AZ::Name("DrawMode::Red"));
+
+            auto shaderVariant = shader->GetVariant(shaderOptionGroup.GetShaderVariantId());
+
+            shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
+
+            RHI::RenderAttachmentLayoutBuilder attachmentsBuilder;
+            attachmentsBuilder.AddSubpass()
+                ->RenderTargetAttachment(m_outputFormat);
+            [[maybe_unused]] RHI::ResultCode result = attachmentsBuilder.End(pipelineStateDescriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout);
+            AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
+
+            m_pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
+            if (!m_pipelineState)
+            {
+                AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", triangleShaderFilePath);
+                return;
+            }
+
+            m_shaderResourceGroupShared = CreateShaderResourceGroup(shader, "TriangleInstanceSrg", sampleName);
+
+            const Name objectMatrixConstantId{ "m_objectMatrix" };
+            FindShaderInputIndex(&m_objectMatrixConstantIndex, m_shaderResourceGroupShared, objectMatrixConstantId, sampleName);
+
+            // In practice m_shaderResourceGroupShared should be one of the cached SRGs owned by the DrawItem
+            if (!shaderVariant.IsFullyBaked() && m_shaderResourceGroupShared->HasShaderVariantKeyFallbackEntry())
+            {
+                // Normally if the requested variant isn't an exact match we have to set it by SetShaderVariantKeyFallbackValue
+                // In most cases this should be the preferred behavior:
+                m_shaderResourceGroupShared->SetShaderVariantKeyFallbackValue(shaderOptionGroup.GetShaderVariantKeyFallbackValue());
+                AZ_Warning(
+                    sampleName, false, "Check the Triangle.shader file - some program variants haven't been baked ('%s')",
+                    triangleShaderFilePath);
+            }
+        }
+
+        // Creates a scope for rendering the triangle.
+        {
+            struct ScopeData
+            {
+                bool second{false};
+            };
+
+            const auto prepareFunction = [this](RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
+            {
+                // Binds the swap chain as a color attachment. Clears it to white.
+                RHI::ImageScopeAttachmentDescriptor descriptor;
+                descriptor.m_attachmentId = m_imageAttachmentIds[0];
+                descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Clear;
+                descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::Store;
+                descriptor.m_loadStoreAction.m_clearValue.m_vector4Uint = {0, 0, 0, 0};
+                frameGraph.UseColorAttachment(descriptor);
+
+                // We will submit a single draw item.
+                frameGraph.SetEstimatedItemCount(1);
+            };
+
+            RHI::EmptyCompileFunction<ScopeData> compileFunction;
+
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            {
+                RHI::CommandList* commandList = context.GetCommandList();
+
+                // Set persistent viewport and scissor state.
+                commandList->SetViewports(&m_viewport, 1);
+                commandList->SetScissors(&m_scissors[int(scopeData.second)], 1);
+
+                const RHI::SingleDeviceIndexBufferView indexBufferView = {
+                    *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
+                    offsetof(BufferDataTrianglePass, m_indices), sizeof(BufferDataTrianglePass::m_indices), RHI::IndexFormat::Uint16
+                };
+
+                RHI::DrawIndexed drawIndexed;
+                drawIndexed.m_indexCount = 3;
+                drawIndexed.m_instanceCount = 1;
+
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroupShared->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+
+                RHI::SingleDeviceDrawItem drawItem;
+                drawItem.m_arguments = drawIndexed;
+                drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
+                drawItem.m_indexBufferView = &indexBufferView;
+                drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
+                drawItem.m_shaderResourceGroups = shaderResourceGroups;
+                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
+                AZStd::array<RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
+
+                // Submit the triangle draw item.
+                commandList->Submit(drawItem);
+            };
+
+            m_scopeProducers.emplace_back(
+                aznew
+                    RHI::ScopeProducerFunction<ScopeData, decltype(prepareFunction), decltype(compileFunction), decltype(executeFunction)>(
+                        RHI::ScopeId{ "MultiGPUTriangle0" }, ScopeData{}, prepareFunction, compileFunction, executeFunction, 0));
+
+            m_scopeProducers.emplace_back(
+                aznew
+                    RHI::ScopeProducerFunction<ScopeData, decltype(prepareFunction), decltype(compileFunction), decltype(executeFunction)>(
+                        RHI::ScopeId{ "MultiGPUTriangle1" }, ScopeData{true}, prepareFunction, compileFunction, executeFunction, 1));
+        }
+    }
+
+    void MultiGPUExampleComponent::CreateCompositeScopeProducer()
+    {
+        BufferDataCompositePass bufferData;
+        RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
+
+        // Setup input assembly for fullscreen pass
+        {
+            m_inputAssemblyBufferPoolComposite = aznew RHI::MultiDeviceBufferPool();
+
+            RHI::BufferPoolDescriptor bufferPoolDesc;
+            bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
+            bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
+            m_inputAssemblyBufferPoolComposite->Init(m_deviceMask_1, bufferPoolDesc);
+
+            SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
+
+            m_inputAssemblyBufferComposite = aznew RHI::MultiDeviceBuffer;
+
+            RHI::MultiDeviceBufferInitRequest request;
+            request.m_buffer = m_inputAssemblyBufferComposite.get();
+            request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
+            request.m_initialData = &bufferData;
+            m_inputAssemblyBufferPoolComposite->InitBuffer(request);
+
+            m_streamBufferViewsComposite[0] = { *m_inputAssemblyBufferComposite,
+                                                offsetof(BufferDataCompositePass, m_positions),
+                                                sizeof(BufferDataCompositePass::m_positions), sizeof(VertexPosition) };
+
+            m_streamBufferViewsComposite[1] = { *m_inputAssemblyBufferComposite,
+                                                offsetof(BufferDataCompositePass, m_uvs), sizeof(BufferDataCompositePass::m_uvs),
+                                                sizeof(VertexUV) };
+
+            RHI::InputStreamLayoutBuilder layoutBuilder;
+            layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
+            layoutBuilder.AddBuffer()->Channel("UV", RHI::Format::R32G32_FLOAT);
+            pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
+
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViewsComposite);
+        }
+
+        // Load shader and connect inputs
+        {
+            const char* compositeShaderFilePath = "Shaders/RHI/multigpucomposite.azshader";
+            const char* sampleName = "MultiGPUExample";
+
+            auto shader = LoadShader(compositeShaderFilePath, sampleName);
+            if (shader == nullptr)
+            {
+                AZ_Error("MultiGPUExampleComponent", false, "Could not load shader");
+                return;
+            }
+
+            auto shaderVariant = shader->GetVariant(RPI::ShaderAsset::RootShaderVariantStableId);
+            shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
+
+            RHI::RenderAttachmentLayoutBuilder attachmentsBuilder;
+            attachmentsBuilder.AddSubpass()->RenderTargetAttachment(m_outputFormat);
+            [[maybe_unused]] RHI::ResultCode result =
+                attachmentsBuilder.End(pipelineStateDescriptor.m_renderAttachmentConfiguration.m_renderAttachmentLayout);
+            AZ_Assert(result == RHI::ResultCode::Success, "Failed to create render attachment layout");
+
+            m_pipelineStateComposite = shader->AcquirePipelineState(pipelineStateDescriptor);
+            if (!m_pipelineStateComposite)
+            {
+                AZ_Error(sampleName, false, "Failed to acquire default pipeline state for shader '%s'", compositeShaderFilePath);
+                return;
+            }
+
+            RHI::ShaderResourceGroupPoolDescriptor srgPoolDescriptor{};
+            srgPoolDescriptor.m_layout = shader->GetAsset()->FindShaderResourceGroupLayout(AZ::Name { "CompositeSrg" }, shader->GetSupervariantIndex()).get();
+
+            m_shaderResourceGroupPoolComposite = aznew RHI::MultiDeviceShaderResourceGroupPool;
+            m_shaderResourceGroupPoolComposite->Init(m_deviceMask_1, srgPoolDescriptor);
+
+            m_shaderResourceGroupComposite = aznew RHI::MultiDeviceShaderResourceGroup;
+            m_shaderResourceGroupPoolComposite->InitGroup(*m_shaderResourceGroupComposite);
+
+            m_shaderResourceGroupDataComposite = RHI::MultiDeviceShaderResourceGroupData{*m_shaderResourceGroupPoolComposite};
+
+            {
+                const AZ::Name inputTextureShaderInput{ "m_inputTextureLeft" };
+                m_textureInputIndices[0] = srgPoolDescriptor.m_layout->FindShaderInputImageIndex(inputTextureShaderInput);
+            }
+            {
+                const AZ::Name inputTextureShaderInput{ "m_inputTextureRight" };
+                m_textureInputIndices[1] = srgPoolDescriptor.m_layout->FindShaderInputImageIndex(inputTextureShaderInput);
+            }
+        }
+
+        // Setup ScopeProducer
+        {
+            struct ScopeData
+            {
+            };
+
+            const auto prepareFunction = [this](RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
+            {
+                {
+                    RHI::ImageScopeAttachmentDescriptor descriptor{};
+                    descriptor.m_attachmentId = m_imageAttachmentIds[0];
+                    descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
+                    descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::DontCare;
+                    frameGraph.UseShaderAttachment(descriptor, RHI::ScopeAttachmentAccess::Read);
+                }
+
+                {
+                    RHI::ImageScopeAttachmentDescriptor descriptor{};
+                    descriptor.m_attachmentId = m_imageAttachmentIds[1];
+                    descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
+                    descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::DontCare;
+                    frameGraph.UseShaderAttachment(descriptor, RHI::ScopeAttachmentAccess::Read);
+                }
+
+                {
+                    RHI::ImageScopeAttachmentDescriptor desc{};
+                    desc.m_attachmentId = m_outputAttachmentId;
+                    frameGraph.UseColorAttachment(desc);
+                }
+
+                frameGraph.SetEstimatedItemCount(1);
+
+                frameGraph.ExecuteAfter(RHI::ScopeId{ "MultiGPUTriangle0" });
+                frameGraph.ExecuteAfter(RHI::ScopeId{ "MultiGPUCopyToGPU" });
+            };
+
+            const auto compileFunction = [this](const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            {
+                m_shaderResourceGroupDataComposite.SetImageView(m_textureInputIndices[0], context.GetImageView(m_imageAttachmentIds[0]));
+                m_shaderResourceGroupDataComposite.SetImageView(m_textureInputIndices[1], context.GetImageView(m_imageAttachmentIds[1]));
+
+                m_shaderResourceGroupComposite->Compile(m_shaderResourceGroupDataComposite);
+            };
+
+            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            {
+                RHI::CommandList* commandList = context.GetCommandList();
+
+                commandList->SetViewports(&m_viewport, 1);
+                commandList->SetScissors(&m_scissor, 1);
+
+                const RHI::SingleDeviceIndexBufferView indexBufferView = {
+                    *m_inputAssemblyBufferComposite->GetDeviceBuffer(context.GetDeviceIndex()),
+                    offsetof(BufferDataCompositePass, m_indices), sizeof(BufferDataCompositePass::m_indices), RHI::IndexFormat::Uint16
+                };
+
+                RHI::DrawIndexed drawIndexed;
+                drawIndexed.m_indexCount = 6;
+                drawIndexed.m_instanceCount = 1;
+
+                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroupComposite->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+
+                RHI::SingleDeviceDrawItem drawItem;
+                drawItem.m_arguments = drawIndexed;
+                drawItem.m_pipelineState = m_pipelineStateComposite->GetDevicePipelineState(context.GetDeviceIndex()).get();
+                drawItem.m_indexBufferView = &indexBufferView;
+                drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
+                drawItem.m_shaderResourceGroups = shaderResourceGroups;
+                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViewsComposite.size());
+                AZStd::array<RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViewsComposite[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViewsComposite[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
+                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
+
+                commandList->Submit(drawItem);
+            };
+
+            m_scopeProducers.emplace_back(
+                aznew
+                    RHI::ScopeProducerFunction<ScopeData, decltype(prepareFunction), decltype(compileFunction), decltype(executeFunction)>(
+                        RHI::ScopeId{ "MultiGPUComposite" }, ScopeData{}, prepareFunction, compileFunction, executeFunction));
+        }
+    }
+
+    void MultiGPUExampleComponent::CreateCopyToGPUScopeProducer()
+    {
+        struct ScopeData
+        {
+        };
+
+        const auto prepareFunction = [this]([[maybe_unused]] RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
+        {
+            {
+                RHI::ImageScopeAttachmentDescriptor descriptor{};
+                descriptor.m_attachmentId = m_imageAttachmentIds[1];
+                descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::DontCare;
+                descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::Store;
+                frameGraph.UseCopyAttachment(descriptor, RHI::ScopeAttachmentAccess::Write);
+            }
+        };
+
+        const auto compileFunction = []([[maybe_unused]] const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
+        {
+        };
+
+        const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+        {
+            RHI::SingleDeviceCopyBufferToImageDescriptor copyDescriptor{};
+            copyDescriptor.m_sourceBuffer = m_stagingBufferToGPU->GetDeviceBuffer(context.GetDeviceIndex()).get();
+            copyDescriptor.m_sourceOffset = 0;
+            copyDescriptor.m_sourceBytesPerRow = m_imageWidth * sizeof(uint32_t);
+            copyDescriptor.m_sourceBytesPerImage = static_cast<uint32_t>(m_stagingBufferToGPU->GetDescriptor().m_byteCount);
+            copyDescriptor.m_sourceSize = RHI::Size{ m_imageWidth, m_imageHeight, 1 };
+            copyDescriptor.m_destinationImage = m_transferImage->GetDeviceImage(context.GetDeviceIndex()).get();
+
+            RHI::SingleDeviceCopyItem copyItem(copyDescriptor);
+            context.GetCommandList()->Submit(copyItem);
+        };
+
+        m_scopeProducers.emplace_back(
+            aznew RHI::ScopeProducerFunction<ScopeData, decltype(prepareFunction), decltype(compileFunction), decltype(executeFunction)>(
+                RHI::ScopeId{ "MultiGPUCopyToGPU" }, ScopeData{}, prepareFunction, compileFunction, executeFunction));
+    }
+
+    void MultiGPUExampleComponent::CreateCopyToCPUScopeProducer()
+    {
+        struct ScopeData
+        {
+        };
+
+        const auto prepareFunction = [this]([[maybe_unused]] RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
+        {
+            {
+                RHI::BufferScopeAttachmentDescriptor descriptor{};
+                descriptor.m_attachmentId = m_bufferAttachmentIds[1];
+                descriptor.m_bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, m_stagingBufferToCPU->GetDescriptor().m_byteCount);
+                descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::DontCare;
+                descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::Store;
+                frameGraph.UseCopyAttachment(descriptor, RHI::ScopeAttachmentAccess::Write);
+            }
+
+            {
+                RHI::ImageScopeAttachmentDescriptor descriptor{};
+                descriptor.m_attachmentId = m_imageAttachmentIds[0];
+                descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
+                descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::DontCare;
+                frameGraph.UseCopyAttachment(descriptor, RHI::ScopeAttachmentAccess::Read);
+            }
+
+            frameGraph.ExecuteAfter(RHI::ScopeId{ "MultiGPUTriangle1" });
+        };
+
+        const auto compileFunction = []([[maybe_unused]] const RHI::FrameGraphCompileContext& context, [[maybe_unused]] const ScopeData& scopeData)
+        {
+        };
+
+        const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+        {
+            RHI::SingleDeviceCopyImageToBufferDescriptor copyDescriptor{};
+            copyDescriptor.m_sourceImage = m_image->GetDeviceImage(context.GetDeviceIndex()).get();
+            copyDescriptor.m_sourceSize = RHI::Size{ m_imageWidth, m_imageHeight, 1 };
+            copyDescriptor.m_destinationBuffer = m_stagingBufferToCPU->GetDeviceBuffer(context.GetDeviceIndex()).get();
+            copyDescriptor.m_destinationOffset = 0;
+            copyDescriptor.m_destinationBytesPerRow = m_imageWidth * sizeof(uint32_t);
+            copyDescriptor.m_destinationBytesPerImage = static_cast<uint32_t>(m_stagingBufferToCPU->GetDescriptor().m_byteCount);
+            copyDescriptor.m_destinationFormat = m_outputFormat;
+
+            RHI::SingleDeviceCopyItem copyItem(copyDescriptor);
+            context.GetCommandList()->Submit(copyItem);
+        };
+
+        m_scopeProducers.emplace_back(
+            aznew RHI::ScopeProducerFunction<ScopeData, decltype(prepareFunction), decltype(compileFunction), decltype(executeFunction)>(
+                RHI::ScopeId{ "MultiGPUCopyToCPU" }, ScopeData{}, prepareFunction, compileFunction, executeFunction, 1));
+    }
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+
+#include <Atom/RHI/FrameScheduler.h>
+#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/MultiDeviceImagePool.h>
+#include <Atom/RHI/MultiDeviceImage.h>
+#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
+#include <Atom/RHI/MultiDeviceCopyItem.h>
+
+#include <AzCore/Math/Matrix4x4.h>
+
+#include <RHI/BasicRHIComponent.h>
+
+namespace AtomSampleViewer
+{
+    class MultiGPUExampleComponent final
+        : public BasicRHIComponent
+    {
+    public:
+        AZ_COMPONENT(MultiGPUExampleComponent, "{BBA75A38-F111-4F52-AD5E-334B6DD58827}", AZ::Component);
+        AZ_DISABLE_COPY(MultiGPUExampleComponent);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        MultiGPUExampleComponent();
+        ~MultiGPUExampleComponent() override = default;
+
+    protected:
+
+        // AZ::Component
+        void Activate() override;
+        void Deactivate() override;
+        void FrameBeginInternal(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
+
+        // RHISystemNotificationBus::Handler
+        void OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
+
+    private:
+        /////////////////////////////////////////////////////////////////////////
+        //! Shared Resources
+
+        void CreateRenderScopeProducer();
+
+        AZ::RHI::MultiDevice::DeviceMask m_deviceMask;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+
+        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroupShared;
+        AZ::RHI::ShaderInputConstantIndex m_objectMatrixConstantIndex;
+
+        struct BufferDataTrianglePass
+        {
+            AZStd::array<VertexPosition, 3> m_positions;
+            AZStd::array<VertexColor, 3> m_colors;
+            AZStd::array<uint16_t, 3> m_indices;
+        };
+
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_image{};
+        AZStd::array<AZ::RHI::AttachmentId, 2> m_imageAttachmentIds = { { AZ::RHI::AttachmentId("MultiGPURenderTexture1"),
+                                                                          AZ::RHI::AttachmentId("MultiGPURenderTexture2") } };
+        AZStd::array<AZ::RHI::AttachmentId, 2> m_bufferAttachmentIds = { { AZ::RHI::AttachmentId("MultiGPUBufferToGPU"),
+                                                                          AZ::RHI::AttachmentId("MultiGPUBufferToCPU") } };
+        uint32_t m_imageWidth{0};
+        uint32_t m_imageHeight{0};
+
+        /////////////////////////////////////////////////////////////////////////
+        //! First device methods and members
+
+        void CreateCopyToGPUScopeProducer();
+        void CreateCopyToCPUScopeProducer();
+        void CreateCompositeScopeProducer();
+
+        struct BufferDataCompositePass
+        {
+            AZStd::array<VertexPosition, 4> m_positions;
+            AZStd::array<VertexUV, 4> m_uvs;
+            AZStd::array<uint16_t, 6> m_indices;
+        };
+
+        AZStd::array<AZ::RHI::ShaderInputImageIndex, 2> m_textureInputIndices;
+
+        AZ::RHI::Ptr<AZ::RHI::Device> m_device_1{};
+        AZ::RHI::MultiDevice::DeviceMask m_deviceMask_1{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_stagingBufferPoolToGPU{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_stagingBufferToGPU{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_transferImagePool{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_transferImage{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPoolComposite{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBufferComposite{};
+        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViewsComposite;
+        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineStateComposite;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceShaderResourceGroupPool> m_shaderResourceGroupPoolComposite;
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceShaderResourceGroup> m_shaderResourceGroupComposite;
+        AZ::RHI::MultiDeviceShaderResourceGroupData m_shaderResourceGroupDataComposite;
+        AZStd::array<AZ::RHI::Scissor, 2> m_scissors{};
+
+        /////////////////////////////////////////////////////////////////////////
+        //! Second device methods and members
+
+        AZ::RHI::Ptr<AZ::RHI::Device> m_device_2{};
+        AZ::RHI::MultiDevice::DeviceMask m_deviceMask_2{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_stagingBufferPoolToCPU{};
+        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_stagingBufferToCPU{};
+        AZStd::vector<AZStd::shared_ptr<AZ::RHI::ScopeProducer>> m_secondaryScopeProducers;
+    };
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
@@ -13,15 +13,15 @@
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceImagePool.h>
-#include <Atom/RHI/MultiDeviceImage.h>
-#include <Atom/RHI/MultiDeviceShaderResourceGroupPool.h>
-#include <Atom/RHI/MultiDeviceCopyItem.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/ImagePool.h>
+#include <Atom/RHI/Image.h>
+#include <Atom/RHI/ShaderResourceGroupPool.h>
+#include <Atom/RHI/CopyItem.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -58,10 +58,10 @@ namespace AtomSampleViewer
         void CreateRenderScopeProducer();
 
         AZ::RHI::MultiDevice::DeviceMask m_deviceMask;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroupShared;
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixConstantIndex;
 
@@ -72,10 +72,10 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_image{};
+        AZ::RHI::Ptr<AZ::RHI::ImagePool> m_imagePool{};
+        AZ::RHI::Ptr<AZ::RHI::Image> m_image{};
         AZStd::array<AZ::RHI::AttachmentId, 2> m_imageAttachmentIds = { { AZ::RHI::AttachmentId("MultiGPURenderTexture1"),
                                                                           AZ::RHI::AttachmentId("MultiGPURenderTexture2") } };
         AZStd::array<AZ::RHI::AttachmentId, 2> m_bufferAttachmentIds = { { AZ::RHI::AttachmentId("MultiGPUBufferToGPU"),
@@ -101,17 +101,17 @@ namespace AtomSampleViewer
 
         AZ::RHI::Ptr<AZ::RHI::Device> m_device_1{};
         AZ::RHI::MultiDevice::DeviceMask m_deviceMask_1{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_stagingBufferPoolToGPU{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_stagingBufferToGPU{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_transferImagePool{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage> m_transferImage{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPoolComposite{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBufferComposite{};
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViewsComposite;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineStateComposite;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceShaderResourceGroupPool> m_shaderResourceGroupPoolComposite;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceShaderResourceGroup> m_shaderResourceGroupComposite;
-        AZ::RHI::MultiDeviceShaderResourceGroupData m_shaderResourceGroupDataComposite;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPoolToGPU{};
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_stagingBufferToGPU{};
+        AZ::RHI::Ptr<AZ::RHI::ImagePool> m_transferImagePool{};
+        AZ::RHI::Ptr<AZ::RHI::Image> m_transferImage{};
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPoolComposite{};
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBufferComposite{};
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViewsComposite;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineStateComposite;
+        AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupPool> m_shaderResourceGroupPoolComposite;
+        AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroup> m_shaderResourceGroupComposite;
+        AZ::RHI::ShaderResourceGroupData m_shaderResourceGroupDataComposite;
         AZStd::array<AZ::RHI::Scissor, 2> m_scissors{};
 
         /////////////////////////////////////////////////////////////////////////
@@ -119,8 +119,8 @@ namespace AtomSampleViewer
 
         AZ::RHI::Ptr<AZ::RHI::Device> m_device_2{};
         AZ::RHI::MultiDevice::DeviceMask m_deviceMask_2{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_stagingBufferPoolToCPU{};
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_stagingBufferToCPU{};
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPoolToCPU{};
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_stagingBufferToCPU{};
         AZStd::vector<AZStd::shared_ptr<AZ::RHI::ScopeProducer>> m_secondaryScopeProducers;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -153,7 +153,7 @@ namespace AtomSampleViewer
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        result = m_bufferPool->Init(AZ::RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        result = m_bufferPool->Init(AZ::RHI::MultiDevice::AllDevices, bufferPoolDesc);
         if (result != AZ::RHI::ResultCode::Success)
         {
             AZ_Error("MultiThreadComponent", false, "Failed to initialize buffer pool with error code %d", result);

--- a/Gem/Code/Source/RHI/MultiThreadComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.cpp
@@ -9,7 +9,7 @@
 
 #include <AzCore/Math/MatrixUtils.h>
 
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <AzCore/Math/Random.h>
@@ -149,7 +149,7 @@ namespace AtomSampleViewer
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
 
-        m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
+        m_bufferPool = aznew AZ::RHI::BufferPool();
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
@@ -162,8 +162,8 @@ namespace AtomSampleViewer
 
         SingleCubeBufferData bufferData = CreateSingleCubeBufferData(AZ::Vector4(1.0f, 0.0f, 0.0f, 0.0f));
 
-        m_inputAssemblyBuffer = aznew AZ::RHI::MultiDeviceBuffer();
-        AZ::RHI::MultiDeviceBufferInitRequest request;
+        m_inputAssemblyBuffer = aznew AZ::RHI::Buffer();
+        AZ::RHI::BufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, sizeof(SingleCubeBufferData) };
@@ -326,9 +326,11 @@ namespace AtomSampleViewer
             
             for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)
             {
-                const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const AZ::RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroups[i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                AZ::RHI::SingleDeviceDrawItem drawItem;
+                AZ::RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -336,8 +338,10 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem, i);

--- a/Gem/Code/Source/RHI/MultiThreadComponent.h
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.h
@@ -9,9 +9,9 @@
 
 #include <RHI/BasicRHIComponent.h>
 
-#include <Atom/RHI/MultiDeviceBuffer.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/PipelineState.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <MultiThreadComponent_Traits_Platform.h>
 
@@ -75,18 +75,18 @@ namespace AtomSampleViewer
 
         AZStd::array<AZ::Matrix4x4, s_numberOfCubes> m_cubeTransforms;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
         AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numberOfCubes> m_shaderResourceGroups;
         AZ::RHI::ShaderInputConstantIndex m_shaderIndexWorldMat;
         AZ::RHI::ShaderInputConstantIndex m_shaderIndexViewProj;
 
         AZ::RHI::AttachmentId m_depthStencilID;
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::IndexBufferView m_indexBufferView;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -9,7 +9,7 @@
 
 #include <AzCore/Math/MatrixUtils.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameAttachment.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
@@ -235,7 +235,7 @@ namespace AtomSampleViewer
 
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
 
-        m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
+        m_bufferPool = aznew AZ::RHI::BufferPool();
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
@@ -243,9 +243,9 @@ namespace AtomSampleViewer
 
         BufferData bufferData = CreateBufferData();
 
-        m_inputAssemblyBuffer = aznew AZ::RHI::MultiDeviceBuffer();
+        m_inputAssemblyBuffer = aznew AZ::RHI::Buffer();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
-        AZ::RHI::MultiDeviceBufferInitRequest request;
+        AZ::RHI::BufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
@@ -420,9 +420,11 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = geometryIndexCount;
             drawIndexed.m_instanceCount = 1;
 
-            const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const AZ::RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_shaderResourceGroups[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            AZ::RHI::SingleDeviceDrawItem drawItem;
+            AZ::RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[0]->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -430,9 +432,11 @@ namespace AtomSampleViewer
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 3> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[2].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 3> deviceStreamBufferViews{
+                m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[2].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);
@@ -513,9 +517,11 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = geometryIndexCount;
             drawIndexed.m_instanceCount = 1;
 
-            const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const AZ::RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_shaderResourceGroups[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            AZ::RHI::SingleDeviceDrawItem drawItem;
+            AZ::RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_pipelineStates[1]->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -523,9 +529,11 @@ namespace AtomSampleViewer
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 3> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[2].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 3> deviceStreamBufferViews{
+                m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_streamBufferViews[2].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
             commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.cpp
@@ -239,7 +239,7 @@ namespace AtomSampleViewer
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         BufferData bufferData = CreateBufferData();
 

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.h
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.h
@@ -10,9 +10,9 @@
 
 #include <RHI/BasicRHIComponent.h>
 
-#include <Atom/RHI/MultiDeviceBuffer.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/PipelineState.h>
 #include <Atom/RPI.Public/Image/AttachmentImage.h>
 
 #include <AzCore/Component/EntityBus.h>
@@ -90,17 +90,17 @@ namespace AtomSampleViewer
         
         static const int s_shadowMapSize = 1024;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, 2> m_pipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, 2> m_pipelineStates;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, 2> m_shaderResourceGroups;
         AZStd::array<AZ::RHI::ShaderInputConstantIndex, 6> m_shaderInputConstantIndices;
         AZ::RHI::ShaderInputImageIndex m_shaderInputImageIndex;
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 3> m_streamBufferViews;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 3> m_streamBufferViews;
+        AZ::RHI::IndexBufferView m_indexBufferView;
         AZ::RHI::AttachmentId m_depthMapID;
         AZ::RHI::AttachmentId m_depthStencilID;
         AZ::RHI::ClearValue m_depthClearValue;

--- a/Gem/Code/Source/RHI/QueryExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.cpp
@@ -159,7 +159,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         {
             // Create quad buffer and views
@@ -554,7 +554,7 @@ namespace AtomSampleViewer
         queryPoolDesc.m_pipelineStatisticsMask = statisticsMask;
 
         queryPool = aznew RHI::MultiDeviceQueryPool;
-        auto result = queryPool->Init(RHI::MultiDevice::DefaultDevice, queryPoolDesc);
+        auto result = queryPool->Init(RHI::MultiDevice::AllDevices, queryPoolDesc);
         if (result != RHI::ResultCode::Success)
         {
             AZ_Assert(false, "Failed to createa query pool");
@@ -594,7 +594,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Predication | RHI::BufferBindFlags::CopyWrite;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_predicationBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_predicationBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         m_predicationBuffer = aznew RHI::MultiDeviceBuffer();
 

--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -16,13 +16,13 @@
 #include <Atom/RHI.Reflect/ShaderResourceGroupLayoutDescriptor.h>
 #include <Atom/RHI.Reflect/ScopeId.h>
 
-#include <Atom/RHI/MultiDeviceBuffer.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceQueryPool.h>
-#include <Atom/RHI/MultiDeviceQuery.h>
-#include <Atom/RHI/MultiDeviceStreamBufferView.h>
+#include <Atom/RHI/Buffer.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/QueryPool.h>
+#include <Atom/RHI/Query.h>
+#include <Atom/RHI/StreamBufferView.h>
 
 #include <RHI/BasicRHIComponent.h>
 #include <ExampleComponentBus.h>
@@ -92,30 +92,30 @@ namespace AtomSampleViewer
         void SetQueryType(QueryType type);
         void DrawSampleSettings();
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_quadInputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_quadInputAssemblyBuffer;
 
         struct BufferData
         {
             AZStd::array<VertexPosition, 4> m_positions;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZ::RHI::MultiDeviceStreamBufferView m_quadStreamBufferView;
+        AZ::RHI::StreamBufferView m_quadStreamBufferView;
         AZ::RHI::InputStreamLayout m_quadInputStreamLayout;
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, 3> m_shaderResourceGroups;
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixConstantIndex;
         AZ::RHI::ShaderInputConstantIndex m_colorConstantIndex;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_quadPipelineState;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_boudingBoxPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_quadPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_boudingBoxPipelineState;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceQueryPool> m_occlusionQueryPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceQueryPool> m_timeStampQueryPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceQueryPool> m_statisticsQueryPool;
+        AZ::RHI::Ptr<AZ::RHI::QueryPool> m_occlusionQueryPool;
+        AZ::RHI::Ptr<AZ::RHI::QueryPool> m_timeStampQueryPool;
+        AZ::RHI::Ptr<AZ::RHI::QueryPool> m_statisticsQueryPool;
 
         struct QueryEntry
         {
-            AZ::RHI::Ptr<AZ::RHI::MultiDeviceQuery> m_query;
+            AZ::RHI::Ptr<AZ::RHI::Query> m_query;
             bool m_isValid = false; // Indicates if the query has been written at least once.
         };
 
@@ -128,8 +128,8 @@ namespace AtomSampleViewer
 
         QueryType m_currentType = QueryType::Occlusion;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_predicationBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_predicationBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_predicationBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_predicationBuffer;
         AZ::RHI::BufferScopeAttachmentDescriptor m_predicationBufferAttachmentDescriptor;
 
         bool m_timestampEnabled = false;

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -71,7 +71,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Host;
-            [[maybe_unused]] RHI::ResultCode resultCode = m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            [[maybe_unused]] RHI::ResultCode resultCode = m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
             AZ_Assert(resultCode == RHI::ResultCode::Success, "Failed to initialize input assembly buffer pool");
         }
 
@@ -81,13 +81,13 @@ namespace AtomSampleViewer
             imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShaderReadWrite;
 
             m_imagePool = aznew RHI::MultiDeviceImagePool();
-            [[maybe_unused]] RHI::ResultCode result = m_imagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
+            [[maybe_unused]] RHI::ResultCode result = m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image pool");
         }
 
         // initialize ray tracing buffer pools
         m_rayTracingBufferPools = aznew RHI::MultiDeviceRayTracingBufferPools;
-        m_rayTracingBufferPools->Init(RHI::MultiDevice::DefaultDevice);
+        m_rayTracingBufferPools->Init(RHI::MultiDevice::AllDevices);
     }
 
     void RayTracingExampleComponent::CreateGeometry()
@@ -306,13 +306,13 @@ namespace AtomSampleViewer
     
         // create the ray tracing pipeline state object
         m_rayTracingPipelineState = aznew RHI::MultiDeviceRayTracingPipelineState;
-        m_rayTracingPipelineState->Init(RHI::MultiDevice::DefaultDevice, descriptor);
+        m_rayTracingPipelineState->Init(RHI::MultiDevice::AllDevices, descriptor);
     }
 
     void RayTracingExampleComponent::CreateRayTracingShaderTable()
     {
         m_rayTracingShaderTable = aznew RHI::MultiDeviceRayTracingShaderTable;
-        m_rayTracingShaderTable->Init(RHI::MultiDevice::DefaultDevice, *m_rayTracingBufferPools);
+        m_rayTracingShaderTable->Init(RHI::MultiDevice::AllDevices, *m_rayTracingBufferPools);
     }
 
     void RayTracingExampleComponent::CreateRayTracingAccelerationTableScope()
@@ -350,7 +350,7 @@ namespace AtomSampleViewer
                         ->IndexBuffer(triangleIndexBufferView)
                 ;
 
-                m_triangleRayTracingBlas->CreateBuffers(RHI::MultiDevice::DefaultDevice, &triangleBlasDescriptor, *m_rayTracingBufferPools);
+                m_triangleRayTracingBlas->CreateBuffers(RHI::MultiDevice::AllDevices, &triangleBlasDescriptor, *m_rayTracingBufferPools);
             }
 
             // create rectangle BLAS if necessary
@@ -380,7 +380,7 @@ namespace AtomSampleViewer
                         ->IndexBuffer(rectangleIndexBufferView)
                 ;
 
-                m_rectangleRayTracingBlas->CreateBuffers(RHI::MultiDevice::DefaultDevice, &rectangleBlasDescriptor, *m_rayTracingBufferPools);
+                m_rectangleRayTracingBlas->CreateBuffers(RHI::MultiDevice::AllDevices, &rectangleBlasDescriptor, *m_rayTracingBufferPools);
             }
 
             m_time += 0.005f;
@@ -427,7 +427,7 @@ namespace AtomSampleViewer
                     ->Transform(rectangleTransform)
                 ;
 
-            m_rayTracingTlas->CreateBuffers(RHI::MultiDevice::DefaultDevice, &tlasDescriptor, *m_rayTracingBufferPools);
+            m_rayTracingTlas->CreateBuffers(RHI::MultiDevice::AllDevices, &tlasDescriptor, *m_rayTracingBufferPools);
 
             m_tlasBufferViewDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, (uint32_t)m_rayTracingTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
 

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -8,20 +8,20 @@
 
 #pragma once
 
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/Device.h>
+#include <Atom/RHI/DeviceDispatchRaysItem.h>
+#include <Atom/RHI/Factory.h>
+#include <Atom/RHI/FrameScheduler.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/RayTracingAccelerationStructure.h>
+#include <Atom/RHI/RayTracingBufferPools.h>
+#include <Atom/RHI/RayTracingPipelineState.h>
+#include <Atom/RHI/RayTracingShaderTable.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Matrix4x4.h>
-#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
-#include <Atom/RHI/MultiDeviceRayTracingPipelineState.h>
-#include <Atom/RHI/MultiDeviceRayTracingShaderTable.h>
-#include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/SingleDeviceDispatchRaysItem.h>
-#include <Atom/RHI/Device.h>
-#include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
 #include <RHI/BasicRHIComponent.h>
-#include <Atom/RHI/MultiDeviceRayTracingBufferPools.h>
-#include <Atom/RHI/MultiDeviceRayTracingAccelerationStructure.h>
 
 namespace AtomSampleViewer
 {
@@ -66,28 +66,28 @@ namespace AtomSampleViewer
         static const uint32_t m_imageHeight = 1080;
 
         // resource pools
-        RHI::Ptr<RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        RHI::Ptr<RHI::MultiDeviceImagePool> m_imagePool;
-        RHI::Ptr<RHI::MultiDeviceRayTracingBufferPools> m_rayTracingBufferPools;
+        RHI::Ptr<RHI::BufferPool> m_inputAssemblyBufferPool;
+        RHI::Ptr<RHI::ImagePool> m_imagePool;
+        RHI::Ptr<RHI::RayTracingBufferPools> m_rayTracingBufferPools;
 
         // triangle vertex/index buffers
         AZStd::array<VertexPosition, 3> m_triangleVertices;
         AZStd::array<uint16_t, 3> m_triangleIndices;
 
-        RHI::Ptr<RHI::MultiDeviceBuffer> m_triangleVB;
-        RHI::Ptr<RHI::MultiDeviceBuffer> m_triangleIB;
+        RHI::Ptr<RHI::Buffer> m_triangleVB;
+        RHI::Ptr<RHI::Buffer> m_triangleIB;
 
         // rectangle vertex/index buffers
         AZStd::array<VertexPosition, 4> m_rectangleVertices;
         AZStd::array<uint16_t, 6> m_rectangleIndices;
 
-        RHI::Ptr<RHI::MultiDeviceBuffer> m_rectangleVB;
-        RHI::Ptr<RHI::MultiDeviceBuffer> m_rectangleIB;
+        RHI::Ptr<RHI::Buffer> m_rectangleVB;
+        RHI::Ptr<RHI::Buffer> m_rectangleIB;
 
         // ray tracing acceleration structures
-        RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_triangleRayTracingBlas;
-        RHI::Ptr<RHI::MultiDeviceRayTracingBlas> m_rectangleRayTracingBlas;
-        RHI::Ptr<RHI::MultiDeviceRayTracingTlas> m_rayTracingTlas;
+        RHI::Ptr<RHI::RayTracingBlas> m_triangleRayTracingBlas;
+        RHI::Ptr<RHI::RayTracingBlas> m_rectangleRayTracingBlas;
+        RHI::Ptr<RHI::RayTracingTlas> m_rayTracingTlas;
         RHI::BufferViewDescriptor m_tlasBufferViewDescriptor;
         RHI::AttachmentId m_tlasBufferAttachmentId = RHI::AttachmentId("tlasBufferAttachmentId");
 
@@ -98,14 +98,14 @@ namespace AtomSampleViewer
         Data::Instance<RPI::Shader> m_closestHitSolidShader;
 
         // ray tracing pipeline state
-        RHI::Ptr<RHI::MultiDeviceRayTracingPipelineState> m_rayTracingPipelineState;
+        RHI::Ptr<RHI::RayTracingPipelineState> m_rayTracingPipelineState;
 
         // ray tracing shader table
-        RHI::Ptr<RHI::MultiDeviceRayTracingShaderTable> m_rayTracingShaderTable;
+        RHI::Ptr<RHI::RayTracingShaderTable> m_rayTracingShaderTable;
 
         // ray tracing global shader resource group and pipeline state
         Data::Instance<RPI::ShaderResourceGroup> m_globalSrg;
-        RHI::ConstPtr<RHI::MultiDevicePipelineState> m_globalPipelineState;
+        RHI::ConstPtr<RHI::PipelineState> m_globalPipelineState;
 
         // ray tracing local shader resource groups, one for each object in the scene
         enum LocalSrgs
@@ -120,8 +120,8 @@ namespace AtomSampleViewer
         bool m_buildLocalSrgs = true;
 
         // output image, written to by the ray tracing shader and displayed in the fullscreen draw shader
-        RHI::Ptr<RHI::MultiDeviceImage> m_outputImage;
-        RHI::Ptr<RHI::MultiDeviceImageView> m_outputImageView;
+        RHI::Ptr<RHI::Image> m_outputImage;
+        RHI::Ptr<RHI::ImageView> m_outputImageView;
         RHI::ImageViewDescriptor m_outputImageViewDescriptor;
         RHI::AttachmentId m_outputImageAttachmentId = RHI::AttachmentId("outputImageAttachmentId");
 
@@ -133,12 +133,12 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        RHI::Ptr<RHI::MultiDeviceBuffer> m_fullScreenInputAssemblyBuffer;
-        AZStd::array<RHI::MultiDeviceStreamBufferView, 2> m_fullScreenStreamBufferViews;
-        RHI::MultiDeviceIndexBufferView m_fullScreenIndexBufferView;
+        RHI::Ptr<RHI::Buffer> m_fullScreenInputAssemblyBuffer;
+        AZStd::array<RHI::StreamBufferView, 2> m_fullScreenStreamBufferViews;
+        RHI::IndexBufferView m_fullScreenIndexBufferView;
         RHI::InputStreamLayout m_fullScreenInputStreamLayout;
 
-        RHI::ConstPtr<RHI::MultiDevicePipelineState> m_drawPipelineState;
+        RHI::ConstPtr<RHI::PipelineState> m_drawPipelineState;
         Data::Instance<RPI::ShaderResourceGroup> m_drawSRG;
         RHI::ShaderInputConstantIndex m_drawDimensionConstantIndex;
 

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -93,7 +93,7 @@ namespace AtomSampleViewer
         }
 
         {
-            m_bufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_bufferPool = aznew RHI::BufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -102,12 +102,12 @@ namespace AtomSampleViewer
 
             SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-            m_positionBuffer = aznew RHI::MultiDeviceBuffer();
-            m_indexBuffer = aznew RHI::MultiDeviceBuffer();
-            m_uvBuffer = aznew RHI::MultiDeviceBuffer();
+            m_positionBuffer = aznew RHI::Buffer();
+            m_indexBuffer = aznew RHI::Buffer();
+            m_uvBuffer = aznew RHI::Buffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
 
             request.m_buffer = m_positionBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, positionBufSize };
@@ -309,34 +309,34 @@ namespace AtomSampleViewer
                 // Bind ViewSrg
                 commandList->SetShaderResourceGroupForDraw(*m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get());
 
-                const RHI::SingleDeviceIndexBufferView indexBufferView =
-                {
-                    *m_indexBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                    0,
-                    indexBufSize,
-                    RHI::IndexFormat::Uint16
-                };
+                const RHI::DeviceIndexBufferView indexBufferView = { *m_indexBuffer->GetDeviceBuffer(context.GetDeviceIndex()), 0,
+                                                                     indexBufSize, RHI::IndexFormat::Uint16 };
 
                 RHI::DrawIndexed drawIndexed;
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                    (m_mode ? m_demoShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() :
-                              m_renderShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
-                    ),
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    (m_mode ? m_demoShaderResourceGroup->GetRHIShaderResourceGroup()
+                                  ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                                  .get()
+                            : m_renderShaderResourceGroup->GetRHIShaderResourceGroup()
+                                  ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                                  .get()),
                     m_viewShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_mode ? m_demoPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get() : m_renderPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -98,7 +98,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
 #include <AzCore/Component/TickBus.h>
@@ -58,7 +58,7 @@ namespace AtomSampleViewer
 
 
         // ------------------- demo mode variables -------------------
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>        m_demoPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState>        m_demoPipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_demoShaderResourceGroup;
 
         AZ::RHI::ShaderInputConstantIndex m_demoObjectMatrixInputIndex;
@@ -84,7 +84,7 @@ namespace AtomSampleViewer
 
 
         // ------------------- render mode variables -------------------
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>        m_renderPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState>        m_renderPipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_renderShaderResourceGroup;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_viewShaderResourceGroup;
 
@@ -122,10 +122,10 @@ namespace AtomSampleViewer
 
 
         // ---------------- streaming buffer variables ----------------
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indexBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_uvBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_indexBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_positionBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_uvBuffer;
 
         struct BufferData
         {
@@ -134,7 +134,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
         // ------------------------------------------------------------
 
         AZ::EntityId m_cameraEntityId;

--- a/Gem/Code/Source/RHI/StencilExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.cpp
@@ -52,7 +52,7 @@ namespace AtomSampleViewer
         RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -95,9 +95,9 @@ namespace AtomSampleViewer
             // Triangles index
             SetVertexIndexIncreasing(bufferData.m_indices.data(), s_numberOfVertices);
 
-            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+            m_inputAssemblyBuffer = aznew RHI::Buffer();
 
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -202,22 +202,20 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::SingleDeviceIndexBufferView indexBufferView =
-                {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                    offsetof(BufferData, m_indices),
-                    sizeof(BufferData::m_indices),
-                    RHI::IndexFormat::Uint16
-                };
+                const RHI::DeviceIndexBufferView indexBufferView = { *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
+                                                                     offsetof(BufferData, m_indices), sizeof(BufferData::m_indices),
+                                                                     RHI::IndexFormat::Uint16 };
 
                 RHI::DrawIndexed drawIndexed;
                 drawIndexed.m_instanceCount = 1;
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 for (uint32_t i = context.GetSubmitRange().m_startIndex; i < context.GetSubmitRange().m_endIndex; ++i)

--- a/Gem/Code/Source/RHI/StencilExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.cpp
@@ -57,8 +57,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
-
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             BufferData bufferData;
 

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -11,9 +11,9 @@
 
 #include <AzCore/Math/Vector3.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/Device.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 
 namespace AtomSampleViewer
 {
@@ -45,11 +45,11 @@ namespace AtomSampleViewer
         // Triangles setting
         void SetTriangleVertices(int startIndex, VertexPosition* vertexData, AZ::Vector3 center, float offset);
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineStateBasePass;
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, 8> m_pipelineStateStencil;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineStateBasePass;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, 8> m_pipelineStateStencil;
 
         static const size_t s_numberOfVertices = 48;
 
@@ -60,7 +60,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, s_numberOfVertices> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
 
         AZ::RHI::AttachmentId m_depthStencilID;
         AZ::RHI::ClearValue m_depthClearValue;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.cpp
@@ -14,7 +14,7 @@
 
 #include <Atom/Component/DebugCamera/ArcBallControllerComponent.h>
 #include <Atom/RHI/CommandList.h>
-#include <Atom/RHI/MultiDeviceIndirectBufferWriter.h>
+#include <Atom/RHI/IndirectBufferWriter.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -399,14 +399,15 @@ namespace AtomSampleViewer
             {
                 // Model
                 const auto& modelData = m_opaqueModelsData[i];
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
-                {
-                    modelData.m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    modelData.m_shaderResourceGroup->GetRHIShaderResourceGroup()
+                        ->GetDeviceShaderResourceGroup(context.GetDeviceIndex())
+                        .get()
                 };
 
                 for (const auto& mesh : m_models[modelData.m_modelType]->GetLods()[0]->GetMeshes())
                 {
-                    RHI::SingleDeviceDrawItem drawItem;
+                    RHI::DeviceDrawItem drawItem;
                     drawItem.m_arguments = mesh.m_drawArguments.GetDeviceDrawArguments(context.GetDeviceIndex());
                     drawItem.m_pipelineState = modelData.m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                     auto deviceIndexBufferView{mesh.m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -414,7 +415,7 @@ namespace AtomSampleViewer
                     drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                     drawItem.m_shaderResourceGroups = shaderResourceGroups;
                     drawItem.m_streamBufferViewCount = static_cast<uint8_t>(modelData.m_streamBufferList.size());
-                    AZStd::vector<AZ::RHI::SingleDeviceStreamBufferView> deviceStreamBufferViews;
+                    AZStd::vector<AZ::RHI::DeviceStreamBufferView> deviceStreamBufferViews;
                     for(const auto& streamBufferView : modelData.m_streamBufferList)
                     {
                         deviceStreamBufferViews.emplace_back(streamBufferView.GetDeviceStreamBufferView(context.GetDeviceIndex()));
@@ -514,8 +515,7 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] =
-            {
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                 m_compositionSubpassInputsSRG->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
                 m_sceneShaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
             };
@@ -526,8 +526,8 @@ namespace AtomSampleViewer
             drawArguments.m_vertexCount = 4;
             drawArguments.m_vertexOffset = 0;
 
-            RHI::SingleDeviceDrawItem drawItem;
-            drawItem.m_arguments = RHI::SingleDeviceDrawArguments(drawArguments);
+            RHI::DeviceDrawItem drawItem;
+            drawItem.m_arguments = RHI::DeviceDrawArguments(drawArguments);
             drawItem.m_pipelineState = m_compositionPipeline->GetDevicePipelineState(context.GetDeviceIndex()).get();
             drawItem.m_indexBufferView = nullptr;
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -17,12 +17,12 @@
 #include <Atom/RPI.Public/Model/Model.h>
 #include <Atom/RPI.Public/Model/ModelLod.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 #include <Atom/RHI/RHISystemInterface.h>
 
 #include <AzFramework/Entity/EntityContextBus.h>
@@ -73,7 +73,7 @@ namespace AtomSampleViewer
         struct ModelData
         {
             AZ::RPI::ModelLod::StreamBufferViewList m_streamBufferList;
-            AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+            AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
             ModelType m_modelType = ModelType_ShaderBall;
         };
@@ -125,6 +125,6 @@ namespace AtomSampleViewer
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_sceneShaderResourceGroup;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_compositionSubpassInputsSRG;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_viewShaderResourceGroup;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_compositionPipeline;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_compositionPipeline;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -68,7 +68,7 @@ namespace AtomSampleViewer
             const uint64_t imagePoolBudget = 1 << 24; // 16 Megabyte
             imagePoolDesc.m_budgetInBytes = imagePoolBudget;
 
-            const RHI::ResultCode resultCode = m_imagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
+            const RHI::ResultCode resultCode = m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
             if (resultCode != RHI::ResultCode::Success)
             {
                 AZ_Error("Texture3dExampleComponent", false, "Failed to initialize image pool.");

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -14,8 +14,8 @@
 #include <Atom/RHI/Factory.h>
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/MultiDeviceImage.h>
-#include <Atom/RHI/MultiDeviceImagePool.h>
+#include <Atom/RHI/Image.h>
+#include <Atom/RHI/ImagePool.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RHI.Reflect/RenderAttachmentLayoutBuilder.h>
 
@@ -60,7 +60,7 @@ namespace AtomSampleViewer
 
         // Create image pool
         {
-            m_imagePool = aznew RHI::MultiDeviceImagePool;
+            m_imagePool = aznew RHI::ImagePool;
             m_imagePool->SetName(Name("Texture3DPool"));
 
             RHI::ImagePoolDescriptor imagePoolDesc = {};
@@ -91,10 +91,10 @@ namespace AtomSampleViewer
                                                             "textures/streaming/streaming19.dds.streamingimage" });
 
             // Create the image resource
-            m_image = aznew RHI::MultiDeviceImage();
+            m_image = aznew RHI::Image();
             m_image->SetName(Name("Texture3D"));
 
-            RHI::MultiDeviceImageInitRequest imageRequest;
+            RHI::ImageInitRequest imageRequest;
             imageRequest.m_image = m_image.get();
             imageRequest.m_descriptor = RHI::ImageDescriptor::Create3D(RHI::ImageBindFlags::ShaderRead, deviceImageLayout.m_size.m_width, deviceImageLayout.m_size.m_height, deviceImageLayout.m_size.m_depth, format);
             RHI::ResultCode resultCode = m_imagePool->InitImage(imageRequest);
@@ -118,10 +118,10 @@ namespace AtomSampleViewer
             }
 
             // Update/stage the image with data
-            RHI::MultiDeviceImageSubresourceLayout imageSubresourceLayout;
+            RHI::ImageSubresourceLayout imageSubresourceLayout;
             m_image->GetSubresourceLayout(imageSubresourceLayout);
 
-            RHI::MultiDeviceImageUpdateRequest updateRequest;
+            RHI::ImageUpdateRequest updateRequest;
             updateRequest.m_image = m_image.get();
             updateRequest.m_sourceSubresourceLayout = imageSubresourceLayout;
             updateRequest.m_sourceData = imageData.data();
@@ -217,10 +217,12 @@ namespace AtomSampleViewer
                 drawIndexed.m_vertexCount = 4;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
                 // Create the draw item
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = nullptr;

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -12,8 +12,8 @@
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/BufferPool.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
 #include <AzCore/Component/TickBus.h>
@@ -46,14 +46,14 @@ namespace AtomSampleViewer
 
         ImGuiSidebar m_imguiSidebar;
         AzFramework::WindowSize m_windowSize;
-        AZ::RHI::MultiDeviceImageSubresourceLayout m_imageLayout;
+        AZ::RHI::ImageSubresourceLayout m_imageLayout;
 
         // Rendering resources
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool = nullptr;
-        AZ::Data::Instance<AZ::RHI::MultiDeviceImage> m_image = nullptr;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImageView> m_imageView = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::ImagePool> m_imagePool = nullptr;
+        AZ::Data::Instance<AZ::RHI::Image> m_image = nullptr;
+        AZ::RHI::Ptr<AZ::RHI::ImageView> m_imageView = nullptr;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup = nullptr;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState = nullptr;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState = nullptr;
 
         // Shader Input indices
         AZ::RHI::ShaderInputImageIndex m_texture3dInputIndex;

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -59,7 +59,7 @@ namespace AtomSampleViewer
         };
 
         RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+        m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
         // Load the shader
         {
@@ -133,10 +133,10 @@ namespace AtomSampleViewer
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
             m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
-            m_rectangleInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+            m_rectangleInputAssemblyBuffer = aznew RHI::Buffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_rectangleInputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -205,30 +205,31 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&viewport, 1u);
                 commandList->SetScissors(&m_scissor, 1u);
 
-                const RHI::SingleDeviceIndexBufferView indexBufferView =
-                {
-                    *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                    offsetof(RectangleBufferData, m_indices),
-                    sizeof(RectangleBufferData::m_indices),
-                    RHI::IndexFormat::Uint16
+                const RHI::DeviceIndexBufferView indexBufferView = {
+                    *m_rectangleInputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()), offsetof(RectangleBufferData, m_indices),
+                    sizeof(RectangleBufferData::m_indices), RHI::IndexFormat::Uint16
                 };
 
                 RHI::DrawIndexed drawIndexed;
                 drawIndexed.m_indexCount = 6u;
                 drawIndexed.m_instanceCount = 1u;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = {
-                    m_textureArraySrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(), m_textureIndexSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_textureArraySrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
+                    m_textureIndexSrg->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_rectangleStreamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_rectangleStreamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_rectangleStreamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_rectangleStreamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_rectangleStreamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.cpp
@@ -132,7 +132,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
             m_rectangleInputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
@@ -39,11 +39,11 @@ namespace AtomSampleViewer
         // AZ::TickBus::Handler overrides...
         void OnTick(float deltaTime, AZ::ScriptTimePoint scriptTime);
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_rectangleInputAssemblyBuffer;
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_rectangleStreamBufferViews;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_rectangleInputAssemblyBuffer;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
 
         // Srg related resources
         AZ::Data::Instance<AZ::RPI::Shader> m_shader;

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -61,7 +61,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -56,7 +56,7 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_bufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_bufferPool = aznew RHI::BufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -65,12 +65,12 @@ namespace AtomSampleViewer
 
             SetFullScreenRect(bufferData.m_positions.data(), bufferData.m_uvs.data(), bufferData.m_indices.data());
 
-            m_positionBuffer = aznew RHI::MultiDeviceBuffer();
-            m_indexBuffer = aznew RHI::MultiDeviceBuffer();
-            m_uvBuffer = aznew RHI::MultiDeviceBuffer();
+            m_positionBuffer = aznew RHI::Buffer();
+            m_indexBuffer = aznew RHI::Buffer();
+            m_uvBuffer = aznew RHI::Buffer();
 
             RHI::ResultCode result = RHI::ResultCode::Success;
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
 
             request.m_buffer = m_positionBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, positionBufSize };
@@ -224,29 +224,28 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::SingleDeviceIndexBufferView indexBufferView =
-                {
-                    *m_indexBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                    0,
-                    indexBufSize,
-                    RHI::IndexFormat::Uint16
-                };
+                const RHI::DeviceIndexBufferView indexBufferView = { *m_indexBuffer->GetDeviceBuffer(context.GetDeviceIndex()), 0,
+                                                                     indexBufSize, RHI::IndexFormat::Uint16 };
 
                 RHI::DrawIndexed drawIndexed;
                 drawIndexed.m_indexCount = 6;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/TextureExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.h
@@ -12,7 +12,7 @@
 
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI.Reflect/SamplerState.h>
 
 #include <AzCore/Component/TickBus.h>
@@ -52,12 +52,12 @@ namespace AtomSampleViewer
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixInputIndex;
         AZ::RHI::ShaderInputConstantIndex m_uvMatrixInputIndex;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_indexBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_positionBuffer;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_uvBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_indexBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_positionBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_uvBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
 
         struct BufferData
@@ -67,8 +67,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZ::RHI::SingleDeviceDrawItem m_drawItem;
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::DeviceDrawItem m_drawItem;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
 
         AZ::RHI::SamplerState m_samplerState;
         bool m_useStaticSampler = true;

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -204,7 +204,7 @@ namespace AtomSampleViewer
     void TextureMapExampleComponent::CreateInputAssemblyBufferPool()
     {
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
-        m_inputAssemblyBufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
+        m_inputAssemblyBufferPool = aznew AZ::RHI::BufferPool();
 
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
@@ -513,16 +513,21 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = 6;
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_targetSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_targetSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            RHI::SingleDeviceDrawItem drawItem;
+            RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_targetPipelineStates[target]->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_bufferViews[RenderTargetIndex::BufferViewIndex].m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
             drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[0].GetDeviceStreamBufferView(
+                    context.GetDeviceIndex()),
+                m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
@@ -593,16 +598,20 @@ namespace AtomSampleViewer
             drawIndexed.m_indexCount = m_bufferViews[target].m_indexBufferView.GetByteCount() / sizeof(uint16_t);
             drawIndexed.m_instanceCount = 1;
 
-            const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_screenSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+            const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                m_screenSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+            };
 
-            RHI::SingleDeviceDrawItem drawItem;
+            RHI::DeviceDrawItem drawItem;
             drawItem.m_arguments = drawIndexed;
             drawItem.m_pipelineState = m_screenPipelineStates[target]->GetDevicePipelineState(context.GetDeviceIndex()).get();
             auto deviceIndexBufferView{m_bufferViews[target].m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
             drawItem.m_indexBufferView = &deviceIndexBufferView;
             drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_bufferViews[target].m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_bufferViews[target].m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_bufferViews[target].m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                m_bufferViews[target].m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                m_bufferViews[target].m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+            };
             drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
@@ -771,9 +780,9 @@ namespace AtomSampleViewer
         uint32_t uvSize, void* uvData, uint32_t uvTypeSize,
         uint32_t indexSize, void* indexData)
     {
-        m_positionBuffer[target] = aznew AZ::RHI::MultiDeviceBuffer();
+        m_positionBuffer[target] = aznew AZ::RHI::Buffer();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
-        AZ::RHI::MultiDeviceBufferInitRequest request;
+        AZ::RHI::BufferInitRequest request;
         request.m_buffer = m_positionBuffer[target].get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, posSize };
         request.m_initialData = posData;
@@ -792,7 +801,7 @@ namespace AtomSampleViewer
             sizeof(VertexPosition)
         };
 
-        m_uvBuffer[target] = aznew AZ::RHI::MultiDeviceBuffer();
+        m_uvBuffer[target] = aznew AZ::RHI::Buffer();
         request.m_buffer = m_uvBuffer[target].get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, uvSize };
         request.m_initialData = uvData;
@@ -811,7 +820,7 @@ namespace AtomSampleViewer
             uvTypeSize
         };
 
-        m_indexBuffer[target] = aznew AZ::RHI::MultiDeviceBuffer();
+        m_indexBuffer[target] = aznew AZ::RHI::Buffer();
         request.m_buffer = m_indexBuffer[target].get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, indexSize };
         request.m_initialData = indexData;

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -209,7 +209,7 @@ namespace AtomSampleViewer
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_inputAssemblyBufferPool->Init(AZ::RHI::MultiDevice::AllDevices, bufferPoolDesc);
     }
 
     void TextureMapExampleComponent::InitRenderTargetBufferView()

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -9,7 +9,7 @@
 
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Math/Matrix3x3.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 #include <RHI/BasicRHIComponent.h>
 
 namespace AtomSampleViewer
@@ -56,8 +56,8 @@ namespace AtomSampleViewer
 
         struct BufferViewData
         {
-            AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
-            AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+            AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+            AZ::RHI::IndexBufferView m_indexBufferView;
             AZ::RHI::InputStreamLayout m_inputStreamLayout;
         };
         
@@ -115,21 +115,21 @@ namespace AtomSampleViewer
         // -------------------------------------
         // Input Assembly buffer and buffer view
         // -------------------------------------
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
         // array for buffer and buffer view ( all render targets + screen)
-        AZStd::array< AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>, s_numOfTargets + 1> m_positionBuffer;
-        AZStd::array< AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>, s_numOfTargets + 1> m_uvBuffer;
-        AZStd::array< AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer>, s_numOfTargets + 1> m_indexBuffer;
+        AZStd::array< AZ::RHI::Ptr<AZ::RHI::Buffer>, s_numOfTargets + 1> m_positionBuffer;
+        AZStd::array< AZ::RHI::Ptr<AZ::RHI::Buffer>, s_numOfTargets + 1> m_uvBuffer;
+        AZStd::array< AZ::RHI::Ptr<AZ::RHI::Buffer>, s_numOfTargets + 1> m_indexBuffer;
         AZStd::array<BufferViewData, s_numOfTargets + 1> m_bufferViews;
 
         // ---------------------------------------
         // Pipeline state, SRG, shader input index
         // ---------------------------------------
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, s_numOfTargets> m_targetPipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, s_numOfTargets> m_targetPipelineStates;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numOfTargets> m_targetSRGs;
         AZStd::array<AZ::RHI::ShaderInputConstantIndex, s_numOfTargets> m_shaderInputConstantIndices;
 
-        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState>, s_numOfTargets> m_screenPipelineStates;
+        AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, s_numOfTargets> m_screenPipelineStates;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, s_numOfTargets> m_screenSRGs;
         AZStd::array<AZ::RHI::ShaderInputImageIndex, s_numOfTargets> m_shaderInputImageIndices;
 

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -64,7 +64,7 @@ namespace AtomSampleViewer
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
-            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -83,9 +83,9 @@ namespace AtomSampleViewer
 
             SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
 
-            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+            m_inputAssemblyBuffer = aznew RHI::Buffer();
 
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -194,29 +194,29 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::SingleDeviceIndexBufferView indexBufferView =
-                {
-                    *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                    offsetof(BufferData, m_indices),
-                    sizeof(BufferData::m_indices),
-                    RHI::IndexFormat::Uint16
-                };
+                const RHI::DeviceIndexBufferView indexBufferView = { *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
+                                                                     offsetof(BufferData, m_indices), sizeof(BufferData::m_indices),
+                                                                     RHI::IndexFormat::Uint16 };
 
                 RHI::DrawIndexed drawIndexed;
                 drawIndexed.m_indexCount = 3;
                 drawIndexed.m_instanceCount = 1;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -61,8 +61,6 @@ namespace AtomSampleViewer
     {
         using namespace AZ;
 
-        RHI::Ptr<RHI::Device> device = Utils::GetRHIDevice();
-
         AZ::RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
 
         {
@@ -71,7 +69,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             BufferData bufferData;
 

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.h
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.h
@@ -15,8 +15,8 @@
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -46,10 +46,10 @@ namespace AtomSampleViewer
         void OnFramePrepare(AZ::RHI::FrameGraphBuilder& frameGraphBuilder) override;
 
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixConstantIndex;
 
@@ -60,6 +60,6 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -125,7 +125,7 @@ namespace AtomSampleViewer
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
             bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+            m_inputAssemblyBufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
             IABufferData bufferData;
 
@@ -186,7 +186,7 @@ namespace AtomSampleViewer
             constantBufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
             constantBufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
             constantBufferPoolDesc.m_hostMemoryAccess = RHI::HostMemoryAccess::Write;
-            [[maybe_unused]] RHI::ResultCode result = m_constantBufferPool->Init(RHI::MultiDevice::DefaultDevice, constantBufferPoolDesc);
+            [[maybe_unused]] RHI::ResultCode result = m_constantBufferPool->Init(RHI::MultiDevice::AllDevices, constantBufferPoolDesc);
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialized constant buffer pool");
         }
 

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -95,10 +95,10 @@ namespace AtomSampleViewer
 
     void TrianglesConstantBufferExampleComponent::UploadDataToConstantBuffer(InstanceInfo* data, uint32_t elementSize, uint32_t elementCount)
     {
-        AZ::RHI::MultiDeviceBufferMapRequest mapRequest;
+        AZ::RHI::BufferMapRequest mapRequest;
         mapRequest.m_buffer = m_constantBuffer.get();
         mapRequest.m_byteCount = elementSize * elementCount;
-        AZ::RHI::MultiDeviceBufferMapResponse mapResponse;
+        AZ::RHI::BufferMapResponse mapResponse;
         AZ::RHI::ResultCode resultCode = m_constantBufferPool->MapBuffer(mapRequest, mapResponse);
         if (resultCode == AZ::RHI::ResultCode::Success)
         {
@@ -120,7 +120,7 @@ namespace AtomSampleViewer
 
         // Creates Input Assembly buffer and Streams/Index Views
         {
-            m_inputAssemblyBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_inputAssemblyBufferPool = aznew RHI::BufferPool();
 
             RHI::BufferPoolDescriptor bufferPoolDesc;
             bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
@@ -139,9 +139,9 @@ namespace AtomSampleViewer
 
             SetVertexIndexIncreasing(bufferData.m_indices.data(), bufferData.m_indices.size());
 
-            m_inputAssemblyBuffer = aznew RHI::MultiDeviceBuffer();
+            m_inputAssemblyBuffer = aznew RHI::Buffer();
 
-            RHI::MultiDeviceBufferInitRequest request;
+            RHI::BufferInitRequest request;
             request.m_buffer = m_inputAssemblyBuffer.get();
             request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::InputAssembly, sizeof(bufferData) };
             request.m_initialData = &bufferData;
@@ -181,7 +181,7 @@ namespace AtomSampleViewer
 
         // Create the buffer pool where both buffers get allocated from
         {
-            m_constantBufferPool = aznew RHI::MultiDeviceBufferPool();
+            m_constantBufferPool = aznew RHI::BufferPool();
             RHI::BufferPoolDescriptor constantBufferPoolDesc;
             constantBufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::Constant;
             constantBufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
@@ -263,9 +263,11 @@ namespace AtomSampleViewer
                 drawIndexed.m_indexCount = 3;
                 drawIndexed.m_instanceCount = s_numberOfTrianglesTotal;
 
-                const RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                RHI::SingleDeviceDrawItem drawItem;
+                RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -273,8 +275,10 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
@@ -303,8 +307,8 @@ namespace AtomSampleViewer
         using namespace AZ;
         const uint32_t constantBufferSize = sizeof(InstanceInfo) * s_numberOfTrianglesTotal;
 
-        m_constantBuffer = aznew RHI::MultiDeviceBuffer();
-        RHI::MultiDeviceBufferInitRequest request;
+        m_constantBuffer = aznew RHI::Buffer();
+        RHI::BufferInitRequest request;
         request.m_buffer = m_constantBuffer.get();
         request.m_descriptor = RHI::BufferDescriptor{ RHI::BufferBindFlags::Constant, constantBufferSize };
         [[maybe_unused]] RHI::ResultCode result = m_constantBufferPool->InitBuffer(request);

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -20,8 +20,8 @@
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -88,22 +88,22 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_inputAssemblyBufferPool;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::IndexBufferView m_indexBufferView;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_constantBufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_constantBufferPool;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_constantBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_constantBuffer;
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferView> m_constantBufferView;
+        AZ::RHI::Ptr<AZ::RHI::BufferView> m_constantBufferView;
 
         // --------------------------------------------------------
         // Pipeline state and SRG to be constructed from the shader
         // --------------------------------------------------------
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.cpp
@@ -172,7 +172,7 @@ namespace AtomSampleViewer
         m_imagePool = aznew RHI::MultiDeviceImagePool();
         RHI::ImagePoolDescriptor imagePoolDesc;
         imagePoolDesc.m_bindFlags = RHI::ImageBindFlags::ShadingRate | RHI::ImageBindFlags::ShaderReadWrite;
-        m_imagePool->Init(RHI::MultiDevice::DefaultDevice, imagePoolDesc);
+        m_imagePool->Init(RHI::MultiDevice::AllDevices, imagePoolDesc);
 
         // Initialize the shading rate images with proper values. Invalid values may cause a crash.
         uint32_t width = static_cast<uint32_t>(m_shadingRateImageSize.GetX());
@@ -216,13 +216,8 @@ namespace AtomSampleViewer
             request.m_image = image.get();
             request.m_sourceData = shadingRatePatternData.data();
             request.m_sourceSubresourceLayout = RHI::MultiDeviceImageSubresourceLayout();
-            request.m_sourceSubresourceLayout.Init(RHI::MultiDevice::DefaultDevice, {
-                RHI::Size(width, height, 1),
-                height,
-                width * formatSize,
-                bufferSize,
-                1,
-                1});
+            request.m_sourceSubresourceLayout.Init(
+                RHI::MultiDevice::AllDevices, { RHI::Size(width, height, 1), height, width * formatSize, bufferSize, 1, 1 });
 
             m_imagePool->UpdateImageContents(request);
         }        
@@ -448,7 +443,7 @@ namespace AtomSampleViewer
         RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = RHI::HeapMemoryLevel::Device;
-        m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
 
         struct BufferData
         {

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
@@ -20,13 +20,13 @@
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 
-#include <Atom/RHI/MultiDeviceBufferPool.h>
-#include <Atom/RHI/MultiDeviceDrawItem.h>
+#include <Atom/RHI/BufferPool.h>
 #include <Atom/RHI/Device.h>
+#include <Atom/RHI/DeviceCopyItem.h>
+#include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/SingleDeviceCopyItem.h>
 #include <Atom/RHI/FrameScheduler.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 
 #include <RHI/BasicRHIComponent.h>
 #include <Utils/ImGuiSidebar.h>
@@ -107,11 +107,11 @@ namespace AtomSampleViewer
         AZ::RHI::ShadingRate m_shadingRate = AZ::RHI::ShadingRate::Rate1x1;
 
         // Pipelines used for rendering the full screen quad with and without a shading rate attachments.
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_modelPipelineState[2];
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_modelPipelineState[2];
         // Pipeline used for updating the shading rate image.
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_computePipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_computePipelineState;
         // Pipeline used for showing the shading rate image.
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_imagePipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_imagePipelineState;
         // Compute and graphics shaders.
         AZStd::vector<AZ::Data::Instance<AZ::RPI::Shader>> m_shaders;
         // SRG with information when rendering the full screen quad.
@@ -133,20 +133,20 @@ namespace AtomSampleViewer
         int m_numThreadsZ = 1;
 
         // Bufferpool for creating the IA buffer
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
         // Buffer for the IA of the full screen quad.
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
         // Bufferviews into the full screen quad IA
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
         // Indexview of the full screen quad index buffer
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
+        AZ::RHI::IndexBufferView m_indexBufferView;
         // Layout of the full screen quad.
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // Image pool containing the shading rate images.
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceImagePool> m_imagePool;
+        AZ::RHI::Ptr<AZ::RHI::ImagePool> m_imagePool;
         // List of shading rate images used as attachments.
-        AZStd::fixed_vector<AZ::RHI::Ptr<AZ::RHI::MultiDeviceImage>, AZ::RHI::Limits::Device::FrameCountMax> m_shadingRateImages;
+        AZStd::fixed_vector<AZ::RHI::Ptr<AZ::RHI::Image>, AZ::RHI::Limits::Device::FrameCountMax> m_shadingRateImages;
 
         // Cursor position (mouse or touch)
         AZ::Vector2 m_cursorPos;

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -194,7 +194,7 @@ namespace AtomSampleViewer
         const AZ::RHI::Ptr<AZ::RHI::Device> device = Utils::GetRHIDevice();
         AZ::RHI::ResultCode result = AZ::RHI::ResultCode::Success;
 
-        m_bufferPool = aznew AZ::RHI::MultiDeviceBufferPool();
+        m_bufferPool = aznew AZ::RHI::BufferPool();
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
@@ -207,8 +207,8 @@ namespace AtomSampleViewer
 
         SingleCubeBufferData bufferData = CreateSingleCubeBufferData();
 
-        m_inputAssemblyBuffer = aznew AZ::RHI::MultiDeviceBuffer();
-        AZ::RHI::MultiDeviceBufferInitRequest request;
+        m_inputAssemblyBuffer = aznew AZ::RHI::Buffer();
+        AZ::RHI::BufferInitRequest request;
 
         request.m_buffer = m_inputAssemblyBuffer.get();
         request.m_descriptor = AZ::RHI::BufferDescriptor{ AZ::RHI::BufferBindFlags::InputAssembly, sizeof(SingleCubeBufferData) };
@@ -373,9 +373,11 @@ namespace AtomSampleViewer
 
             for (uint32_t i = indexStart; i < indexEnd; ++i)
             {
-                const AZ::RHI::SingleDeviceShaderResourceGroup* shaderResourceGroups[] = { m_shaderResourceGroups[i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get() };
+                const AZ::RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
+                    m_shaderResourceGroups[i]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
+                };
 
-                AZ::RHI::SingleDeviceDrawItem drawItem;
+                AZ::RHI::DeviceDrawItem drawItem;
                 drawItem.m_arguments = drawIndexed;
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
                 auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
@@ -383,8 +385,10 @@ namespace AtomSampleViewer
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
                 drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::SingleDeviceStreamBufferView, 2> deviceStreamBufferViews{m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()), 
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())};
+                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
+                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
+                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
+                };
                 drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -198,7 +198,7 @@ namespace AtomSampleViewer
         AZ::RHI::BufferPoolDescriptor bufferPoolDesc;
         bufferPoolDesc.m_bindFlags = AZ::RHI::BufferBindFlags::InputAssembly;
         bufferPoolDesc.m_heapMemoryLevel = AZ::RHI::HeapMemoryLevel::Device;
-        result = m_bufferPool->Init(RHI::MultiDevice::DefaultDevice, bufferPoolDesc);
+        result = m_bufferPool->Init(RHI::MultiDevice::AllDevices, bufferPoolDesc);
         if (result != AZ::RHI::ResultCode::Success)
         {
             AZ_Error("XRExampleComponent", false, "Failed to initialize buffer pool with error code %d", result);

--- a/Gem/Code/Source/RHI/XRExampleComponent.h
+++ b/Gem/Code/Source/RHI/XRExampleComponent.h
@@ -16,8 +16,8 @@
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/Device.h>
 #include <Atom/RHI/Factory.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
-#include <Atom/RHI/MultiDeviceBufferPool.h>
+#include <Atom/RHI/PipelineState.h>
+#include <Atom/RHI/BufferPool.h>
 
 #include <AzCore/Math/Matrix4x4.h>
 
@@ -93,11 +93,11 @@ namespace AtomSampleViewer
         //! Create the relevant Scope
         void CreateScope();
 
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBufferPool> m_bufferPool;
-        AZ::RHI::MultiDeviceIndexBufferView m_indexBufferView;
-        AZ::RHI::Ptr<AZ::RHI::MultiDeviceBuffer> m_inputAssemblyBuffer;
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
+        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
         AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
 
         struct BufferData
         {
@@ -106,7 +106,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::MultiDeviceStreamBufferView, 2> m_streamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
         float m_time = 0.0f;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumberOfCubes> m_shaderResourceGroups;
         AZStd::array<AZ::Matrix4x4, NumberOfCubes> m_modelMatrices;

--- a/Gem/Code/Source/ReadbackExampleComponent.cpp
+++ b/Gem/Code/Source/ReadbackExampleComponent.cpp
@@ -276,7 +276,7 @@ namespace AtomSampleViewer
 
     void ReadbackExampleComponent::ReadbackCallback(const AZ::RPI::AttachmentReadback::ReadbackResult& result)
     {
-        AZ::RHI::MultiDeviceImageSubresourceLayout layout;
+        AZ::RHI::ImageSubresourceLayout layout;
         m_previewImage->GetRHIImage()->GetSubresourceLayout(layout);
 
         m_textureNeedsUpdate = true;
@@ -290,9 +290,9 @@ namespace AtomSampleViewer
 
     void ReadbackExampleComponent::UploadReadbackResult() const
     {
-        AZ::RHI::MultiDeviceImageSubresourceLayout layout;
+        AZ::RHI::ImageSubresourceLayout layout;
         m_previewImage->GetRHIImage()->GetSubresourceLayout(layout);
-        AZ::RHI::MultiDeviceImageUpdateRequest updateRequest;
+        AZ::RHI::ImageUpdateRequest updateRequest;
         updateRequest.m_image = m_previewImage->GetRHIImage();
         updateRequest.m_sourceSubresourceLayout = layout;
         updateRequest.m_sourceData = m_resultData->begin();

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -20,8 +20,8 @@
 #include <Atom/Component/DebugCamera/NoClipControllerComponent.h>
 #include <Atom/Feature/CoreLights/CoreLightsConstants.h>
 
-#include <Atom/RHI/MultiDeviceDrawPacket.h>
-#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/DrawPacket.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 
@@ -303,14 +303,14 @@ namespace AtomSampleViewer
                 auto const& mesh = meshes[i];
 
                 // Build draw packet and set the values of the inline constants.
-                RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
+                RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
                 drawPacketBuilder.Begin(nullptr);
                 drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
                 drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
                 drawPacketBuilder.SetRootConstants(m_rootConstantData.GetConstantData());
                 drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup());
 
-                RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
+                RHI::DrawPacketBuilder::DrawRequest drawRequest;
                 drawRequest.m_listTag = m_drawListTag;
                 drawRequest.m_pipelineState = m_pipelineState.get();
                 drawRequest.m_streamBufferViews = m_modelStreamBufferViews[modelIndex][i];

--- a/Gem/Code/Source/RootConstantsExampleComponent.h
+++ b/Gem/Code/Source/RootConstantsExampleComponent.h
@@ -12,8 +12,8 @@
 
 #include <Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h>
 
-#include <Atom/RHI/MultiDeviceIndexBufferView.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/IndexBufferView.h>
+#include <Atom/RHI/PipelineState.h>
 #include <Atom/RHI/DrawList.h>
 #include <Atom/RHI/ConstantsData.h>
 
@@ -75,7 +75,7 @@ namespace AtomSampleViewer
         AZ::Render::DirectionalLightFeatureProcessorInterface* m_directionalLightFeatureProcessor = nullptr;
 
         // Render related data
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::RHI::DrawListTag m_drawListTag;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_srg;
 

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -92,6 +92,7 @@
 #include <LightCullingExampleComponent.h>
 #include <MeshExampleComponent.h>
 #include <MSAA_RPI_ExampleComponent.h>
+#include <MultiGPURPIExampleComponent.h>
 #include <MultiRenderPipelineExampleComponent.h>
 #include <MultiSceneExampleComponent.h>
 #include <ParallaxMappingExampleComponent.h>
@@ -308,6 +309,7 @@ namespace AtomSampleViewer
             NewRPISample<DynamicMaterialTestComponent>("DynamicMaterialTest"),
             NewRPISample<MeshExampleComponent>("Mesh"),
             NewRPISample<MSAA_RPI_ExampleComponent>("MSAA"),
+            NewRPISample<MultiGPURPIExampleComponent>("MultiGPU", []() { return AZ::RHI::RHISystemInterface::Get()->GetDeviceCount() >= 2; }),
             NewRPISample<MultiRenderPipelineExampleComponent>("MultiRenderPipeline"),
             NewRPISample<MultiSceneExampleComponent>("MultiScene"),
             NewRPISample<MultiViewSingleSceneAuxGeomExampleComponent>("MultiViewSingleSceneAuxGeom"),

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -52,6 +52,7 @@
 #include <RHI/MRTExampleComponent.h>
 #include <RHI/MSAAExampleComponent.h>
 #include <RHI/MultiThreadComponent.h>
+#include <RHI/MultiGPUExampleComponent.h>
 #include <RHI/MultiViewportSwapchainComponent.h>
 #include <RHI/MultipleViewsComponent.h>
 #include <RHI/QueryExampleComponent.h>
@@ -280,6 +281,7 @@ namespace AtomSampleViewer
             NewRHISample<MultipleViewsComponent>("MultipleViews"),
             NewRHISample<MRTExampleComponent>("MultiRenderTarget"),
             NewRHISample<MultiThreadComponent>("MultiThread"),
+            NewRHISample<MultiGPUExampleComponent>("MultiGPU", []() { return AZ::RHI::RHISystemInterface::Get()->GetDeviceCount() >= 2; }),
             NewRHISample<MultiViewportSwapchainComponent>("MultiViewportSwapchainComponent", [] { return IsMultiViewportSwapchainSampleSupported(); }),
             NewRHISample<QueryExampleComponent>("Queries"),
             NewRHISample<RayTracingExampleComponent>("RayTracing", []() {return Utils::GetRHIDevice()->GetFeatures().m_rayTracing; }),

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -6,8 +6,8 @@
  *
  */
 
-#include <Atom/RHI/MultiDeviceDrawPacket.h>
-#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/DrawPacket.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
 
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
@@ -55,7 +55,7 @@ namespace AtomSampleViewer
             const char* srgName,
             Data::Asset<AZ::RPI::ShaderAsset>& shaderAsset,
             RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout>& srgLayout,
-            RHI::ConstPtr<RHI::MultiDevicePipelineState>& pipelineState,
+            RHI::ConstPtr<RHI::PipelineState>& pipelineState,
             RHI::DrawListTag& drawListTag,
             RPI::Scene* scene)
         {
@@ -390,7 +390,7 @@ namespace AtomSampleViewer
             size_t budgetInBytes = memoryUsage.m_budgetInBytes;
             int budgetInMB = aznumeric_cast<int>(budgetInBytes/MB);
             ImGui::Text("GPU memory budget: %d MB", budgetInMB);
-            if (ScriptableImGui::SliderInt("MB", &budgetInMB, RHI::SingleDeviceStreamingImagePool::ImagePoolMininumSizeInBytes/MB, 512))
+            if (ScriptableImGui::SliderInt("MB", &budgetInMB, RHI::DeviceStreamingImagePool::ImagePoolMininumSizeInBytes / MB, 512))
             {
                 streamingImagePool->SetMemoryBudget(budgetInMB * (1024*1024));
             }
@@ -490,14 +490,14 @@ namespace AtomSampleViewer
         for (Image3dToDraw& image3d : m_3dImages)
         {
             // Build draw packet...
-            RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
+            RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
             drawPacketBuilder.Begin(nullptr);
             RHI::DrawLinear drawLinear;
             drawLinear.m_vertexCount = 4;
             drawLinear.m_instanceCount = image3d.m_sliceCount;
             drawPacketBuilder.SetDrawArguments(drawLinear);
 
-            RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
+            RHI::DrawPacketBuilder::DrawRequest drawRequest;
             drawRequest.m_listTag = m_image3dDrawListTag;
             drawRequest.m_pipelineState = m_image3dPipelineState.get();
             drawRequest.m_sortKey = 0;
@@ -513,14 +513,14 @@ namespace AtomSampleViewer
     void StreamingImageExampleComponent::DrawImage(const ImageToDraw* imageInfo)
     {
         // Build draw packet...
-        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
+        RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
         RHI::DrawLinear drawLinear;
         drawLinear.m_vertexCount = 4;
         drawLinear.m_instanceCount = imageInfo->m_image->GetMipLevelCount();
         drawPacketBuilder.SetDrawArguments(drawLinear);
 
-        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
+        RHI::DrawPacketBuilder::DrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;
@@ -653,7 +653,7 @@ namespace AtomSampleViewer
         // will be uploaded with a single command
         {
             AZStd::vector<uint8_t> imageData;
-            RHI::SingleDeviceImageSubresourceLayout layout;
+            RHI::DeviceImageSubresourceLayout layout;
             RHI::Format format = {};
             BasicRHIComponent::CreateImage3dData(imageData, layout, format, {
                                                             "textures/streaming/streaming13.dds.streamingimage",

--- a/Gem/Code/Source/StreamingImageExampleComponent.h
+++ b/Gem/Code/Source/StreamingImageExampleComponent.h
@@ -10,8 +10,8 @@
 
 #include <CommonSampleComponentBase.h>
 
-#include <Atom/RHI/MultiDeviceIndexBufferView.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/IndexBufferView.h>
+#include <Atom/RHI/PipelineState.h>
 #include <Atom/RHI/DrawList.h>
 
 #include <Atom/RPI.Public/DynamicDraw/DynamicDrawInterface.h>
@@ -171,8 +171,8 @@ namespace AtomSampleViewer
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;
 
         // render related data
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_image3dPipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_image3dPipelineState;
 
         AZ::RHI::DrawListTag m_drawListTag;
         AZ::RHI::DrawListTag m_image3dDrawListTag;

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -20,7 +20,7 @@
 
 #include <Atom/Feature/Utils/FrameCaptureBus.h>
 
-#include <Atom/RHI/MultiDeviceDrawPacketBuilder.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
 
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
@@ -205,7 +205,7 @@ namespace AtomSampleViewer
             const char* srgName,
             Data::Asset<AZ::RPI::ShaderAsset>& shaderAsset,
             RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout>& srgLayout,
-            RHI::ConstPtr<RHI::MultiDevicePipelineState>& pipelineState,
+            RHI::ConstPtr<RHI::PipelineState>& pipelineState,
             RHI::DrawListTag& drawListTag,
             RPI::Scene* scene)
         {
@@ -271,13 +271,13 @@ namespace AtomSampleViewer
     void TonemappingExampleComponent::DrawImage(const ImageToDraw* imageInfo)
     {
         // Build draw packet
-        RHI::MultiDeviceDrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
+        RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
         RHI::DrawLinear drawLinear;
         drawLinear.m_vertexCount = 4;
         drawPacketBuilder.SetDrawArguments(drawLinear);
 
-        RHI::MultiDeviceDrawPacketBuilder::MultiDeviceDrawRequest drawRequest;
+        RHI::DrawPacketBuilder::DrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;

--- a/Gem/Code/Source/TonemappingExampleComponent.h
+++ b/Gem/Code/Source/TonemappingExampleComponent.h
@@ -86,7 +86,7 @@ namespace AtomSampleViewer
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;
 
         // render related data
-        AZ::RHI::ConstPtr<AZ::RHI::MultiDevicePipelineState> m_pipelineState;
+        AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::RHI::DrawListTag m_drawListTag;
         AZ::Data::Asset<AZ::RPI::ShaderAsset> m_shaderAsset;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout> m_srgLayout;

--- a/Gem/Code/Source/Utils/Utils.cpp
+++ b/Gem/Code/Source/Utils/Utils.cpp
@@ -214,7 +214,7 @@ namespace AtomSampleViewer
 
             uint32_t pitch = width * pixelSize;
 
-            AZ::RHI::SingleDeviceImageSubresourceLayout layout;
+            AZ::RHI::DeviceImageSubresourceLayout layout;
             layout.m_bytesPerImage = pixelDataSize;
             layout.m_rowCount = layout.m_bytesPerImage / pitch;
             layout.m_size = AZ::RHI::Size(width, height, 1);

--- a/Gem/Code/Source/Utils/Utils.h
+++ b/Gem/Code/Source/Utils/Utils.h
@@ -10,7 +10,7 @@
 #include <AzFramework/Windowing/WindowBus.h>
 
 #include <Atom/RHI/Device.h>
-#include <Atom/RHI/MultiDevicePipelineState.h>
+#include <Atom/RHI/PipelineState.h>
 
 #include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Image/StreamingImage.h>

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -143,6 +143,8 @@ set(FILES
     Source/MeshExampleComponent.h
     Source/MSAA_RPI_ExampleComponent.cpp
     Source/MSAA_RPI_ExampleComponent.h
+    Source/MultiGPURPIExampleComponent.cpp
+    Source/MultiGPURPIExampleComponent.h
     Source/MultiRenderPipelineExampleComponent.cpp
     Source/MultiRenderPipelineExampleComponent.h
     Source/MultiSceneExampleComponent.cpp

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -53,6 +53,8 @@ set(FILES
     Source/RHI/MRTExampleComponent.cpp
     Source/RHI/MSAAExampleComponent.h
     Source/RHI/MSAAExampleComponent.cpp
+    Source/RHI/MultiGPUExampleComponent.cpp
+    Source/RHI/MultiGPUExampleComponent.h
     Source/RHI/MultiThreadComponent.cpp
     Source/RHI/MultiThreadComponent.h
     Source/RHI/MultipleViewsComponent.cpp

--- a/Passes/ASV/PassTemplates.azasset
+++ b/Passes/ASV/PassTemplates.azasset
@@ -69,6 +69,22 @@
                 "Path": "Passes/MultiGPUPipeline.pass"
             },
             {
+                "Name": "MultiGPUCopyTestPipeline",
+                "Path": "Passes/MultiGPUCopyTestPipeline.pass"
+            },
+            {
+                "Name": "MultiGPUCopyImageToBufferPassTemplate",
+                "Path": "Passes/MultiGPUCopyImageToBuffer.pass"
+            },
+            {
+                "Name": "MultiGPUCopyBufferToBufferPassTemplate",
+                "Path": "Passes/MultiGPUCopyBufferToBuffer.pass"
+            },
+            {
+                "Name": "MultiGPUCopyBufferToImagePassTemplate",
+                "Path": "Passes/MultiGPUCopyBufferToImage.pass"
+            },
+            {
                 "Name": "MultiGPUCompositePassTemplate",
                 "Path": "Passes/MultiGPUCompositePass.pass"
             },

--- a/Passes/ASV/PassTemplates.azasset
+++ b/Passes/ASV/PassTemplates.azasset
@@ -65,6 +65,18 @@
                 "Path": "Passes/FullscreenPipeline.pass"
             },
             {
+                "Name": "MultiGPUPipeline",
+                "Path": "Passes/MultiGPUPipeline.pass"
+            },
+            {
+                "Name": "MultiGPUCompositePassTemplate",
+                "Path": "Passes/MultiGPUCompositePass.pass"
+            },
+            {
+                "Name": "MultiGPUTrianglePassTemplate",
+                "Path": "Passes/MultiGPUTrianglePass.pass"
+            },
+            {
                 "Name": "ReadbackFillerPassTemplate",
                 "Path": "Passes/ReadbackFiller.pass"
             },

--- a/Passes/MultiGPUCompositePass.pass
+++ b/Passes/MultiGPUCompositePass.pass
@@ -1,0 +1,54 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MultiGPUCompositePassTemplate",
+            "PassClass": "FullScreenTriangle",
+            "Slots": [
+                {
+                    "Name": "Input1",
+                    "ShaderInputName": "m_image1",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "Input2",
+                    "ShaderInputName": "m_image2",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Shader"
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "Parent",
+                            "Attachment": "PipelineOutput"
+                        }
+                    },
+                    "FormatSource": {
+                        "Pass": "Parent",
+                        "Attachment": "PipelineOutput"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Passes/MultiGPUCopyBufferToBuffer.pass
+++ b/Passes/MultiGPUCopyBufferToBuffer.pass
@@ -1,0 +1,52 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MultiGPUCopyImageToBufferPassTemplate",
+            "PassClass": "CopyPass",
+            "Slots": [
+                {
+                    "Name": "Input",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Copy",
+                    "BufferViewDesc": {
+                        "m_elementOffset": 0,
+                        "m_elementCount": 153600,
+                        "m_elementSize": 4
+                    }
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "Copy",
+                    "BufferViewDesc": {
+                        "m_elementOffset": 0,
+                        "m_elementCount": 153600,
+                        "m_elementSize": 4
+                    }
+                }
+            ],
+            "BufferAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "BufferDescriptor": {
+                        "m_byteCount": 614400,
+                        "m_alignment": 16,
+                        "m_bindFlags": "ShaderReadWrite"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Passes/MultiGPUCopyBufferToImage.pass
+++ b/Passes/MultiGPUCopyBufferToImage.pass
@@ -1,0 +1,50 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MultiGPUCopyImageToBufferPassTemplate",
+            "PassClass": "CopyPass",
+            "Slots": [
+                {
+                    "Name": "Input",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Copy",
+                    "BufferViewDesc": {
+                        "m_elementOffset": 0,
+                        "m_elementCount": 153600,
+                        "m_elementSize": 4
+                    }
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "Copy"
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "ImageDescriptor": {
+                        "Format": "R8G8B8A8_UNORM",
+                        "Size": {
+                            "Width": 320,
+                            "Height": 480,
+                            "Depth": 1
+                        }
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Passes/MultiGPUCopyImageToBuffer.pass
+++ b/Passes/MultiGPUCopyImageToBuffer.pass
@@ -1,0 +1,47 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MultiGPUCopyImageToBufferPassTemplate",
+            "PassClass": "CopyPass",
+            "Slots": [
+                {
+                    "Name": "Input",
+                    "SlotType": "Input",
+                    "ScopeAttachmentUsage": "Copy"
+                },
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "Copy",
+                    "BufferViewDesc": {
+                        "m_elementOffset": 0,
+                        "m_elementCount": 153600,
+                        "m_elementSize": 4
+                    }
+                }
+            ],
+            "BufferAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "BufferDescriptor": {
+                        "m_byteCount": 614400,
+                        "m_alignment": 16,
+                        "m_bindFlags": "ShaderReadWrite"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Passes/MultiGPUCopyTestPipeline.pass
+++ b/Passes/MultiGPUCopyTestPipeline.pass
@@ -4,7 +4,7 @@
     "ClassName": "PassAsset",
     "ClassData": {
         "PassTemplate": {
-            "Name": "MultiGPUPipeline",
+            "Name": "MultiGPUCopyTestPipeline",
             "PassClass": "ParentPass",
             "Slots": [
                 {
@@ -16,32 +16,24 @@
             "ImageAttachments": [
                 {
                     "Name": "TriangleAttachment1",
-                    "SizeSource": {
-                        "Source": {
-                            "Pass": "This",
-                            "Attachment": "PipelineOutput"
-                        },
-                        "Multipliers": {
-                            "WidthMultiplier": "0.5"
-                        }
-                    },
                     "ImageDescriptor": {
-                        "Format": "R8G8B8A8_UNORM"
+                        "Format": "R8G8B8A8_UNORM",
+                        "Size": {
+                            "Width": 320,
+                            "Height": 480,
+                            "Depth": 1
+                        }
                     }
                 },
                 {
                     "Name": "TriangleAttachment2",
-                    "SizeSource": {
-                        "Source": {
-                            "Pass": "This",
-                            "Attachment": "PipelineOutput"
-                        },
-                        "Multipliers": {
-                            "WidthMultiplier": "0.5"
-                        }
-                    },
                     "ImageDescriptor": {
-                        "Format": "R8G8B8A8_UNORM"
+                        "Format": "R8G8B8A8_UNORM",
+                        "Size": {
+                            "Width": 320,
+                            "Height": 480,
+                            "Depth": 1
+                        }
                     }
                 }
             ],
@@ -136,18 +128,11 @@
                     }
                 },
                 {
-                    "Name": "CopyPass",
-                    "TemplateName": "CopyPassTemplate",
+                    "Name": "CopyPass1",
+                    "TemplateName": "MultiGPUCopyImageToBufferPassTemplate",
                     "Connections": [
                         {
                             "LocalSlot": "Input",
-                            "AttachmentRef": {
-                                "Pass": "TrianglePass2",
-                                "Attachment": "Output"
-                            }
-                        },
-                        {
-                            "LocalSlot": "Output",
                             "AttachmentRef": {
                                 "Pass": "TrianglePass2",
                                 "Attachment": "Output"
@@ -156,8 +141,92 @@
                     ],
                     "PassData": {
                         "$type": "CopyPassData",
+                        "CloneInput": false,
+                        "SourceDeviceIndex": 1,
+                        "DestinationDeviceIndex": 0
+                    }
+                },
+                {
+                    "Name": "CopyPass2",
+                    "TemplateName": "MultiGPUCopyBufferToBufferPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "CopyPass1",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "CopyPassData",
+                        "CloneInput": true,
+                        "SourceDeviceIndex": 0,
+                        "DestinationDeviceIndex": 1
+                    }
+                },
+                {
+                    "Name": "CopyPass3",
+                    "TemplateName": "MultiGPUCopyBufferToImagePassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "CopyPass2",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "CopyPassData",
+                        "CloneInput": false,
+                        "SourceDeviceIndex": 1,
                         "DestinationDeviceIndex": 0,
-                        "SourceDeviceIndex": 1
+                        "BufferSourceOffset": 0,
+                        "BufferSourceBytesPerRow": 1280,
+                        "BufferSourceBytesPerImage": 614400,
+                        "ImageSourceSize": {
+                            "Width": 320,
+                            "Height": 480
+                        }
+                    }
+                },
+                {
+                    "Name": "CopyPass4",
+                    "TemplateName": "CopyPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "CopyPass3",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "CopyPassData",
+                        "CloneInput": true,
+                        "SourceDeviceIndex": 0,
+                        "DestinationDeviceIndex": 1
+                    }
+                },
+                {
+                    "Name": "CopyPass5",
+                    "TemplateName": "CopyPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "CopyPass4",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "CopyPassData",
+                        "CloneInput": true,
+                        "SourceDeviceIndex": 1,
+                        "DestinationDeviceIndex": 0
                     }
                 },
                 {
@@ -174,7 +243,7 @@
                         {
                             "LocalSlot": "Input2",
                             "AttachmentRef": {
-                                "Pass": "CopyPass",
+                                "Pass": "CopyPass5",
                                 "Attachment": "Output"
                             }
                         }

--- a/Passes/MultiGPUPipeline.pass
+++ b/Passes/MultiGPUPipeline.pass
@@ -1,0 +1,180 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MultiGPUPipeline",
+            "PassClass": "ParentPass",
+            "Slots": [
+                {
+                    "Name": "PipelineOutput",
+                    "SlotType": "InputOutput",
+                    "ScopeAttachmentUsage": "RenderTarget"
+                }
+            ],
+            "PassRequests": [
+                {
+                    "Name": "TrianglePass1",
+                    "TemplateName": "MultiGPUTrianglePassTemplate",
+                    "PassData": {
+                        "$type": "FullscreenTrianglePassData",
+                        "ShaderAsset": {
+                            "FilePath": "Shaders/MultiGPURPIExample/Triangle.shader"
+                        },
+                        "ShaderDataMappings": {
+                            "Matrix4x4Mappings": [
+                                {
+                                    "Name": "m_objectMatrix",
+                                    "Value": [
+                                        2.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0,
+                                        0.0,
+                                        1.0,
+                                        0.0,
+                                        0.0,
+                                        1.0
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "Name": "TrianglePass2",
+                    "TemplateName": "MultiGPUTrianglePassTemplate",
+                    "PassData": {
+                        "$type": "FullscreenTrianglePassData",
+                        "ShaderAsset": {
+                            "FilePath": "Shaders/MultiGPURPIExample/Triangle.shader"
+                        },
+                        "DeviceIndex": 1,
+                        "ShaderDataMappings": {
+                            "Matrix4x4Mappings": [
+                                {
+                                    "Name": "m_objectMatrix",
+                                    "Value": [
+                                        2.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0,
+                                        0.0,
+                                        -1.0,
+                                        0.0,
+                                        0.0,
+                                        1.0
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "Name": "CopyPass",
+                    "TemplateName": "CopyPassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "TrianglePass2",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "TrianglePass2",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "CopyPassData",
+                        "DestinationDeviceIndex": 0,
+                        "SourceDeviceIndex": 1
+                    }
+                },
+                {
+                    "Name": "CompositePass",
+                    "TemplateName": "MultiGPUCompositePassTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input1",
+                            "AttachmentRef": {
+                                "Pass": "TrianglePass1",
+                                "Attachment": "Output"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Input2",
+                            "AttachmentRef": {
+                                "Pass": "CopyPass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "FullscreenTrianglePassData",
+                        "ShaderAsset": {
+                            "FilePath": "Shaders/MultiGPURPIExample/Composite.shader"
+                        }
+                    }
+                },
+                {
+                    "Name": "ImGuiPass",
+                    "TemplateName": "ImGuiPassTemplate",
+                    "Enabled": true,
+                    "Connections": [
+                        {
+                            "LocalSlot": "InputOutput",
+                            "AttachmentRef": {
+                                "Pass": "CompositePass",
+                                "Attachment": "Output"
+                            }
+                        }
+                    ],
+                    "PassData": {
+                        "$type": "ImGuiPassData",
+                        "IsDefaultImGui": true
+                    }
+                },
+                {
+                    "Name": "CopyToSwapChain",
+                    "TemplateName": "FullscreenCopyTemplate",
+                    "Connections": [
+                        {
+                            "LocalSlot": "Input",
+                            "AttachmentRef": {
+                                "Pass": "ImGuiPass",
+                                "Attachment": "InputOutput"
+                            }
+                        },
+                        {
+                            "LocalSlot": "Output",
+                            "AttachmentRef": {
+                                "Pass": "Parent",
+                                "Attachment": "PipelineOutput"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/Passes/MultiGPUTrianglePass.pass
+++ b/Passes/MultiGPUTrianglePass.pass
@@ -23,32 +23,6 @@
                         "LoadAction": "Clear"
                     }
                 }
-            ],
-            "ImageAttachments": [
-                {
-                    "Name": "OutputAttachment",
-                    "SizeSource": {
-                        "Source": {
-                            "Pass": "Parent",
-                            "Attachment": "PipelineOutput"
-                        },
-                        "Multipliers": {
-                            "WidthMultiplier": "0.5"
-                        }
-                    },
-                    "ImageDescriptor": {
-                        "Format": "R8G8B8A8_UNORM"
-                    }
-                }
-            ],
-            "Connections": [
-                {
-                    "LocalSlot": "Output",
-                    "AttachmentRef": {
-                        "Pass": "This",
-                        "Attachment": "OutputAttachment"
-                    }
-                }
             ]
         }
     }

--- a/Passes/MultiGPUTrianglePass.pass
+++ b/Passes/MultiGPUTrianglePass.pass
@@ -1,0 +1,55 @@
+{
+    "Type": "JsonSerialization",
+    "Version": 1,
+    "ClassName": "PassAsset",
+    "ClassData": {
+        "PassTemplate": {
+            "Name": "MultiGPUTrianglePassTemplate",
+            "PassClass": "FullScreenTriangle",
+            "Slots": [
+                {
+                    "Name": "Output",
+                    "SlotType": "Output",
+                    "ScopeAttachmentUsage": "RenderTarget",
+                    "LoadStoreAction": {
+                        "ClearValue": {
+                            "Value": [
+                                0.0,
+                                0.0,
+                                0.0,
+                                0.0
+                            ]
+                        },
+                        "LoadAction": "Clear"
+                    }
+                }
+            ],
+            "ImageAttachments": [
+                {
+                    "Name": "OutputAttachment",
+                    "SizeSource": {
+                        "Source": {
+                            "Pass": "Parent",
+                            "Attachment": "PipelineOutput"
+                        },
+                        "Multipliers": {
+                            "WidthMultiplier": "0.5"
+                        }
+                    },
+                    "ImageDescriptor": {
+                        "Format": "R8G8B8A8_UNORM"
+                    }
+                }
+            ],
+            "Connections": [
+                {
+                    "LocalSlot": "Output",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "OutputAttachment"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/Shaders/MultiGPURPIExample/Composite.azsl
+++ b/Shaders/MultiGPURPIExample/Composite.azsl
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+#include <Atom/Features/PostProcessing/FullscreenPixelInfo.azsli>
+#include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
+
+ShaderResourceGroup PassSrg : SRG_PerPass
+{
+    Texture2D<float4> m_image1;
+    Texture2D<float4> m_image2;
+
+    Sampler m_sampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+}
+
+PSOutput MainPS(VSOutput IN)
+{
+    PSOutput OUT;
+
+    if(IN.m_texCoord.x <= 0.5)
+    {
+        OUT.m_color = PassSrg::m_image1.Sample(PassSrg::m_sampler, float2(IN.m_texCoord.x * 2, IN.m_texCoord.y));
+    }
+    else
+    {
+        OUT.m_color = PassSrg::m_image2.Sample(PassSrg::m_sampler, float2(IN.m_texCoord.x * 2 - 1, IN.m_texCoord.y));
+    }
+
+    return OUT;
+}

--- a/Shaders/MultiGPURPIExample/Composite.shader
+++ b/Shaders/MultiGPURPIExample/Composite.shader
@@ -1,0 +1,22 @@
+{
+    "Source" : "Composite.azsl",
+
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }
+    },
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    }
+}

--- a/Shaders/MultiGPURPIExample/Triangle.azsl
+++ b/Shaders/MultiGPURPIExample/Triangle.azsl
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+ShaderResourceGroup PassSrg : SRG_PerPass
+{
+    column_major float4x4 m_objectMatrix;
+}
+
+struct VSInput
+{
+    uint m_vertexID : SV_VertexID;
+};
+
+struct VSOutput
+{
+    float4 m_position : SV_Position;
+    float4 m_color : COLOR0;
+};
+
+VSOutput MainVS(VSInput vsInput)
+{
+    VSOutput OUT;
+
+    switch(vsInput.m_vertexID)
+    {
+    case 0:
+        OUT.m_position = float4(0.0,  0.5, 0.0, 1.0);
+        OUT.m_color = float4(1.0, 0.0, 0.0, 1.0);
+        break;
+    case 1:
+        OUT.m_position = float4(-0.5, -0.5, 0.0, 1.0);
+        OUT.m_color = float4(0.0, 1.0, 0.0, 1.0);
+        break;
+    default:
+        OUT.m_position = float4(0.5, -0.5, 0.0, 1.0);
+        OUT.m_color = float4(0.0, 0.0, 1.0, 1.0);
+        break;
+    }
+
+    OUT.m_position = mul(PassSrg::m_objectMatrix, OUT.m_position);
+
+    return OUT;
+}
+
+struct PSOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+PSOutput MainPS(VSOutput vsOutput)
+{
+    PSOutput OUT;
+
+    OUT.m_color = vsOutput.m_color;
+
+    // Simple tonemapping:
+    OUT.m_color.rgb = pow(OUT.m_color.rgb, 1.0/2.2);
+    return OUT;
+}

--- a/Shaders/MultiGPURPIExample/Triangle.shader
+++ b/Shaders/MultiGPURPIExample/Triangle.shader
@@ -1,0 +1,22 @@
+{
+    "Source" : "Triangle.azsl",
+
+    "DepthStencilState" : { 
+        "Depth" : { "Enable" : false, "CompareFunc" : "GreaterEqual" }
+    },
+
+    "ProgramSettings":
+    {
+      "EntryPoints":
+      [
+        {
+          "name": "MainVS",
+          "type": "Vertex"
+        },
+        {
+          "name": "MainPS",
+          "type": "Fragment"
+        }
+      ]
+    }
+}

--- a/Shaders/RHI/MultiGPUComposite.azsl
+++ b/Shaders/RHI/MultiGPUComposite.azsl
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+
+ShaderResourceGroup CompositeSrg : SRG_PerObject
+{
+    Texture2D m_inputTextureLeft;
+    Texture2D m_inputTextureRight;
+
+    Sampler m_sampler
+    {
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+}
+
+struct VSInput 
+{
+    float3 m_position : POSITION;
+    float2 m_uv : UV0;
+};
+
+struct VSOutput
+{
+    float4 m_position : SV_Position;
+    float2 m_uv : UV0;
+};
+
+VSOutput MainVS(VSInput vsInput)
+{
+    VSOutput OUT;
+    OUT.m_position = float4(vsInput.m_position, 1.0);
+    OUT.m_uv = vsInput.m_uv;
+    return OUT;
+}
+
+struct PSOutput
+{
+    float4 m_color : SV_Target0;
+};
+
+PSOutput MainPS(VSOutput psInput)
+{
+    PSOutput OUT;
+    if(psInput.m_uv.x <= 0.5)
+    {
+        OUT.m_color = CompositeSrg::m_inputTextureLeft.Sample(CompositeSrg::m_sampler, psInput.m_uv);
+    }
+    else
+    {
+        OUT.m_color = CompositeSrg::m_inputTextureRight.Sample(CompositeSrg::m_sampler, psInput.m_uv);
+    }
+	return OUT;
+}

--- a/Shaders/RHI/MultiGPUComposite.shader
+++ b/Shaders/RHI/MultiGPUComposite.shader
@@ -1,0 +1,22 @@
+{
+    "Source": "MultiGPUComposite.azsl",
+    "DepthStencilState": {
+        "Depth": {
+            "Enable": false,
+            "CompareFunc": "GreaterEqual"
+        }
+    },
+    "DrawList": "forward",
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "MainVS",
+                "type": "Vertex"
+            },
+            {
+                "name": "MainPS",
+                "type": "Fragment"
+            }
+        ]
+    }
+}

--- a/atomsampleviewer_asset_files.cmake
+++ b/atomsampleviewer_asset_files.cmake
@@ -117,6 +117,8 @@ set(FILES
     Shaders/RHI/MRTTarget.shader
     Shaders/RHI/MSAAResolve.azsl
     Shaders/RHI/MSAAResolve.shader
+    Shaders/RHI/MultiGPUComposite.azsl
+    Shaders/RHI/MultiGPUComposite.shader
     Shaders/RHI/MultipleViewsDepth.azsl
     Shaders/RHI/MultipleViewsDepth.shader
     Shaders/RHI/MultipleViewsShadow.azsl

--- a/atomsampleviewer_asset_files.cmake
+++ b/atomsampleviewer_asset_files.cmake
@@ -17,6 +17,9 @@ set(FILES
     Passes/CheckerboardPipeline.pass
     Passes/Fullscreen.pass
     Passes/FullscreenPipeline.pass
+    Passes/MultiGPUPipeline.pass
+    Passes/MultiGPUCompositePass.pass
+    Passes/MultiGPUTrianglePass.pass
     Passes/RayTracingAmbientOcclusion.pass
     Passes/ReadbackFiller.pass
     Passes/ReadbackPipeline.pass
@@ -26,6 +29,7 @@ set(FILES
     Passes/RHISamplePipeline.pass
     Passes/SelectorPass.pass
     Passes/SsaoPipeline.pass
+    Passes/ASV/PassTemplates.azasset
     scripts/AreaLightTest.bv.lua
     scripts/AuxGeom.bv.lua
     scripts/CheckerboardTest.bv.lua
@@ -63,6 +67,10 @@ set(FILES
     Shaders/Instanced.azsl
     Shaders/DynamicDraw/DynamicDrawExample.azsl
     Shaders/DynamicDraw/DynamicDrawExample.shader
+    Shaders/MultiGPURPIExample/Composite.azsl
+    Shaders/MultiGPURPIExample/Composite.shader
+    Shaders/MultiGPURPIExample/Triangle.azsl
+    Shaders/MultiGPURPIExample/Triangle.shader
     Shaders/OptimizationTests/DummyTransformColor.azsl
     Shaders/OptimizationTests/DummyTransformColor.shader
     Shaders/PostProcessing/ColorInvertCS.azsl


### PR DESCRIPTION
This PR introduces sample multi-GPU sample implementation for both RHI & RPI, both are based on the `TriangleExampleComponent`, which simply renders a triangle (the RHI sample also animates the position of the triangle).

Both cases split the screen in the middle, render the left half on device 0 and the right half on device 1. The right half is then copied over from device 1 to device 0 (either via a copy-ScopeProducer in the `RHI` sample or using the `CopyPass` in case of `RPI`) and composited there for the final output.

This PR also includes some commits that are already present in `development`, but not yet in `multi-device-resources` and will be removed in a rebase.
Also, some fixes are included as well, the full list of commits is
1. https://github.com/o3de/o3de-atom-sampleviewer/commit/234d1c289610ce14c6f70d45791ef7c0d7e91c74 (rebase remove)
2. https://github.com/o3de/o3de-atom-sampleviewer/commit/193f75cff9e8407ecd487c4d62e5375d39ea29fb (rebase remove)
3. Fixes for the build (mostly release build)
4. **RHI Sample**
5. **RPI Sample**
6. Fixes for `IndirectRenderingExample`
7. Rewrite deviceMasks from `DefaultDevice` to `AllDevices` to work correctly