### PR TITLE
Build*View to Get*View

### DIFF
--- a/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
+++ b/Gem/Code/Source/Passes/RayTracingAmbientOcclusionPass.cpp
@@ -167,7 +167,7 @@ namespace AZ
                 RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
 
                 bufferIndex = srgLayout->FindShaderInputBufferIndex(AZ::Name("m_scene"));
-                m_shaderResourceGroup->SetBufferView(bufferIndex, tlasBuffer->BuildBufferView(bufferViewDescriptor).get());
+                m_shaderResourceGroup->SetBufferView(bufferIndex, tlasBuffer->GetBufferView(bufferViewDescriptor).get());
             }
 
             // Bind constants

--- a/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/BindlessPrototypeExampleComponent.cpp
@@ -281,7 +281,7 @@ namespace AtomSampleViewer
 
         RHI::BufferViewDescriptor viewDesc =
             RHI::BufferViewDescriptor::CreateRaw(0, aznumeric_cast<uint32_t>(bufferRequest.m_descriptor.m_byteCount));
-        bufferView = indirectionBuffer->BuildBufferView(viewDesc);
+        bufferView = indirectionBuffer->GetBufferView(viewDesc);
     }
 
     void BindlessPrototypeExampleComponent::CreateColorBuffer(
@@ -308,7 +308,7 @@ namespace AtomSampleViewer
 
         RHI::BufferViewDescriptor viewDesc =
             RHI::BufferViewDescriptor::CreateRaw(0, aznumeric_cast<uint32_t>(bufferRequest.m_descriptor.m_byteCount));
-        bufferView = buffer->BuildBufferView(viewDesc);
+        bufferView = buffer->GetBufferView(viewDesc);
     }
 
     void BindlessPrototypeExampleComponent::ClearObjects()
@@ -507,7 +507,7 @@ namespace AtomSampleViewer
             m_floatBuffer = std::make_unique<FloatBuffer>(FloatBuffer(m_bufferPool, byteCount));
 
             RHI::BufferViewDescriptor bufferViewDesc = RHI::BufferViewDescriptor::CreateStructured(0u, m_bufferFloatCount, sizeof(float));
-            AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = m_floatBuffer->m_buffer->BuildBufferView(bufferViewDesc);
+            AZ::RHI::Ptr<AZ::RHI::BufferView> bufferView = m_floatBuffer->m_buffer->GetBufferView(bufferViewDesc);
             bufferView->SetName(Name(m_floatBufferSrgName));
             m_bindlessSrg->SetBufferView(m_floatBufferSrgName, floatBufferId, bufferView.get());
 
@@ -591,7 +591,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialized compute buffer");
 
             m_rwBufferViewDescriptor = RHI::BufferViewDescriptor::CreateRaw(0, bufferSize);
-            m_computeBufferView = m_computeBuffer->BuildBufferView(m_rwBufferViewDescriptor);
+            m_computeBufferView = m_computeBuffer->GetBufferView(m_rwBufferViewDescriptor);
         }
 
         // Set the image version of color multiplier buffer
@@ -606,7 +606,7 @@ namespace AtomSampleViewer
             AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image");
 
             m_rwImageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::R32G32B32A32_FLOAT, 0, 0);
-            m_computeImageView = m_computeImage->BuildImageView(m_rwImageViewDescriptor);
+            m_computeImageView = m_computeImage->GetImageView(m_rwImageViewDescriptor);
         }
 
 #if ATOMSAMPLEVIEWER_TRAIT_BINDLESS_PROTOTYPE_SUPPORTS_DIRECT_BOUND_UNBOUNDED_ARRAY

--- a/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/ComputeExampleComponent.cpp
@@ -253,8 +253,8 @@ namespace AtomSampleViewer
 
         
         m_bufferViewDescriptor = RHI::BufferViewDescriptor::CreateStructured(0, m_bufferWidth * m_bufferHeight, RHI::GetFormatSize(RHI::Format::R32G32B32A32_FLOAT));
