### PR TITLE
Fix SsaoPipeline depth attachment after O3DE PR19102

### DIFF
--- a/Passes/SsaoPipeline.pass
+++ b/Passes/SsaoPipeline.pass
@@ -254,6 +254,13 @@
                                 "Pass": "DebugWhiteTexture",
                                 "Attachment": "Output"
                             }
+                        },
+                        {
+                            "LocalSlot": "DepthLinear",
+                            "AttachmentRef": {
+                                "Pass": "DepthPrePass",
+                                "Attachment": "DepthLinear"
+                            }
                         }
                     ]
                 },


### PR DESCRIPTION
This PR fixes the SSAO pipeline after the DepthLinear attachment was changed to a non-global slot in O3DE [PR19102](https://github.com/o3de/o3de/pull/19102). Without this PR screen-space AO of the SSAO sample does no longer work, although RTAO works fine nonetheless.