### PR TITLE
(Cherry-pick from `main`) Fixes "Unused Variable" warnings for 25.05.1

### DIFF
--- a/Gem/Code/Source/ExposureExampleComponent.cpp
+++ b/Gem/Code/Source/ExposureExampleComponent.cpp
@@ -146,7 +146,7 @@ namespace AtomSampleViewer
         m_pointLight = lightHandle;
     }
 
-    void ExposureExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
+    void ExposureExampleComponent::OnModelReady([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Model> model)
     {
         m_sponzaAssetLoaded = true;
 

--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -88,7 +88,7 @@ namespace AtomSampleViewer
 
     // --- World Model ---
 
-    void SsaoExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
+    void SsaoExampleComponent::OnModelReady([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Model> model)
     {
         m_worldModelAssetLoaded = true;
     }


### PR DESCRIPTION
This cherry-picks the 2 "Unused Variable" warnings from `main` branch to `development`.

