### PR TITLE
Fix compile errors after O3DE PR18405

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -25,7 +25,7 @@ ly_add_target(
         PUBLIC
             AZ::AzGameFramework
             Gem::Atom_AtomBridge.Static
-            Gem::Atom_Feature_Common.Static
+            Gem::Atom_Feature_Common.Public
             Gem::Atom_Component_DebugCamera.Static
             Gem::Profiler.Static
             Gem::DiffuseProbeGrid.Static

--- a/Gem/Code/Source/CullingAndLodExampleComponent.h
+++ b/Gem/Code/Source/CullingAndLodExampleComponent.h
@@ -12,7 +12,7 @@
 #include <Atom/Feature/CoreLights/DirectionalLightFeatureProcessorInterface.h>
 #include <Atom/Feature/CoreLights/DiskLightFeatureProcessorInterface.h>
 #include <Atom/Feature/CoreLights/ShadowConstants.h>
-#include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
+#include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
 #include <Atom/RPI.Reflect/Material/MaterialAsset.h>
 #include <Atom/RPI.Reflect/Model/ModelAsset.h>
 #include <AzCore/Component/TickBus.h>

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <Atom/Feature/TransformService/TransformServiceFeatureProcessor.h>
+#include <Atom/Feature/TransformService/TransformServiceFeatureProcessorInterface.h>
 #include <Atom/RHI/CommandList.h>
 #include <Atom/RHI/DeviceDispatchRaysItem.h>
 #include <Atom/RHI/Factory.h>
@@ -110,7 +110,7 @@ namespace AZ
             if (m_createRayTracingPipelineState)
             {
                 RPI::Scene* scene = m_pipeline->GetScene();
-                m_rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
+                m_rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessorInterface>();
 
                 CreateRayTracingPipelineState();
                 m_createRayTracingPipelineState = false;
@@ -201,7 +201,7 @@ namespace AZ
         void RayTracingAmbientOcclusionPass::BuildCommandListInternal([[maybe_unused]] const RHI::FrameGraphExecuteContext& context)
         {
             RPI::Scene* scene = m_pipeline->GetScene();
-            RayTracingFeatureProcessor* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessor>();
+            RayTracingFeatureProcessorInterface* rayTracingFeatureProcessor = scene->GetFeatureProcessor<RayTracingFeatureProcessorInterface>();
             AZ_Assert(rayTracingFeatureProcessor, "RayTracingAmbientOcclusionPass requires the RayTracingFeatureProcessor");
 
             if (!rayTracingFeatureProcessor->GetSubMeshCount())

--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.h
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include <Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h>
 #include <Atom/RHI/ScopeProducer.h>
 #include <Atom/RPI.Public/Pass/RenderPass.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
@@ -16,8 +17,6 @@
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
-
-#include <RayTracing/RayTracingFeatureProcessor.h>
 
 namespace AZ
 {
@@ -71,7 +70,7 @@ namespace AZ
             // ray tracing global pipeline state
             RHI::ConstPtr<RHI::PipelineState> m_globalPipelineState;
 
-            Render::RayTracingFeatureProcessor* m_rayTracingFeatureProcessor = nullptr;
+            Render::RayTracingFeatureProcessorInterface* m_rayTracingFeatureProcessor = nullptr;
 
             uint32_t m_frameCount = 0;
 

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -12,13 +12,13 @@
 #include <Atom/Component/DebugCamera/CameraComponent.h>
 #include <Atom/Component/DebugCamera/NoClipControllerComponent.h>
 #include <Atom/Component/DebugCamera/ArcBallControllerComponent.h>
-#include <Atom/Feature/AuxGeom/AuxGeomFeatureProcessor.h>
 #include <Atom/Feature/ImGui/ImGuiUtils.h>
 #include <Atom/Feature/ImGui/SystemBus.h>
-#include <Atom/Feature/Mesh/MeshFeatureProcessor.h>
+#include <Atom/Feature/Mesh/MeshFeatureProcessorInterface.h>
 #include <Atom/Feature/PostProcessing/PostProcessingConstants.h>
 #include <Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h>
 
+#include <Atom/RPI.Public/AuxGeom/AuxGeomFeatureProcessorInterface.h>
 #include <Atom/RPI.Public/Pass/Pass.h>
 #include <Atom/RPI.Public/Pass/ParentPass.h>
 #include <Atom/RPI.Public/Pass/PassSystemInterface.h>
@@ -27,6 +27,7 @@
 #include <Atom/RPI.Public/RenderPipeline.h>
 #include <Atom/RPI.Public/RPISystemInterface.h>
 #include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h>
 #include <Atom/RPI.Reflect/Image/AttachmentImageAsset.h>
 #include <Atom/RPI.Reflect/Image/AttachmentImageAssetCreator.h>


### PR DESCRIPTION
Fix compile errors (mostly include paths) after O3DE [PR18405](https://github.com/o3de/o3de/pull/18405) changed some file locations. Tested by running a few samples in the AtomSampleViewer