### PR TITLE
GeomtryView: Updated AtomSampleViewer to work with new GeometryView changes

### DIFF
--- a/Gem/Code/Source/BloomExampleComponent.cpp
+++ b/Gem/Code/Source/BloomExampleComponent.cpp
@@ -374,9 +374,8 @@ namespace AtomSampleViewer
         // Build draw packet
         RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
-        RHI::DrawLinear drawLinear;
-        drawLinear.m_vertexCount = 4;
-        drawPacketBuilder.SetDrawArguments(drawLinear);
+        m_geometryView.SetDrawArguments(RHI::DrawLinear(4, 0));
+        drawPacketBuilder.SetGeometryView(&m_geometryView);
 
         RHI::DrawPacketBuilder::DrawRequest drawRequest;
         drawRequest.m_listTag = m_drawListTag;

--- a/Gem/Code/Source/BloomExampleComponent.h
+++ b/Gem/Code/Source/BloomExampleComponent.h
@@ -98,6 +98,7 @@ namespace AtomSampleViewer
         AZ::RHI::DrawListTag m_drawListTag;
         AZ::Data::Asset<AZ::RPI::ShaderAsset> m_shaderAsset;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout> m_srgLayout;
+        AZ::RHI::GeometryView m_geometryView;
 
         // shader input indices
         AZ::RHI::ShaderInputNameIndex m_imageInputIndex = "m_texture";

--- a/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
+++ b/Gem/Code/Source/RHI/AlphaToCoverageExampleComponent.h
@@ -93,7 +93,7 @@ namespace AtomSampleViewer
         };
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_rectangleInputAssemblyBuffer;
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_rectangleStreamBufferViews;
+        AZ::RHI::GeometryView m_geometryView;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
 
         // Shader Resource

--- a/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/AsyncComputeExampleComponent.h
@@ -122,14 +122,13 @@ namespace AtomSampleViewer
         // Quad related variables
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_quadBufferPool;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_quadInputAssemblyBuffer;
-        AZ::RHI::IndexBufferView m_quadIndexBufferView;
-        AZStd::array<AZStd::vector<AZ::RHI::StreamBufferView>, NumScopes> m_quadStreamBufferViews;
+        AZStd::array<AZ::RHI::GeometryView, NumScopes> m_geometryViews;
 
         // Terrain related variables
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, NumScopes> m_terrainPipelineStates;
 
         // Model related variables
-        AZStd::array<AZ::RPI::ModelLod::StreamBufferViewList, NumScopes> m_modelStreamBufferViews;
+        AZStd::array<AZ::RHI::StreamBufferIndices, NumScopes> m_modelStreamBufferIndices;
         AZStd::array<AZ::RHI::ConstPtr<AZ::RHI::PipelineState>, NumScopes> m_modelPipelineStates;
         AZ::Data::Instance<AZ::RPI::Model> m_model;
 

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.h
@@ -131,8 +131,8 @@ namespace AtomSampleViewer
 
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_perSubMeshSrg;
 
-            const AZ::RPI::ModelLod::Mesh* m_mesh;
-            AZ::RPI::ModelLod::StreamBufferViewList bufferStreamViewArray;
+            AZ::RPI::ModelLod::Mesh* m_mesh;
+            AZ::RHI::StreamBufferIndices m_streamIndices;
 
             AZ::Matrix4x4 m_modelMatrix;
 

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -119,36 +119,35 @@ namespace AtomSampleViewer
         request.m_initialData = &bufferData;
         m_inputAssemblyBufferPool->InitBuffer(request);
 
-        m_streamBufferViews[0] =
-        {
+        m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 6, 0));
+
+        m_geometryView.AddStreamBufferView({
             *m_inputAssemblyBuffer,
             offsetof(BufferData, m_positions),
             sizeof(BufferData::m_positions),
             sizeof(VertexPosition)
-        };
+        });
 
-        m_streamBufferViews[1] =
-        {
+        m_geometryView.AddStreamBufferView({
             *m_inputAssemblyBuffer,
             offsetof(BufferData, m_uvs),
             sizeof(BufferData::m_uvs),
             sizeof(VertexUV)
-        };
+        });
 
-        m_indexBufferView =
-        {
+        m_geometryView.SetIndexBufferView({
             *m_inputAssemblyBuffer,
             offsetof(BufferData, m_indices),
             sizeof(BufferData::m_indices),
             RHI::IndexFormat::Uint16
-        };
+        });
 
         RHI::InputStreamLayoutBuilder layoutBuilder;
         layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
         layoutBuilder.AddBuffer()->Channel("UV", RHI::Format::R32G32_FLOAT);
         m_inputStreamLayout = layoutBuilder.End();
 
-        RHI::ValidateStreamBufferViews(m_inputStreamLayout, m_streamBufferViews);
+        RHI::ValidateStreamBufferViews(m_inputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
     }
 
     void ComputeExampleComponent::LoadComputeShader()
@@ -392,26 +391,15 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            RHI::DrawIndexed drawIndexed;
-            drawIndexed.m_indexCount = 6;
-            drawIndexed.m_instanceCount = 1;
-
             const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                 m_drawSRGs[0]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get(),
                 m_drawSRGs[1]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
             };
 
             RHI::DeviceDrawItem drawItem;
-            drawItem.m_arguments = drawIndexed;
+            drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+            drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
             drawItem.m_pipelineState = m_drawPipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-            auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
-            drawItem.m_indexBufferView = &deviceIndexBufferView;
-            drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-            };
-            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.h
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.h
@@ -83,8 +83,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::GeometryView m_geometryView;
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // ----------------------------

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -138,26 +138,35 @@ namespace AtomSampleViewer
                 return;
             }
 
-            m_streamBufferViews[0] = {
+            m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 6, 0));
+
+            m_geometryView.SetIndexBufferView({
+                *m_indexBuffer,
+                0,
+                indexBufSize,
+                RHI::IndexFormat::Uint16
+            });
+
+            m_geometryView.AddStreamBufferView({
                 *m_positionBuffer,
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
-            };
+            });
 
-            m_streamBufferViews[1] = {
+            m_geometryView.AddStreamBufferView({
                 *m_uvBuffer,
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
-            };
+            });
 
             RHI::InputStreamLayoutBuilder layoutBuilder;
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             layoutBuilder.AddBuffer()->Channel("UV", RHI::Format::R32G32_FLOAT);
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
         }
 
         {
@@ -226,30 +235,16 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::DeviceIndexBufferView indexBufferView = { *m_indexBuffer->GetDeviceBuffer(context.GetDeviceIndex()), 0,
-                                                                     indexBufSize, RHI::IndexFormat::Uint16 };
-
-                RHI::DrawIndexed drawIndexed;
-                drawIndexed.m_indexCount = 6;
-                drawIndexed.m_instanceCount = 1;
-
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
-
                 commandList->Submit(drawItem);
             };
 

