### PR TITLE
Fix unused variables compiler errors for 25.05.1

### DIFF
--- a/Gem/Code/Source/ExposureExampleComponent.cpp
+++ b/Gem/Code/Source/ExposureExampleComponent.cpp
@@ -146,7 +146,7 @@ namespace AtomSampleViewer
         m_pointLight = lightHandle;
     }
 
-    void ExposureExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
+    void ExposureExampleComponent::OnModelReady([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Model> model)
     {
         m_sponzaAssetLoaded = true;
 

--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -88,7 +88,7 @@ namespace AtomSampleViewer
 
     // --- World Model ---
 
-    void SsaoExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
+    void SsaoExampleComponent::OnModelReady([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Model> model)
     {
         m_worldModelAssetLoaded = true;
     }


### PR DESCRIPTION
This change applies to the `main` branch, which is the Last Known Good ASV that compiles against 25.05.0 and 25.05.1

Once this is in, I'll cherry pick this from `main` to `development`.

With this change, I'm able to compile and run ASV off the `main` branch if I have the `main` branch on O3DE.   (or 25.05.1 point release since no other APIs have changed since then).  This works with latest MSVC compiler.

