### PR TITLE
Re-enable deprecated-this-capture warning

### DIFF
--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -227,7 +227,7 @@ namespace AtomSampleViewer
 
             RHI::EmptyCompileFunction<ScopeData> compileFunction;
 
-            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 
                 RHI::CommandList* commandList = context.GetCommandList();

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -599,7 +599,7 @@ namespace AtomSampleViewer
                 m_shaderResourceGroupComposite->Compile(m_shaderResourceGroupDataComposite);
             };
 
-            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -308,7 +308,7 @@ namespace AtomSampleViewer
                 }
             };
 
-            const auto executeFunction = [=]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -206,7 +206,7 @@ namespace AtomSampleViewer
                 m_shaderResourceGroup->Compile();
             };
 
-            const auto executeFunction = [=]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -221,7 +221,7 @@ namespace AtomSampleViewer
                 }
             };
 
-            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 


### PR DESCRIPTION
This PR fixes compile errors caused by O3DE [PR19165](https://github.com/o3de/o3de/pull/19165), which re-enables the deprecated-this-capture warning.