--- a/Gem/Code/Source/RHI/CopyQueueComponent.h
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.h
@@ -93,7 +93,7 @@ namespace AtomSampleViewer
 
         BufferData m_bufferData;
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::GeometryView m_geometryView;
 
         static const int numberOfPaths = 3;
         const char* m_filePaths[numberOfPaths] = {

--- a/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
+++ b/Gem/Code/Source/RHI/DualSourceBlendingComponent.h
@@ -63,8 +63,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::GeometryView m_geometryView;
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         // ----------------------------------

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.h
@@ -171,6 +171,7 @@ namespace AtomSampleViewer
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumSequencesType> m_indirectCommandsShaderResourceGroups;
 
+        AZStd::vector<AZ::RHI::GeometryView> m_geometryViews;
         AZStd::array<AZ::RHI::StreamBufferView, 3> m_streamBufferViews;
         AZStd::array<AZ::RHI::IndexBufferView, 2> m_indexBufferViews;
         AZ::RHI::IndirectBufferView m_indirectDrawBufferView;

--- a/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
+++ b/Gem/Code/Source/RHI/InputAssemblyExampleComponent.h
@@ -65,7 +65,7 @@ namespace AtomSampleViewer
         // -------------------------------------------------
         // Input Assembly buffer and its Streams/Index Views
         // -------------------------------------------------
-        AZ::RHI::StreamBufferView m_streamBufferView[2];
+        AZ::RHI::GeometryView m_geometryView[2];
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;

--- a/Gem/Code/Source/RHI/MRTExampleComponent.h
+++ b/Gem/Code/Source/RHI/MRTExampleComponent.h
@@ -79,8 +79,7 @@ namespace AtomSampleViewer
             AZStd::array<VertexUV, 4> m_uvs;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::GeometryView m_geometryView;
 
         AZStd::array<AZ::RHI::AttachmentId, 3> m_attachmentID;
         AZ::RHI::ClearValue m_clearValue;

--- a/Gem/Code/Source/RHI/MSAAExampleComponent.h
+++ b/Gem/Code/Source/RHI/MSAAExampleComponent.h
@@ -133,8 +133,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_triangleStreamBufferViews;
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_quadStreamBufferViews;
+        AZ::RHI::GeometryView m_triangleGeometryView;
+        AZ::RHI::GeometryView m_quadGeometryView;
         AZ::RHI::InputStreamLayout m_triangleInputStreamLayout;
         AZ::RHI::InputStreamLayout m_quadInputStreamLayout;
 

--- a/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
+++ b/Gem/Code/Source/RHI/MatrixAlignmentTestExampleComponent.h
@@ -175,7 +175,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::GeometryView m_geometryView;
 
         // ImGui stuff.
         ImGuiSidebar m_imguiSidebar;

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -101,7 +101,7 @@ namespace AtomSampleViewer
                     AZ_Error("MultiGPUExampleComponent", false, "StagingBufferToGPU was not created");
                 }
 
-                auto bufferViewDescriptor{ RHI::BufferViewDescriptor::CreateRaw(0, request.m_descriptor.m_byteCount) };
+                auto bufferViewDescriptor{ RHI::BufferViewDescriptor::CreateRaw(0, static_cast<u32>(request.m_descriptor.m_byteCount)) };
                 auto bufferView = m_stagingBufferToGPU->BuildBufferView(bufferViewDescriptor);
                 bufferView->GetDeviceBufferView(0);
                 bufferView->GetDeviceBufferView(1);
@@ -304,20 +304,35 @@ namespace AtomSampleViewer
             request.m_initialData = &bufferData;
             m_inputAssemblyBufferPool->InitBuffer(request);
 
-            m_streamBufferViews[0] = { *m_inputAssemblyBuffer,
-                                       offsetof(BufferDataTrianglePass, m_positions), sizeof(BufferDataTrianglePass::m_positions),
-                                       sizeof(VertexPosition) };
+            m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 3, 0));
 
-            m_streamBufferViews[1] = { *m_inputAssemblyBuffer,
-                                       offsetof(BufferDataTrianglePass, m_colors), sizeof(BufferDataTrianglePass::m_colors),
-                                       sizeof(VertexColor) };
+            m_geometryView.SetIndexBufferView({
+                *m_inputAssemblyBuffer,
+                offsetof(BufferDataTrianglePass, m_indices),
+                sizeof(BufferDataTrianglePass::m_indices),
+                RHI::IndexFormat::Uint16
+            });
+
+            m_geometryView.AddStreamBufferView({
+                *m_inputAssemblyBuffer,
+                offsetof(BufferDataTrianglePass, m_positions),
+                sizeof(BufferDataTrianglePass::m_positions),
+                sizeof(VertexPosition)
+            });
+
+            m_geometryView.AddStreamBufferView({
+                *m_inputAssemblyBuffer,
+                offsetof(BufferDataTrianglePass, m_colors),
+                sizeof(BufferDataTrianglePass::m_colors),
+                sizeof(VertexColor)
+            });
 
             RHI::InputStreamLayoutBuilder layoutBuilder;
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             layoutBuilder.AddBuffer()->Channel("COLOR", RHI::Format::R32G32B32A32_FLOAT);
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
         }
 
         {
@@ -402,32 +417,17 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissors[int(scopeData.second)], 1);
 
-                const RHI::DeviceIndexBufferView indexBufferView = { *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                                                                     offsetof(BufferDataTrianglePass, m_indices),
-                                                                     sizeof(BufferDataTrianglePass::m_indices), RHI::IndexFormat::Uint16 };
-
-                RHI::DrawIndexed drawIndexed;
-                drawIndexed.m_indexCount = 3;
-                drawIndexed.m_instanceCount = 1;
-
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroupShared->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
+                // Submit the triangle draw item.
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
-
-                // Submit the triangle draw item.
                 commandList->Submit(drawItem);
             };
 
@@ -461,20 +461,35 @@ namespace AtomSampleViewer
             request.m_deviceMask = m_deviceMask_1;
             m_inputAssemblyBufferPool->InitBuffer(request);
 
-            m_streamBufferViewsComposite[0] = { *m_inputAssemblyBufferComposite,
-                                                offsetof(BufferDataCompositePass, m_positions),
-                                                sizeof(BufferDataCompositePass::m_positions), sizeof(VertexPosition) };
+            m_geometryViewComposite.SetDrawArguments(RHI::DrawIndexed(0, 6, 0));
 
