### PR TITLE
Update usages of AZ_CRC macro with 2 parameters

### DIFF
--- a/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
+++ b/Gem/Code/Source/AtomSampleViewerSystemComponent.cpp
@@ -76,15 +76,15 @@ namespace AtomSampleViewer
 
     void AtomSampleViewerSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
     {
-        provided.push_back(AZ_CRC("PrototypeLmbrCentralService", 0xe35e6de0));
+        provided.push_back(AZ_CRC_CE("PrototypeLmbrCentralService"));
     }
 
     void AtomSampleViewerSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
         required.push_back(AZ::RHI::Factory::GetComponentService());
-        required.push_back(AZ_CRC("AssetDatabaseService", 0x3abf5601));
-        required.push_back(AZ_CRC("RPISystem", 0xf2add773));
-        required.push_back(AZ_CRC("BootstrapSystemComponent", 0xb8f32711));
+        required.push_back(AZ_CRC_CE("AssetDatabaseService"));
+        required.push_back(AZ_CRC_CE("RPISystem"));
+        required.push_back(AZ_CRC_CE("BootstrapSystemComponent"));
     }
 
     AtomSampleViewerSystemComponent::AtomSampleViewerSystemComponent()

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -256,7 +256,7 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
     {
-        required.push_back(AZ_CRC("PrototypeLmbrCentralService", 0xe35e6de0));
+        required.push_back(AZ_CRC_CE("PrototypeLmbrCentralService"));
     }
 
     void SampleComponentManager::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
@@ -266,7 +266,7 @@ namespace AtomSampleViewer
 
     void SampleComponentManager::GetDependentServices(AZ::ComponentDescriptor::DependencyArrayType& dependent)
     {
-        dependent.push_back(AZ_CRC("AzFrameworkConfigurationSystemComponentService", 0xcc49c96e)); // Ensures a scene is created for the GameEntityContext
+        dependent.push_back(AZ_CRC_CE("AzFrameworkConfigurationSystemComponentService")); // Ensures a scene is created for the GameEntityContext
     }
 
     AZStd::vector<SampleEntry> SampleComponentManager::GetSamples()


### PR DESCRIPTION
This PR replaces usages of the two-parameter macro `AZ_CRC` (string value and crc value) with the macro `AZ_CRC_CE` (only string value). This was already done for the O3DE repository some time ago in o3de/o3de#18120.