-        m_computeBufferView = m_computeBuffer->BuildBufferView(m_bufferViewDescriptor);
-                  
+        m_computeBufferView = m_computeBuffer->GetBufferView(m_bufferViewDescriptor);
+
         if(!m_computeBufferView.get())
         {
             AZ_Assert(false, "Failed to initialized compute buffer view");

--- a/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/IndirectRenderingExampleComponent.cpp
@@ -447,8 +447,8 @@ namespace AtomSampleViewer
         indirectBufferWriter->Shutdown();
 
         auto viewDescriptor = RHI::BufferViewDescriptor::CreateStructured(0, s_maxNumberOfObjects, commandsStride);
-        m_sourceIndirectBufferView = m_sourceIndirectBuffer->BuildBufferView(viewDescriptor);
-                  
+        m_sourceIndirectBufferView = m_sourceIndirectBuffer->GetBufferView(viewDescriptor);
+
         if(!m_sourceIndirectBufferView.get())
         {
             AZ_Assert(false, "Fail to initialize Indirect Buffer View");
@@ -540,8 +540,8 @@ namespace AtomSampleViewer
         m_instancesBufferPool->InitBuffer(request);
 
         auto descriptor = RHI::BufferViewDescriptor::CreateStructured(0, static_cast<uint32_t>(m_instancesData.size()), sizeof(InstanceData));
-        m_instancesDataBufferView = m_instancesDataBuffer->BuildBufferView(descriptor);
-                  
+        m_instancesDataBufferView = m_instancesDataBuffer->GetBufferView(descriptor);
+
         if(!m_instancesDataBufferView.get())
         {
             AZ_Assert(false, "Fail to initialize Instances Data Buffer View");

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -102,7 +102,7 @@ namespace AtomSampleViewer
                 }
 
                 auto bufferViewDescriptor{ RHI::BufferViewDescriptor::CreateRaw(0, static_cast<u32>(request.m_descriptor.m_byteCount)) };
-                auto bufferView = m_stagingBufferToGPU->BuildBufferView(bufferViewDescriptor);
+                auto bufferView = m_stagingBufferToGPU->GetBufferView(bufferViewDescriptor);
                 bufferView->GetDeviceBufferView(0);
                 bufferView->GetDeviceBufferView(1);
 

--- a/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/RayTracingExampleComponent.cpp
@@ -209,7 +209,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize output image");
 
         m_outputImageViewDescriptor = RHI::ImageViewDescriptor::Create(RHI::Format::R8G8B8A8_UNORM, 0, 0);
-        m_outputImageView = m_outputImage->BuildImageView(m_outputImageViewDescriptor);
+        m_outputImageView = m_outputImage->GetImageView(m_outputImageViewDescriptor);
         AZ_Assert(m_outputImageView.get(), "Failed to create output image view");
         AZ_Assert(m_outputImageView->GetDeviceImageView(RHI::MultiDevice::DefaultDeviceIndex)->IsFullView(), "Image View initialization IsFullView() failed");
     }
@@ -511,7 +511,7 @@ namespace AtomSampleViewer
 
                 uint32_t tlasBufferByteCount = aznumeric_cast<uint32_t>(m_rayTracingTlas->GetTlasBuffer()->GetDescriptor().m_byteCount);
                 RHI::BufferViewDescriptor bufferViewDescriptor = RHI::BufferViewDescriptor::CreateRayTracingTLAS(tlasBufferByteCount);
-                m_globalSrg->SetBufferView(tlasConstantIndex, m_rayTracingTlas->GetTlasBuffer()->BuildBufferView(bufferViewDescriptor).get());
+                m_globalSrg->SetBufferView(tlasConstantIndex, m_rayTracingTlas->GetTlasBuffer()->GetBufferView(bufferViewDescriptor).get());
 
                 RHI::ShaderInputImageIndex outputConstantIndex;
                 FindShaderInputIndex(&outputConstantIndex, m_globalSrg, AZ::Name{ "m_output" }, RayTracingExampleName);

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -108,8 +108,8 @@ namespace AtomSampleViewer
             RHI::ImageViewDescriptor imageViewDescriptor = {};
             imageViewDescriptor = RHI::ImageViewDescriptor::Create(format, 0, 0);
             imageViewDescriptor.m_overrideBindFlags = RHI::ImageBindFlags::ShaderRead;
-            
-            m_imageView = m_image->BuildImageView(imageViewDescriptor);
+
+            m_imageView = m_image->GetImageView(imageViewDescriptor);
             m_imageView->SetName(Name("Texture3DView"));
             if(!m_imageView.get())
             {

--- a/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TrianglesConstantBufferExampleComponent.cpp
@@ -304,7 +304,7 @@ namespace AtomSampleViewer
         AZ_Assert(result == RHI::ResultCode::Success, "Failed to initialize constant buffer");
 
         RHI::BufferViewDescriptor bufferDesc = RHI::BufferViewDescriptor::CreateStructured(0, 1u, constantBufferSize);
-        m_constantBufferView = m_constantBuffer->BuildBufferView(bufferDesc);
+        m_constantBufferView = m_constantBuffer->GetBufferView(bufferDesc);
     }
 
     void TrianglesConstantBufferExampleComponent::Deactivate()


### PR DESCRIPTION
This PR renames all `Build*View` calls to `Get*View` per the API change in https://github.com/o3de/o3de/pull/18725.