-            m_streamBufferViewsComposite[1] = { *m_inputAssemblyBufferComposite,
-                                                offsetof(BufferDataCompositePass, m_uvs), sizeof(BufferDataCompositePass::m_uvs),
-                                                sizeof(VertexUV) };
+            m_geometryViewComposite.SetIndexBufferView({
+                *m_inputAssemblyBufferComposite,
+                offsetof(BufferDataCompositePass, m_indices),
+                sizeof(BufferDataCompositePass::m_indices),
+                RHI::IndexFormat::Uint16
+            });
+
+            m_geometryViewComposite.AddStreamBufferView({
+                *m_inputAssemblyBufferComposite,
+                offsetof(BufferDataCompositePass, m_positions),
+                sizeof(BufferDataCompositePass::m_positions),
+                sizeof(VertexPosition)
+            });
+
+            m_geometryViewComposite.AddStreamBufferView({
+                *m_inputAssemblyBufferComposite,
+                offsetof(BufferDataCompositePass, m_uvs),
+                sizeof(BufferDataCompositePass::m_uvs),
+                sizeof(VertexUV)
+            });
 
             RHI::InputStreamLayoutBuilder layoutBuilder;
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             layoutBuilder.AddBuffer()->Channel("UV", RHI::Format::R32G32_FLOAT);
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViewsComposite);
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_geometryViewComposite, m_geometryViewComposite.GetFullStreamBufferIndices());
         }
 
         // Load shader and connect inputs
@@ -575,32 +590,16 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::DeviceIndexBufferView indexBufferView = {
-                    *m_inputAssemblyBufferComposite->GetDeviceBuffer(context.GetDeviceIndex()),
-                    offsetof(BufferDataCompositePass, m_indices), sizeof(BufferDataCompositePass::m_indices), RHI::IndexFormat::Uint16
-                };
-
-                RHI::DrawIndexed drawIndexed;
-                drawIndexed.m_indexCount = 6;
-                drawIndexed.m_instanceCount = 1;
-
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroupComposite->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryViewComposite.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryViewComposite.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineStateComposite->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViewsComposite.size());
-                AZStd::array<RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViewsComposite[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViewsComposite[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
-
                 commandList->Submit(drawItem);
             };
 

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
@@ -76,8 +76,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
-
+        AZ::RHI::GeometryView m_geometryView;
         AZ::RHI::Ptr<AZ::RHI::ImagePool> m_imagePool{};
         AZStd::array<AZ::RHI::Ptr<AZ::RHI::Image>, 2> m_images;
         AZStd::array<AZ::RHI::AttachmentId, 2> m_imageAttachmentIds = { { AZ::RHI::AttachmentId("MultiGPURenderTexture1"),
@@ -108,7 +107,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPool{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_stagingBufferToGPU{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBufferComposite{};
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViewsComposite;
+        AZ::RHI::GeometryView m_geometryViewComposite;
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineStateComposite;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupPool> m_shaderResourceGroupPoolComposite;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroup> m_shaderResourceGroupComposite;

--- a/Gem/Code/Source/RHI/MultiThreadComponent.h
+++ b/Gem/Code/Source/RHI/MultiThreadComponent.h
@@ -86,7 +86,6 @@ namespace AtomSampleViewer
         AZ::RHI::ShaderInputConstantIndex m_shaderIndexViewProj;
 
         AZ::RHI::AttachmentId m_depthStencilID;
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
-        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::GeometryView m_geometryView;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/MultipleViewsComponent.h
+++ b/Gem/Code/Source/RHI/MultipleViewsComponent.h
@@ -99,8 +99,7 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::ShaderInputConstantIndex, 6> m_shaderInputConstantIndices;
         AZ::RHI::ShaderInputImageIndex m_shaderInputImageIndex;
 
-        AZStd::array<AZ::RHI::StreamBufferView, 3> m_streamBufferViews;
-        AZ::RHI::IndexBufferView m_indexBufferView;
+        AZ::RHI::GeometryView m_geometryView;
         AZ::RHI::AttachmentId m_depthMapID;
         AZ::RHI::AttachmentId m_depthStencilID;
         AZ::RHI::ClearValue m_depthClearValue;

--- a/Gem/Code/Source/RHI/QueryExampleComponent.h
+++ b/Gem/Code/Source/RHI/QueryExampleComponent.h
@@ -100,8 +100,8 @@ namespace AtomSampleViewer
             AZStd::array<VertexPosition, 4> m_positions;
             AZStd::array<uint16_t, 6> m_indices;
         };
-        AZ::RHI::StreamBufferView m_quadStreamBufferView;
         AZ::RHI::InputStreamLayout m_quadInputStreamLayout;
+        AZ::RHI::GeometryView m_geometryView;
 
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, 3> m_shaderResourceGroups;
         AZ::RHI::ShaderInputConstantIndex m_objectMatrixConstantIndex;

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.h
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.h
@@ -134,8 +134,7 @@ namespace AtomSampleViewer
         };
 
         RHI::Ptr<RHI::Buffer> m_fullScreenInputAssemblyBuffer;
-        AZStd::array<RHI::StreamBufferView, 2> m_fullScreenStreamBufferViews;
-        RHI::IndexBufferView m_fullScreenIndexBufferView;
+        RHI::GeometryView m_geometryView;
         RHI::InputStreamLayout m_fullScreenInputStreamLayout;
 
         RHI::ConstPtr<RHI::PipelineState> m_drawPipelineState;

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.h
@@ -126,6 +126,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_indexBuffer;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_positionBuffer;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_uvBuffer;
+        AZ::RHI::GeometryView m_geometryView;
 
         struct BufferData
         {
@@ -134,7 +135,6 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 6> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
         // ------------------------------------------------------------
 
         AZ::EntityId m_cameraEntityId;

--- a/Gem/Code/Source/RHI/StencilExampleComponent.h
+++ b/Gem/Code/Source/RHI/StencilExampleComponent.h
@@ -60,7 +60,8 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, s_numberOfVertices> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::GeometryView m_geometryView;
+        AZ::RHI::GeometryView m_geometryView2;
 
         AZ::RHI::AttachmentId m_depthStencilID;
         AZ::RHI::ClearValue m_depthClearValue;

--- a/Gem/Code/Source/RHI/SubpassExampleComponent.h
+++ b/Gem/Code/Source/RHI/SubpassExampleComponent.h
@@ -72,7 +72,7 @@ namespace AtomSampleViewer
 
         struct ModelData
         {
-            AZ::RPI::ModelLod::StreamBufferViewList m_streamBufferList;
+            AZ::RHI::StreamBufferIndices m_streamIndices;
             AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
             AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
             ModelType m_modelType = ModelType_ShaderBall;
@@ -109,6 +109,8 @@ namespace AtomSampleViewer
         AZ::RHI::AttachmentId m_normalAttachmentId;
         AZ::RHI::AttachmentId m_positionAttachmentId;
         AZ::RHI::AttachmentId m_depthStencilAttachmentId;
+
+        AZ::RHI::GeometryView m_compositeGeometryView;
 
         AZ::EntityId m_cameraEntityId;
         AzFramework::EntityContextId m_entityContextId;

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -213,9 +213,7 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                RHI::DrawLinear drawIndexed;
-                drawIndexed.m_vertexCount = 4;
-                drawIndexed.m_instanceCount = 1;
+                m_geometryView.SetDrawArguments(RHI::DrawLinear(4, 0));
 
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
@@ -223,13 +221,11 @@ namespace AtomSampleViewer
 
                 // Create the draw item
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = nullptr;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = 0;
-                drawItem.m_streamBufferViews = nullptr;
 
                 // Add the draw item to the commandlist
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.h
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.h
@@ -54,6 +54,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::ImageView> m_imageView = nullptr;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup = nullptr;
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState = nullptr;
+        AZ::RHI::GeometryView m_geometryView;
 
         // Shader Input indices
         AZ::RHI::ShaderInputImageIndex m_texture3dInputIndex;

--- a/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureArrayExampleComponent.h
@@ -44,6 +44,7 @@ namespace AtomSampleViewer
         AZStd::array<AZ::RHI::StreamBufferView, 2> m_rectangleStreamBufferViews;
         AZ::RHI::InputStreamLayout m_rectangleInputStreamLayout;
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
+        AZ::RHI::GeometryView m_geometryView;
 
         // Srg related resources
         AZ::Data::Instance<AZ::RPI::Shader> m_shader;

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -105,26 +105,30 @@ namespace AtomSampleViewer
                 return;
             }
 
-            m_streamBufferViews[0] = {
+            m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 6, 0));
+
+            m_geometryView.SetIndexBufferView({ *m_indexBuffer, 0, indexBufSize, RHI::IndexFormat::Uint16 });
+
+            m_geometryView.AddStreamBufferView({
                 *m_positionBuffer,
                 0,
                 positionBufSize,
                 sizeof(VertexPosition)
-            };
+            });
 
-            m_streamBufferViews[1] = {
+            m_geometryView.AddStreamBufferView({
                 *m_uvBuffer,
                 0,
                 uvBufSize,
                 sizeof(VertexUV)
-            };
+            });
 
             RHI::InputStreamLayoutBuilder layoutBuilder;
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             layoutBuilder.AddBuffer()->Channel("UV", RHI::Format::R32G32_FLOAT);
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
         }
 
         {
@@ -224,29 +228,16 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::DeviceIndexBufferView indexBufferView = { *m_indexBuffer->GetDeviceBuffer(context.GetDeviceIndex()), 0,
-                                                                     indexBufSize, RHI::IndexFormat::Uint16 };
-
-                RHI::DrawIndexed drawIndexed;
-                drawIndexed.m_indexCount = 6;
-                drawIndexed.m_instanceCount = 1;
-
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);
             };

