### PR TITLE
Fixing AtomSampleviewer shaders to compile with new Multi-View Shading

### DIFF
--- a/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
+++ b/Materials/DynamicMaterialTest/EmissiveMaterial.azsl
@@ -71,6 +71,9 @@ VSOutput MainVS(VSInput IN, uint instanceId : SV_InstanceID)
 
 ForwardPassOutput MainPS(VSOutput IN)
 {
+    float3 views[MAX_SHADING_VIEWS];
+    views[0] = ViewSrg::m_worldPosition.xyz;    // Assume one view for forward pass for now
+
     real4x4 objectToWorld = real4x4(GetObjectToWorldMatrix(IN.m_instanceId));
     real3x3 objectToWorldIT = real3x3(GetObjectToWorldMatrixInverseTranspose(IN.m_instanceId));
 
@@ -102,7 +105,7 @@ ForwardPassOutput MainPS(VSOutput IN)
 
     // Light iterator
     lightingData.tileIterator.Init(IN.m_position, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
-    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, ViewSrg::m_worldPosition.xyz);
+    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, views);
 
     // Emissive
     float3 emissive = MaterialSrg::m_emissiveColor.rgb * MaterialSrg::m_emissiveIntensity;
@@ -114,7 +117,7 @@ ForwardPassOutput MainPS(VSOutput IN)
     lightingData.emissiveLighting = emissive;
 
     // Diffuse and Specular response
-    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
+    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.GetSpecularNdotV(), surface.GetSpecularF0(), surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
 
     const float alpha = 1.0f;

--- a/Materials/Pipelines/PrototypeDeferredPipeline/DeferredMaterialPass.azsli
+++ b/Materials/Pipelines/PrototypeDeferredPipeline/DeferredMaterialPass.azsli
@@ -28,7 +28,7 @@ VsOutput MaterialVS(VsInput IN, uint instanceId : SV_InstanceID)
 {
     VsSystemValues SV;
     SV.m_instanceId = instanceId;
-    return EvaluateVertexGeometry(IN, SV);
+    return EvaluateVertexGeometry(IN, SV, GetMaterialParameters());
 }
 
 struct DeferredMaterialOutput
@@ -50,9 +50,9 @@ DeferredMaterialOutput MaterialPS(VsOutput IN, bool isFrontFace : SV_IsFrontFace
 {
     // ------- Geometry -> Surface -------
 
-    PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace);
+    PixelGeometryData geoData = EvaluatePixelGeometry(IN, isFrontFace, GetMaterialParameters());
 
-    Surface surface = EvaluateSurface(IN, geoData);
+    Surface surface = EvaluateSurface(IN, geoData, GetMaterialParameters());
 
     // ------- Output -------
 

--- a/Materials/Types/MinimalMultilayerPBR_ForwardPass.azsl
+++ b/Materials/Types/MinimalMultilayerPBR_ForwardPass.azsl
@@ -89,6 +89,10 @@ VSOutput MinimalMultilayerPBR_MainPassVS(VSInput IN, uint instanceId : SV_Instan
 
 ForwardPassOutput MinimalMultilayerPBR_MainPassPS(VSOutput IN)
 {
+    float3 views[MAX_SHADING_VIEWS];
+    views[0] = ViewSrg::m_worldPosition.xyz;    // Assume one view for forward pass for now
+
+
     real4x4 objectToWorld = real4x4(GetObjectToWorldMatrix(IN.m_instanceId));
     real3x3 objectToWorldIT = real3x3(GetObjectToWorldMatrixInverseTranspose(IN.m_instanceId));
 
@@ -130,10 +134,10 @@ ForwardPassOutput MinimalMultilayerPBR_MainPassPS(VSOutput IN)
 
     // Light iterator
     lightingData.tileIterator.Init(IN.m_position, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
-    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, ViewSrg::m_worldPosition.xyz);
+    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, views);
 
     // Diffuse and Specular response
-    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
+    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.GetSpecularNdotV(), surface.GetSpecularF0(), surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
 
     const float alpha = 1.0f;

--- a/Passes/PrototypeDeferredPipeline/DeferredLighting.azsl
+++ b/Passes/PrototypeDeferredPipeline/DeferredLighting.azsl
@@ -77,6 +77,9 @@ option bool o_deferredPipelineWatermark = false;
 
 PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
 {
+    float3 views[MAX_SHADING_VIEWS];
+    views[0] = ViewSrg::m_worldPosition.xyz;    // Assume one view for forward pass for now
+
     uint2 screenCoords = IN.m_position.xy;
 
     // ------- Unpack G-Buffers -------
@@ -120,11 +123,11 @@ PSOutput MainPS(VSOutput IN, in uint sampleIndex : SV_SampleIndex)
 
     // Light iterator
     lightingData.tileIterator.Init(IN.m_position, PassSrg::m_lightListRemapped, PassSrg::m_tileLightData);
-    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, ViewSrg::m_worldPosition.xyz);
+    lightingData.Init(surface.position, surface.normal, surface.roughnessLinear, views);
 
 
     // Diffuse and Specular response
-    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.NdotV, surface.specularF0, surface.roughnessLinear);
+    lightingData.specularResponse = FresnelSchlickWithRoughness(lightingData.GetSpecularNdotV(), surface.GetSpecularF0(), surface.roughnessLinear);
     lightingData.diffuseResponse = 1.0f - lightingData.specularResponse;
 
     const float alpha = 1.0f;


### PR DESCRIPTION
Fixing AtomSampleviewer shaders to compile with new Multi-View Shading changes (as well as fixing DeferredMaterialPass.azsli to compile with Huawei's Material Params)