### PR TITLE
Change includes for scene/viewsrg.srgi to scene/viewsrg_all.srgi in all shaders

### DIFF
--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/AlphaUtils.azsli>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>

--- a/Materials/Pipelines/PrototypeDeferredPipeline/DeferredMaterialPass.azsli
+++ b/Materials/Pipelines/PrototypeDeferredPipeline/DeferredMaterialPass.azsli
@@ -18,7 +18,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
@@ -48,9 +48,13 @@ struct DeferredMaterialOutput
 #endif
 DeferredMaterialOutput MaterialPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace)
 {
+    // ------- Reconstruct the Instance-Id --------
+    VsSystemValues SV;
+    SV.m_instanceId = IN.m_instanceId;
+
     // ------- Geometry -> Surface -------
 
-    PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
+    PixelGeometryData geoData = EvaluatePixelGeometry(IN, SV, isFrontFace);
 
     Surface surface = EvaluateSurface(IN, geoData);
 

--- a/Materials/Types/MinimalMultilayerPBR_ForwardPass.azsl
+++ b/Materials/Types/MinimalMultilayerPBR_ForwardPass.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>

--- a/Passes/PrototypeDeferredPipeline/DeferredLighting.azsl
+++ b/Passes/PrototypeDeferredPipeline/DeferredLighting.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include <Atom/Features/PostProcessing/FullscreenVertex.azsli>
 #include <Atom/Features/ScreenSpace/ScreenSpaceUtil.azsli>

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,3 +1,4 @@
+// {BEGIN_LICENSE}
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
@@ -5,19 +6,18 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+// {END_LICENSE}
+
 #pragma once
+
+// this file is included by 'scenesrg_all.srgi', which is included by each shader using the scene-srg.
+// Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
+// located in this folder (And how you can optionally customize your own scenesrg.srgi
+// and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
-/* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,3 +1,4 @@
+// {BEGIN_LICENSE}
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
@@ -5,19 +6,18 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
+// {END_LICENSE}
+
 #pragma once
+
+// this file is included by 'viewsrg_all.srgi', which is included by each shader using the view-srg.
+// Please read README.md for an explanation on why scenesrg.srgi and viewsrg.srgi are
+// located in this folder (And how you can optionally customize your own scenesrg.srgi
+// and viewsrg.srgi in your game project).
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
-
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
-/* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/
+    /* Intentionally Empty. Add fields here based on the project's needs */
 };
-
-#define AZ_COLLECTING_PARTIAL_SRGS
-#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgAll.azsli>
-#undef AZ_COLLECTING_PARTIAL_SRGS

--- a/Shaders/DebugVertexNormals.azsl
+++ b/Shaders/DebugVertexNormals.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/PBR/DefaultObjectSrg.azsli>
 #include <Atom/RPI/ShaderResourceGroups/DefaultDrawSrg.azsli>
 #include <Atom/Features/InstancedTransforms.azsli>

--- a/Shaders/DynamicDraw/DynamicDrawExample.azsl
+++ b/Shaders/DynamicDraw/DynamicDrawExample.azsl
@@ -7,7 +7,7 @@
  */
 
 #include <Atom/Features/SrgSemantics.azsli>
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup PerContextSrg : SRG_PerSubPass
 {

--- a/Shaders/Instanced.azsl
+++ b/Shaders/Instanced.azsl
@@ -1,5 +1,5 @@
 #include <Atom/Features/SrgSemantics.azsli>
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 struct CubeTransform
 {

--- a/Shaders/RHI/AsyncComputeShadow.azsl
+++ b/Shaders/RHI/AsyncComputeShadow.azsl
@@ -8,7 +8,7 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 ShaderResourceGroup ShadowSrg : SRG_PerObject
 {

--- a/Shaders/RHI/SHDemo.azsl
+++ b/Shaders/RHI/SHDemo.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/SphericalHarmonicsUtility.azsli>
 
 ShaderResourceGroup SphericalHarmonicsInstanceSrg : SRG_PerObject

--- a/Shaders/RHI/SHRender.azsl
+++ b/Shaders/RHI/SHRender.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/SphericalHarmonicsUtility.azsli>
 #include <Atom/RPI/Math.azsli>
 

--- a/Shaders/RHI/SubpassInputComposition.azsl
+++ b/Shaders/RHI/SubpassInputComposition.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include "SubpassInputSceneSrg.azsli"
 

--- a/Shaders/RHI/SubpassInputGBuffer.azsl
+++ b/Shaders/RHI/SubpassInputGBuffer.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 
 #include "SubpassInputModelSrg.azsli"
 

--- a/Shaders/RootConstantsExample/ColorMesh.azsl
+++ b/Shaders/RootConstantsExample/ColorMesh.azsl
@@ -6,8 +6,8 @@
  *
  */
 
-#include <viewsrg.srgi>
-#include <scenesrg.srgi>
+#include <viewsrg_all.srgi>
+#include <scenesrg_all.srgi>
 
 ShaderResourceGroupSemantic SRG_PerGroup
 {

--- a/Shaders/SubpassExample/SkyBoxSubpass.azsl
+++ b/Shaders/SubpassExample/SkyBoxSubpass.azsl
@@ -16,8 +16,8 @@
 #include <Atom/Features/MatrixUtility.azsli>
 #include <Atom/Features/ShaderQualityOptions.azsli>
 
-#include <scenesrg.srgi>
-#include <viewsrg.srgi>
+#include <scenesrg_all.srgi>
+#include <viewsrg_all.srgi>
 
 #ifndef ENABLE_PHYSICAL_SKY
 #define ENABLE_PHYSICAL_SKY              1

--- a/Shaders/TonemappingExample/RenderImage.azsl
+++ b/Shaders/TonemappingExample/RenderImage.azsl
@@ -6,7 +6,7 @@
  *
  */
 
-#include <viewsrg.srgi>
+#include <viewsrg_all.srgi>
 #include <Atom/Features/ColorManagement/TransformColor.azsli>
 
 ShaderResourceGroup RenderImageSrg : SRG_PerDraw


### PR DESCRIPTION
Necessary follow-up for [PR 18566](https://github.com/o3de/o3de/pull/18566), that introduced the scene/viewsrg_all.srgi in the engine as a wrapper around the project-specific scene/viewsrg.srgi.