--- a/Gem/Code/Source/RHI/TextureExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.h
@@ -56,6 +56,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_indexBuffer;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_positionBuffer;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_uvBuffer;
+        AZ::RHI::GeometryView m_geometryView;
 
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::Data::Instance<AZ::RPI::ShaderResourceGroup> m_shaderResourceGroup;
@@ -68,7 +69,6 @@ namespace AtomSampleViewer
         };
 
         AZ::RHI::DeviceDrawItem m_drawItem;
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
 
         AZ::RHI::SamplerState m_samplerState;
         bool m_useStaticSampler = true;

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -227,7 +227,9 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32_FLOAT);
         m_bufferViews[RenderTargetIndex::BufferViewIndex].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::BufferViewIndex].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::BufferViewIndex].m_inputStreamLayout,
+                                           m_bufferViews[RenderTargetIndex::BufferViewIndex].m_geometryView,
+                                           m_bufferViews[RenderTargetIndex::BufferViewIndex].m_geometryView.GetFullStreamBufferIndices());
     }
 
     void TextureMapExampleComponent::InitTexture1DBufferView()
@@ -258,7 +260,11 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32_FLOAT);
         m_bufferViews[RenderTargetIndex::Texture1D].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::Texture1D].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::Texture1D].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(
+            m_bufferViews[RenderTargetIndex::Texture1D].m_inputStreamLayout,
+            m_bufferViews[RenderTargetIndex::Texture1D].m_geometryView,
+            m_bufferViews[RenderTargetIndex::Texture1D].m_geometryView.GetFullStreamBufferIndices()
+            );
     }
 
     void TextureMapExampleComponent::InitTexture1DArrayBufferView()
@@ -293,7 +299,11 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32_FLOAT);
         m_bufferViews[RenderTargetIndex::Texture1DArray].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::Texture1DArray].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::Texture1DArray].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(
+            m_bufferViews[RenderTargetIndex::Texture1DArray].m_inputStreamLayout,
+            m_bufferViews[RenderTargetIndex::Texture1DArray].m_geometryView,
+            m_bufferViews[RenderTargetIndex::Texture1DArray].m_geometryView.GetFullStreamBufferIndices()
+        );
     }
 
     void TextureMapExampleComponent::InitTexture2DArrayBufferView()
@@ -313,7 +323,11 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32B32_FLOAT);
         m_bufferViews[RenderTargetIndex::Texture2DArray].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::Texture2DArray].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::Texture2DArray].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(
+            m_bufferViews[RenderTargetIndex::Texture2DArray].m_inputStreamLayout,
+            m_bufferViews[RenderTargetIndex::Texture2DArray].m_geometryView,
+            m_bufferViews[RenderTargetIndex::Texture2DArray].m_geometryView.GetFullStreamBufferIndices()
+        );
     }
 
     void TextureMapExampleComponent::InitCubemapBufferView()
@@ -333,7 +347,11 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32B32_FLOAT);
         m_bufferViews[RenderTargetIndex::TextureCubemap].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::TextureCubemap].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::TextureCubemap].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(
+            m_bufferViews[RenderTargetIndex::TextureCubemap].m_inputStreamLayout,
+            m_bufferViews[RenderTargetIndex::TextureCubemap].m_geometryView,
+            m_bufferViews[RenderTargetIndex::TextureCubemap].m_geometryView.GetFullStreamBufferIndices()
+            );
     }
 
     void TextureMapExampleComponent::InitCubemapArrayBufferView()
@@ -355,7 +373,11 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32B32A32_FLOAT);
         m_bufferViews[RenderTargetIndex::TextureCubemapArray].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::TextureCubemapArray].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::TextureCubemapArray].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(
+            m_bufferViews[RenderTargetIndex::TextureCubemapArray].m_inputStreamLayout,
+            m_bufferViews[RenderTargetIndex::TextureCubemapArray].m_geometryView,
+            m_bufferViews[RenderTargetIndex::TextureCubemapArray].m_geometryView.GetFullStreamBufferIndices()
+        );
     }
 
     void TextureMapExampleComponent::InitTexture3DBufferView()
