### PR TITLE
Add option to migrate the second triangle pass.

### DIFF
--- a/Gem/Code/Source/MultiGPURPIExampleComponent.h
+++ b/Gem/Code/Source/MultiGPURPIExampleComponent.h
@@ -74,6 +74,8 @@ namespace AtomSampleViewer
 
         bool m_useCopyPipeline = false;
         bool m_currentlyUsingCopyPipline = false;
+        bool m_migrate = false;
+        bool m_currentlyMigrated = false;
     };
 
 } // namespace AtomSampleViewer


### PR DESCRIPTION
- By default runs on device 1 and migrates to device 0.
- Disables the copy pass when everything runs on device 0.
- Changes the input connection of the composite pass.