### PR TITLE
Fixes to RHI/RPI multiGPU sample

### DIFF
--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -635,15 +635,6 @@ namespace AtomSampleViewer
         const auto prepareFunction = [this]([[maybe_unused]] RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
         {
             {
-                RHI::BufferScopeAttachmentDescriptor descriptor{};
-                descriptor.m_attachmentId = m_bufferAttachmentIds[1];
-                descriptor.m_bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, static_cast<uint32_t>(m_stagingBufferToGPU->GetDescriptor().m_byteCount));
-                descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::Load;
-                descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::DontCare;
-                frameGraph.UseCopyAttachment(descriptor, RHI::ScopeAttachmentAccess::Read);
-            }
-
-            {
                 RHI::ImageScopeAttachmentDescriptor descriptor{};
                 descriptor.m_attachmentId = m_imageAttachmentIds[1];
                 descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::DontCare;
@@ -684,16 +675,6 @@ namespace AtomSampleViewer
 
         const auto prepareFunction = [this]([[maybe_unused]] RHI::FrameGraphInterface frameGraph, [[maybe_unused]] ScopeData& scopeData)
         {
-            {
-                RHI::BufferScopeAttachmentDescriptor descriptor{};
-                descriptor.m_attachmentId = m_bufferAttachmentIds[0];
-                descriptor.m_bufferViewDescriptor =
-                    RHI::BufferViewDescriptor::CreateRaw(0, static_cast<uint32_t>(m_stagingBufferToCPU->GetDescriptor().m_byteCount));
-                descriptor.m_loadStoreAction.m_loadAction = RHI::AttachmentLoadAction::DontCare;
-                descriptor.m_loadStoreAction.m_storeAction = RHI::AttachmentStoreAction::Store;
-                frameGraph.UseCopyAttachment(descriptor, RHI::ScopeAttachmentAccess::Write);
-            }
-
             {
                 RHI::ImageScopeAttachmentDescriptor descriptor{};
                 descriptor.m_attachmentId = m_imageAttachmentIds[1];

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -648,6 +648,7 @@ namespace AtomSampleViewer
             copyDescriptor.m_sourceBytesPerRow = m_imageWidth * sizeof(uint32_t);
             copyDescriptor.m_sourceBytesPerImage = static_cast<uint32_t>(m_stagingBufferToGPU->GetDescriptor().m_byteCount);
             copyDescriptor.m_sourceSize = RHI::Size{ m_imageWidth, m_imageHeight, 1 };
+            copyDescriptor.m_sourceFormat = m_images[1]->GetDeviceImage(context.GetDeviceIndex())->GetDescriptor().m_format;
             copyDescriptor.m_destinationImage = m_images[1]->GetDeviceImage(context.GetDeviceIndex()).get();
 
             RHI::DeviceCopyItem copyItem(copyDescriptor);

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
@@ -104,7 +104,7 @@ namespace AtomSampleViewer
 
         AZ::RHI::Ptr<AZ::RHI::Device> m_device_1{};
         AZ::RHI::MultiDevice::DeviceMask m_deviceMask_1{};
-        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPool{};
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPoolToGPU{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_stagingBufferToGPU{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBufferComposite{};
         AZ::RHI::GeometryView m_geometryViewComposite;
@@ -119,6 +119,7 @@ namespace AtomSampleViewer
 
         AZ::RHI::Ptr<AZ::RHI::Device> m_device_2{};
         AZ::RHI::MultiDevice::DeviceMask m_deviceMask_2{};
+        AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPoolToCPU{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_stagingBufferToCPU{};
         AZStd::vector<AZStd::shared_ptr<AZ::RHI::ScopeProducer>> m_secondaryScopeProducers;
     };

--- a/Passes/MultiGPUCopyBufferToBuffer.pass
+++ b/Passes/MultiGPUCopyBufferToBuffer.pass
@@ -4,7 +4,7 @@
     "ClassName": "PassAsset",
     "ClassData": {
         "PassTemplate": {
-            "Name": "MultiGPUCopyImageToBufferPassTemplate",
+            "Name": "MultiGPUCopyBufferToBufferPassTemplate",
             "PassClass": "CopyPass",
             "Slots": [
                 {

--- a/Passes/MultiGPUCopyBufferToImage.pass
+++ b/Passes/MultiGPUCopyBufferToImage.pass
@@ -4,7 +4,7 @@
     "ClassName": "PassAsset",
     "ClassData": {
         "PassTemplate": {
-            "Name": "MultiGPUCopyImageToBufferPassTemplate",
+            "Name": "MultiGPUCopyBufferToImagePassTemplate",
             "PassClass": "CopyPass",
             "Slots": [
                 {


### PR DESCRIPTION
This PR fixes smaller issues with the two multiGPU samples:
#### RHI
1. Add `m_sourceFormat` to `DeviceCopyBufferToImageDescriptor`
2. Use two distinct `BufferPool`s for the up/download of the resource, fixes
```
The destination resource cannot be on a D3D12_HEAP_TYPE_UPLOAD heap.
```
3. Do not add host-only staging buffers to `FrameGraph` (introduces unnecessary/wrong transitions), fixes:
```
D3D12 ERROR: ID3D12CommandList::ResourceBarrier: Certain resources are restricted to certain D3D12_RESOURCE_STATES states, and cannot be changed. Resources on D3D12_HEAP_TYPE_UPLOAD heaps requires D3D12_RESOURCE_STATE_GENERIC_READ. Reserved buffers used exclusively for texture placement requires D3D12_RESOURCE_STATE_COMMON. [ RESOURCE_MANIPULATION ERROR #741: RESOURCE_BARRIER_INVALID_HEAP]
```

#### RPI
1. Fix PassTemplate names