@@ -390,7 +412,9 @@ namespace AtomSampleViewer
         layoutBuilder.AddBuffer()->Channel("UV", AZ::RHI::Format::R32G32B32_FLOAT);
         m_bufferViews[RenderTargetIndex::Texture3D].m_inputStreamLayout = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::Texture3D].m_inputStreamLayout, m_bufferViews[RenderTargetIndex::Texture3D].m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(m_bufferViews[RenderTargetIndex::Texture3D].m_inputStreamLayout,
+                                           m_bufferViews[RenderTargetIndex::Texture3D].m_geometryView,
+                                           m_bufferViews[RenderTargetIndex::Texture3D].m_geometryView.GetFullStreamBufferIndices());
     }
 
     void TextureMapExampleComponent::InitRenderTargets()
@@ -509,26 +533,16 @@ namespace AtomSampleViewer
             RHI::Scissor scissor(0, 0, m_renderTargetImageDescriptors[target].m_imageDescriptor.m_size.m_width, m_renderTargetImageDescriptors[target].m_imageDescriptor.m_size.m_height);
             commandList->SetScissors(&scissor, 1);
 
-            RHI::DrawIndexed drawIndexed;
-            drawIndexed.m_indexCount = 6;
-            drawIndexed.m_instanceCount = 1;
+            m_bufferViews[RenderTargetIndex::BufferViewIndex].m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 6, 0));
 
             const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                 m_targetSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
             };
 
             RHI::DeviceDrawItem drawItem;
-            drawItem.m_arguments = drawIndexed;
+            drawItem.m_geometryView = m_bufferViews[RenderTargetIndex::BufferViewIndex].m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+            drawItem.m_streamIndices = m_bufferViews[RenderTargetIndex::BufferViewIndex].m_geometryView.GetFullStreamBufferIndices();
             drawItem.m_pipelineState = m_targetPipelineStates[target]->GetDevicePipelineState(context.GetDeviceIndex()).get();
-            auto deviceIndexBufferView{m_bufferViews[RenderTargetIndex::BufferViewIndex].m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
-            drawItem.m_indexBufferView = &deviceIndexBufferView;
-            drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[0].GetDeviceStreamBufferView(
-                    context.GetDeviceIndex()),
-                m_bufferViews[RenderTargetIndex::BufferViewIndex].m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-            };
-            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 
@@ -596,23 +610,16 @@ namespace AtomSampleViewer
 
             RHI::DrawIndexed drawIndexed;
             drawIndexed.m_indexCount = m_bufferViews[target].m_indexBufferView.GetByteCount() / sizeof(uint16_t);
-            drawIndexed.m_instanceCount = 1;
+            m_bufferViews[target].m_geometryView.SetDrawArguments(drawIndexed);
 
             const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                 m_screenSRGs[target]->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
             };
 
             RHI::DeviceDrawItem drawItem;
-            drawItem.m_arguments = drawIndexed;
+            drawItem.m_geometryView = m_bufferViews[target].m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+            drawItem.m_streamIndices = m_bufferViews[target].m_geometryView.GetFullStreamBufferIndices();
             drawItem.m_pipelineState = m_screenPipelineStates[target]->GetDevicePipelineState(context.GetDeviceIndex()).get();
-            auto deviceIndexBufferView{m_bufferViews[target].m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
-            drawItem.m_indexBufferView = &deviceIndexBufferView;
-            drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_bufferViews[target].m_streamBufferViews.size());
-            AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                m_bufferViews[target].m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                m_bufferViews[target].m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-            };
-            drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
             drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
             drawItem.m_shaderResourceGroups = shaderResourceGroups;
 
@@ -793,13 +800,12 @@ namespace AtomSampleViewer
             AZ_Error(s_textureMapExampleName, false, "Failed to initialize buffer with error code %d", result);
         }
 
-        m_bufferViews[target].m_streamBufferViews[0] =
-        {
+        m_bufferViews[target].m_geometryView.AddStreamBufferView({
             *m_positionBuffer[target],
             0,
             posSize,
             sizeof(VertexPosition)
-        };
+        });
 
         m_uvBuffer[target] = aznew AZ::RHI::Buffer();
         request.m_buffer = m_uvBuffer[target].get();
@@ -812,13 +818,12 @@ namespace AtomSampleViewer
             AZ_Error(s_textureMapExampleName, false, "Failed to initialize buffer with error code %d", result);
         }
 
-        m_bufferViews[target].m_streamBufferViews[1] =
-        {
+        m_bufferViews[target].m_geometryView.AddStreamBufferView({
             *m_uvBuffer[target],
             0,
             uvSize,
             uvTypeSize
-        };
+        });
 
         m_indexBuffer[target] = aznew AZ::RHI::Buffer();
         request.m_buffer = m_indexBuffer[target].get();
@@ -831,12 +836,11 @@ namespace AtomSampleViewer
             AZ_Error(s_textureMapExampleName, false, "Failed to initialize buffer with error code %d", result);
         }
 
-        m_bufferViews[target].m_indexBufferView =
-        {
+        m_bufferViews[target].m_geometryView.SetIndexBufferView({
             *m_indexBuffer[target],
             0,
             indexSize,
             AZ::RHI::IndexFormat::Uint16
-        };
+        });
     }
 }

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.cpp
@@ -609,7 +609,7 @@ namespace AtomSampleViewer
             commandList->SetScissors(&m_scissor, 1);
 
             RHI::DrawIndexed drawIndexed;
-            drawIndexed.m_indexCount = m_bufferViews[target].m_indexBufferView.GetByteCount() / sizeof(uint16_t);
+            drawIndexed.m_indexCount = m_bufferViews[target].m_geometryView.GetIndexBufferView().GetByteCount() / sizeof(uint16_t);
             m_bufferViews[target].m_geometryView.SetDrawArguments(drawIndexed);
 
             const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -56,7 +56,7 @@ namespace AtomSampleViewer
 
         struct BufferViewData
         {
-            AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+            AZ::RHI::GeometryView m_geometryView;
             AZ::RHI::IndexBufferView m_indexBufferView;
             AZ::RHI::InputStreamLayout m_inputStreamLayout;
         };

--- a/Gem/Code/Source/RHI/TextureMapExampleComponent.h
+++ b/Gem/Code/Source/RHI/TextureMapExampleComponent.h
@@ -57,7 +57,6 @@ namespace AtomSampleViewer
         struct BufferViewData
         {
             AZ::RHI::GeometryView m_geometryView;
-            AZ::RHI::IndexBufferView m_indexBufferView;
             AZ::RHI::InputStreamLayout m_inputStreamLayout;
         };
         

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.cpp
@@ -91,28 +91,35 @@ namespace AtomSampleViewer
             request.m_initialData = &bufferData;
             m_inputAssemblyBufferPool->InitBuffer(request);
 
-            m_streamBufferViews[0] =
-            {
+            m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 3, 0));
+
+            m_geometryView.SetIndexBufferView({
+                *m_inputAssemblyBuffer,
+                offsetof(BufferData, m_indices),
+                sizeof(BufferData::m_indices),
+                RHI::IndexFormat::Uint16
+            });
+
+            m_geometryView.AddStreamBufferView({
                 *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_positions),
                 sizeof(BufferData::m_positions),
                 sizeof(VertexPosition)
-            };
+            });
 
