### PR TITLE
Only allocate GeometryView on Device 0

### DIFF
--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.h
@@ -107,7 +107,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::BufferPool> m_stagingBufferPoolToGPU{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_stagingBufferToGPU{};
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_inputAssemblyBufferComposite{};
-        AZ::RHI::GeometryView m_geometryViewComposite{ AZ::RHI::MultiDevice::AllDevices };
+        AZ::RHI::GeometryView m_geometryViewComposite{ AZ::RHI::MultiDevice::DeviceMask{1u << 0} };
         AZ::RHI::ConstPtr<AZ::RHI::PipelineState> m_pipelineStateComposite;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroupPool> m_shaderResourceGroupPoolComposite;
         AZ::RHI::Ptr<AZ::RHI::ShaderResourceGroup> m_shaderResourceGroupComposite;


### PR DESCRIPTION
As `m_geometryViewComposite` is only used on device 0 (and gets an `IndexBufferView` that is only available on this device), there is the need to change to device masks correspondingly (from `AllDevice` to just device 0), otherwise one gets errors in the `SetIndexBufferView()` and `AddStreamBufferView()` calls.