-            m_streamBufferViews[1] =
-            {
+            m_geometryView.AddStreamBufferView({
                 *m_inputAssemblyBuffer,
                 offsetof(BufferData, m_colors),
                 sizeof(BufferData::m_colors),
                 sizeof(VertexColor)
-            };
+            });
 
             RHI::InputStreamLayoutBuilder layoutBuilder;
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             layoutBuilder.AddBuffer()->Channel("COLOR", RHI::Format::R32G32B32A32_FLOAT);
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
         }
 
         {
@@ -194,30 +201,16 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                const RHI::DeviceIndexBufferView indexBufferView = { *m_inputAssemblyBuffer->GetDeviceBuffer(context.GetDeviceIndex()),
-                                                                     offsetof(BufferData, m_indices), sizeof(BufferData::m_indices),
-                                                                     RHI::IndexFormat::Uint16 };
-
-                RHI::DrawIndexed drawIndexed;
-                drawIndexed.m_indexCount = 3;
-                drawIndexed.m_instanceCount = 1;
-
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                drawItem.m_indexBufferView = &indexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/TriangleExampleComponent.h
+++ b/Gem/Code/Source/RHI/TriangleExampleComponent.h
@@ -60,6 +60,6 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::GeometryView m_geometryView;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -147,36 +147,35 @@ namespace AtomSampleViewer
             request.m_initialData = &bufferData;
             m_inputAssemblyBufferPool->InitBuffer(request);
 
-            m_streamBufferViews[0] =
-            {
+            m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 3, 0));
+
+            m_geometryView.AddStreamBufferView({
                 *m_inputAssemblyBuffer,
                 offsetof(IABufferData, m_positions),
                 sizeof(IABufferData::m_positions),
                 sizeof(VertexPosition)
-            };
+            });
 
-            m_streamBufferViews[1] =
-            {
+            m_geometryView.AddStreamBufferView({
                 *m_inputAssemblyBuffer,
                 offsetof(IABufferData, m_colors),
                 sizeof(IABufferData::m_colors),
                 sizeof(VertexColor)
-            };
+            });
 
-            m_indexBufferView =
-            {
+            m_geometryView.SetIndexBufferView({
                 *m_inputAssemblyBuffer,
                 offsetof(IABufferData, m_indices),
                 sizeof(IABufferData::m_indices),
                 RHI::IndexFormat::Uint16
-            };
+            });
 
             RHI::InputStreamLayoutBuilder layoutBuilder;
             layoutBuilder.AddBuffer()->Channel("POSITION", RHI::Format::R32G32B32_FLOAT);
             layoutBuilder.AddBuffer()->Channel("COLOR", RHI::Format::R32G32B32A32_FLOAT);
             pipelineStateDescriptor.m_inputStreamLayout = layoutBuilder.End();
 
-            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_streamBufferViews);
+            RHI::ValidateStreamBufferViews(pipelineStateDescriptor.m_inputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
         }
 
         // Create the buffer pool where both buffers get allocated from
@@ -259,27 +258,17 @@ namespace AtomSampleViewer
                 commandList->SetViewports(&m_viewport, 1);
                 commandList->SetScissors(&m_scissor, 1);
 
-                RHI::DrawIndexed drawIndexed;
-                drawIndexed.m_indexCount = 3;
-                drawIndexed.m_instanceCount = s_numberOfTrianglesTotal;
-
                 const RHI::DeviceShaderResourceGroup* shaderResourceGroups[] = {
                     m_shaderResourceGroup->GetRHIShaderResourceGroup()->GetDeviceShaderResourceGroup(context.GetDeviceIndex()).get()
                 };
 
                 RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
+                drawItem.m_drawInstanceArgs = RHI::DrawInstanceArguments(s_numberOfTrianglesTotal, 0);
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
-                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 // Submit the triangle draw item.
                 commandList->Submit(drawItem);

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.h
@@ -91,7 +91,6 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_inputAssemblyBufferPool;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
         AZ::RHI::IndexBufferView m_indexBufferView;
 
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_constantBufferPool;
@@ -99,6 +98,8 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_constantBuffer;
 
         AZ::RHI::Ptr<AZ::RHI::BufferView> m_constantBufferView;
+
+        AZ::RHI::GeometryView m_geometryView;
 
         // --------------------------------------------------------
         // Pipeline state and SRG to be constructed from the shader

--- a/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
+++ b/Gem/Code/Source/RHI/VariableRateShadingExampleComponent.h
@@ -136,10 +136,8 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
         // Buffer for the IA of the full screen quad.
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
-        // Bufferviews into the full screen quad IA
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
-        // Indexview of the full screen quad index buffer
-        AZ::RHI::IndexBufferView m_indexBufferView;
+        // Geometry view for the full screen quad.
+        AZ::RHI::GeometryView m_geometryView;
         // Layout of the full screen quad.
         AZ::RHI::InputStreamLayout m_inputStreamLayout;
 

--- a/Gem/Code/Source/RHI/XRExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/XRExampleComponent.cpp
@@ -220,29 +220,28 @@ namespace AtomSampleViewer
             return;
         }
 
-        m_streamBufferViews[0] =
-        {
+        m_geometryView.SetDrawArguments(AZ::RHI::DrawIndexed(0, GeometryIndexCount, 0));
+
+        m_geometryView.AddStreamBufferView({
             *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_positions),
             sizeof(SingleCubeBufferData::m_positions),
             sizeof(VertexPosition)
-        };
+        });
 
-        m_streamBufferViews[1] =
-        {
+        m_geometryView.AddStreamBufferView({
             *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_colors),
             sizeof(SingleCubeBufferData::m_colors),
             sizeof(VertexColor)
-        };
+        });
 
-        m_indexBufferView =
-        {
+        m_geometryView.SetIndexBufferView({
             *m_inputAssemblyBuffer,
             offsetof(SingleCubeBufferData, m_indices),
             sizeof(SingleCubeBufferData::m_indices),
             AZ::RHI::IndexFormat::Uint16
-        };
+        });
 
         AZ::RHI::InputStreamLayoutBuilder layoutBuilder;
         layoutBuilder.SetTopology(AZ::RHI::PrimitiveTopology::TriangleList);
@@ -251,7 +250,7 @@ namespace AtomSampleViewer
         m_streamLayoutDescriptor.Clear();
         m_streamLayoutDescriptor = layoutBuilder.End();
 
-        AZ::RHI::ValidateStreamBufferViews(m_streamLayoutDescriptor, m_streamBufferViews);
+        AZ::RHI::ValidateStreamBufferViews(m_streamLayoutDescriptor, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
     }
 
     void XRExampleComponent::CreateCubePipeline()
@@ -358,10 +357,6 @@ namespace AtomSampleViewer
             commandList->SetViewports(&m_viewport, 1);
             commandList->SetScissors(&m_scissor, 1);
 
-            AZ::RHI::DrawIndexed drawIndexed;
-            drawIndexed.m_indexCount = GeometryIndexCount;
-            drawIndexed.m_instanceCount = 1;
-
             // Dividing NumberOfCubes by context.GetCommandListCount() to balance to number 
             // of draw call equally between each thread.
             uint32_t numberOfCubesPerCommandList = NumberOfCubes / context.GetCommandListCount();
@@ -380,18 +375,11 @@ namespace AtomSampleViewer
                 };
 
                 AZ::RHI::DeviceDrawItem drawItem;
-                drawItem.m_arguments = drawIndexed;
+                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
+                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
                 drawItem.m_pipelineState = m_pipelineState->GetDevicePipelineState(context.GetDeviceIndex()).get();
-                auto deviceIndexBufferView{m_indexBufferView.GetDeviceIndexBufferView(context.GetDeviceIndex())};
-                drawItem.m_indexBufferView = &deviceIndexBufferView;
                 drawItem.m_shaderResourceGroupCount = static_cast<uint8_t>(AZ::RHI::ArraySize(shaderResourceGroups));
                 drawItem.m_shaderResourceGroups = shaderResourceGroups;
-                drawItem.m_streamBufferViewCount = static_cast<uint8_t>(m_streamBufferViews.size());
-                AZStd::array<AZ::RHI::DeviceStreamBufferView, 2> deviceStreamBufferViews{
-                    m_streamBufferViews[0].GetDeviceStreamBufferView(context.GetDeviceIndex()),
-                    m_streamBufferViews[1].GetDeviceStreamBufferView(context.GetDeviceIndex())
-                };
-                drawItem.m_streamBufferViews = deviceStreamBufferViews.data();
 
                 commandList->Submit(drawItem);
             }

--- a/Gem/Code/Source/RHI/XRExampleComponent.h
+++ b/Gem/Code/Source/RHI/XRExampleComponent.h
@@ -94,7 +94,6 @@ namespace AtomSampleViewer
         void CreateScope();
 
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_bufferPool;
-        AZ::RHI::IndexBufferView m_indexBufferView;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBuffer;
         AZ::RHI::InputStreamLayout m_streamLayoutDescriptor;
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
@@ -106,7 +105,7 @@ namespace AtomSampleViewer
             AZStd::array<uint16_t, 3> m_indices;
         };
 
-        AZStd::array<AZ::RHI::StreamBufferView, 2> m_streamBufferViews;
+        AZ::RHI::GeometryView m_geometryView;
         float m_time = 0.0f;
         AZStd::array<AZ::Data::Instance<AZ::RPI::ShaderResourceGroup>, NumberOfCubes> m_shaderResourceGroups;
         AZStd::array<AZ::Matrix4x4, NumberOfCubes> m_modelMatrices;

--- a/Gem/Code/Source/RootConstantsExampleComponent.cpp
+++ b/Gem/Code/Source/RootConstantsExampleComponent.cpp
@@ -166,7 +166,7 @@ namespace AtomSampleViewer
             }
             m_srg->Compile();
 
-            m_modelStreamBufferViews.resize(m_models.size());
+            m_streamIndices.resize(m_models.size());
             for (uint32_t i = 0; i < m_models.size(); ++i)
             {
                 auto model = m_models[i];
@@ -174,12 +174,12 @@ namespace AtomSampleViewer
                 {
                     Data::Instance<AZ::RPI::ModelLod> modelLod = model->GetLods()[0];
 
-                    m_modelStreamBufferViews[i].resize(modelLod->GetMeshes().size());
+                    m_streamIndices[i].resize(modelLod->GetMeshes().size());
 
-                    for (uint32_t j = 0; j < m_modelStreamBufferViews[i].size(); ++j)
+                    for (uint32_t j = 0; j < m_streamIndices[i].size(); ++j)
                     {
                         modelLod->GetStreamsForMesh(
-                            pipelineStateDescriptor.m_inputStreamLayout, m_modelStreamBufferViews[i][j], nullptr, shader->GetInputContract(),
+                            pipelineStateDescriptor.m_inputStreamLayout, m_streamIndices[i][j], nullptr, shader->GetInputContract(),
                             j);
                     }
                 }
@@ -237,7 +237,7 @@ namespace AtomSampleViewer
         m_srg = nullptr;
         m_modelMatrices.clear();
         m_models.clear();
-        m_modelStreamBufferViews.clear();
+        m_streamIndices.clear();
     }
        
     void RootConstantsExampleComponent::OnTick([[maybe_unused]] float deltaTime, AZ::ScriptTimePoint timePoint)
@@ -294,26 +294,25 @@ namespace AtomSampleViewer
         m_rootConstantData.SetConstant(m_materialIdInputIndex, modelIndex);
         m_rootConstantData.SetConstant(m_modelMatrixInputIndex, m_modelMatrices[modelIndex]);
 
-        const auto& model = m_models[modelIndex];
+        auto& model = m_models[modelIndex];
         if (model)
         {
-            const auto& meshes = model->GetLods()[0]->GetMeshes();
+            AZStd::span<AZ::RPI::ModelLod::Mesh> meshes = model->GetLods()[0]->GetMeshes();
             for (uint32_t i = 0; i < meshes.size(); ++i)
             {
-                auto const& mesh = meshes[i];
+                auto& mesh = meshes[i];
 
                 // Build draw packet and set the values of the inline constants.
                 RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
                 drawPacketBuilder.Begin(nullptr);
-                drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
-                drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
+                drawPacketBuilder.SetGeometryView(&mesh);
                 drawPacketBuilder.SetRootConstants(m_rootConstantData.GetConstantData());
                 drawPacketBuilder.AddShaderResourceGroup(m_srg->GetRHIShaderResourceGroup());
 
                 RHI::DrawPacketBuilder::DrawRequest drawRequest;
                 drawRequest.m_listTag = m_drawListTag;
                 drawRequest.m_pipelineState = m_pipelineState.get();
-                drawRequest.m_streamBufferViews = m_modelStreamBufferViews[modelIndex][i];
+                drawRequest.m_streamIndices = m_streamIndices[modelIndex][i];
                 drawRequest.m_sortKey = 0;
                 drawPacketBuilder.AddDrawItem(drawRequest);
 

--- a/Gem/Code/Source/RootConstantsExampleComponent.h
+++ b/Gem/Code/Source/RootConstantsExampleComponent.h
@@ -68,7 +68,7 @@ namespace AtomSampleViewer
        
         // Models
         AZStd::vector<AZ::Data::Instance<AZ::RPI::Model>> m_models;
-        AZStd::vector<AZStd::vector<AZ::RPI::ModelLod::StreamBufferViewList>> m_modelStreamBufferViews;
+        AZStd::vector<AZStd::vector<AZ::RHI::StreamBufferIndices>> m_streamIndices;
 
         // Cache interfaces
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;

--- a/Gem/Code/Source/StreamingImageExampleComponent.cpp
+++ b/Gem/Code/Source/StreamingImageExampleComponent.cpp
@@ -114,6 +114,8 @@ namespace AtomSampleViewer
 
     void StreamingImageExampleComponent::Activate()
     {
+        m_geometryView.SetDrawArguments(RHI::DrawLinear(4, 0));
+
         // Save the streaming image pool's budget and streaming image pool controller's mip bias 
         // These would be recovered when exist the example
         Data::Instance<RPI::StreamingImagePool> streamingImagePool = RPI::ImageSystemInterface::Get()->GetSystemStreamingPool();
@@ -492,12 +494,11 @@ namespace AtomSampleViewer
             // Build draw packet...
             RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
             drawPacketBuilder.Begin(nullptr);
-            RHI::DrawLinear drawLinear;
-            drawLinear.m_vertexCount = 4;
-            drawLinear.m_instanceCount = image3d.m_sliceCount;
-            drawPacketBuilder.SetDrawArguments(drawLinear);
+            drawPacketBuilder.SetGeometryView(&m_geometryView);
+            drawPacketBuilder.SetDrawInstanceArguments(RHI::DrawInstanceArguments(image3d.m_sliceCount, 0));
 
             RHI::DrawPacketBuilder::DrawRequest drawRequest;
+            drawRequest.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
             drawRequest.m_listTag = m_image3dDrawListTag;
             drawRequest.m_pipelineState = m_image3dPipelineState.get();
             drawRequest.m_sortKey = 0;
@@ -510,17 +511,16 @@ namespace AtomSampleViewer
         }
     }
 
-    void StreamingImageExampleComponent::DrawImage(const ImageToDraw* imageInfo)
+    void StreamingImageExampleComponent::DrawImage(ImageToDraw* imageInfo)
     {
         // Build draw packet...
         RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
-        RHI::DrawLinear drawLinear;
-        drawLinear.m_vertexCount = 4;
-        drawLinear.m_instanceCount = imageInfo->m_image->GetMipLevelCount();
-        drawPacketBuilder.SetDrawArguments(drawLinear);
+        drawPacketBuilder.SetGeometryView(&m_geometryView);
+        drawPacketBuilder.SetDrawInstanceArguments(RHI::DrawInstanceArguments(imageInfo->m_image->GetMipLevelCount(), 0));
 
         RHI::DrawPacketBuilder::DrawRequest drawRequest;
+        drawRequest.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;

--- a/Gem/Code/Source/StreamingImageExampleComponent.h
+++ b/Gem/Code/Source/StreamingImageExampleComponent.h
@@ -102,7 +102,7 @@ namespace AtomSampleViewer
         void Draw3dImages();
 
         // Submit draw package for one image
-        void DrawImage(const ImageToDraw* imageInfo);
+        void DrawImage(ImageToDraw* imageInfo);
 
         // Creates resources, resource views, pipeline state, etc. for rendering
         void PrepareRenderData();
@@ -182,6 +182,8 @@ namespace AtomSampleViewer
 
         AZ::Data::Asset<AZ::RPI::ShaderAsset> m_image3dShaderAsset;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupLayout> m_image3dSrgLayout;
+
+        AZ::RHI::GeometryView m_geometryView;
 
         // shader input indices
         AZ::RHI::ShaderInputImageIndex m_imageInputIndex;

--- a/Gem/Code/Source/TonemappingExampleComponent.cpp
+++ b/Gem/Code/Source/TonemappingExampleComponent.cpp
@@ -60,6 +60,7 @@ namespace AtomSampleViewer
     {
         using namespace AZ;
 
+        m_geometryView.SetDrawArguments(RHI::DrawLinear(4, 0));
         m_dynamicDraw = RPI::DynamicDrawInterface::Get();
 
         m_imguiSidebar.Activate();
@@ -273,11 +274,10 @@ namespace AtomSampleViewer
         // Build draw packet
         RHI::DrawPacketBuilder drawPacketBuilder{RHI::MultiDevice::DefaultDevice};
         drawPacketBuilder.Begin(nullptr);
-        RHI::DrawLinear drawLinear;
-        drawLinear.m_vertexCount = 4;
-        drawPacketBuilder.SetDrawArguments(drawLinear);
+        drawPacketBuilder.SetGeometryView(&m_geometryView);
 
         RHI::DrawPacketBuilder::DrawRequest drawRequest;
+        drawRequest.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
         drawRequest.m_listTag = m_drawListTag;
         drawRequest.m_pipelineState = m_pipelineState.get();
         drawRequest.m_sortKey = 0;

--- a/Gem/Code/Source/TonemappingExampleComponent.h
+++ b/Gem/Code/Source/TonemappingExampleComponent.h
@@ -86,6 +86,7 @@ namespace AtomSampleViewer
         AZ::RPI::DynamicDrawInterface* m_dynamicDraw = nullptr;
 
         // render related data
+        AZ::RHI::GeometryView m_geometryView;
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineState;
         AZ::RHI::DrawListTag m_drawListTag;
         AZ::Data::Asset<AZ::RPI::ShaderAsset> m_shaderAsset;


### PR DESCRIPTION
Updated AtomSampleViewer to work with new GeometryView changes
See: https://github.com/o3de/o3de/pull/18285
For that review

Helpful tip for reviewing:
Most example components changed in this review have two changes
The Geometry View Setup:
```
        m_geometryView.SetDrawArguments(RHI::DrawIndexed(0, 6, 0));

        m_geometryView.SetIndexBufferView({
            *m_rectangleInputAssemblyBuffer,
            offsetof(RectangleBufferData, m_indices),
            sizeof(RectangleBufferData::m_indices),
            RHI::IndexFormat::Uint16
        });

        m_geometryView.AddStreamBufferView({
            *m_rectangleInputAssemblyBuffer,
            offsetof(RectangleBufferData, m_positions),
            sizeof(RectangleBufferData::m_positions),
            sizeof(VertexPosition)
        });

        m_geometryView.AddStreamBufferView({
            *m_rectangleInputAssemblyBuffer,
            offsetof(RectangleBufferData, m_uvs),
            sizeof(RectangleBufferData::m_uvs),
            sizeof(VertexUV)
        });

        RHI::ValidateStreamBufferViews(m_rectangleInputStreamLayout, m_geometryView, m_geometryView.GetFullStreamBufferIndices());
```

And setting the GeometryView on the DrawItem:
```
                drawItem.m_geometryView = m_geometryView.GetDeviceGeometryView(context.GetDeviceIndex());
                drawItem.m_streamIndices = m_geometryView.GetFullStreamBufferIndices();
```
Once you've seen and understood these changes in one example component, you'll have understood 80-90% of the changes in this PR.