### PR TITLE
Add RT vertex animation benchmark sample

### DIFF
--- a/Gem/Code/Source/Passes/VertexAnimationPass.cpp
+++ b/Gem/Code/Source/Passes/VertexAnimationPass.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include "VertexAnimationPass.h"
+
+namespace AZ::Render
+{
+    RPI::Ptr<VertexAnimationPass> VertexAnimationPass::Create(const RPI::PassDescriptor& descriptor)
+    {
+        return aznew VertexAnimationPass{ descriptor };
+    }
+
+    VertexAnimationPass::VertexAnimationPass(const RPI::PassDescriptor& descriptor)
+        : BaseClass{ descriptor }
+    {
+    }
+
+    void VertexAnimationPass::SetSourceBuffer(Data::Instance<RPI::Buffer> sourceBuffer)
+    {
+        m_sourceBuffer = sourceBuffer;
+    }
+
+    void VertexAnimationPass::SetTargetBuffer(Data::Instance<RPI::Buffer> targetBuffer)
+    {
+        m_targetBuffer = targetBuffer;
+    }
+
+    void VertexAnimationPass::SetInstanceCount(u32 instanceCount)
+    {
+        m_instanceCount = instanceCount;
+    }
+
+    void VertexAnimationPass::SetVertexCountPerInstance(u32 vertexCountPerInstance)
+    {
+        m_vertexCountPerInstance = vertexCountPerInstance;
+    }
+
+    void VertexAnimationPass::SetTargetVertexStridePerInstance(u32 targetVertexStridePerInstance)
+    {
+        m_targetVertexStridePerInstance = targetVertexStridePerInstance;
+    }
+
+    void VertexAnimationPass::BuildInternal()
+    {
+        AttachBufferToSlot("SourceData", m_sourceBuffer);
+        AttachBufferToSlot("TargetData", m_targetBuffer);
+
+        RHI::BufferViewDescriptor sourceBufferView;
+        sourceBufferView.m_elementOffset = 0;
+        sourceBufferView.m_elementCount = m_vertexCountPerInstance;
+        sourceBufferView.m_elementSize = 12;
+        FindAttachmentBinding(Name{ "SourceData" })->m_unifiedScopeDesc.SetAsBuffer(sourceBufferView);
+
+        RHI::BufferViewDescriptor targetBufferView;
+        targetBufferView.m_elementOffset = 0;
+        targetBufferView.m_elementCount = m_targetVertexStridePerInstance * m_instanceCount;
+        targetBufferView.m_elementSize = 12;
+        FindAttachmentBinding(Name{ "TargetData" })->m_unifiedScopeDesc.SetAsBuffer(targetBufferView);
+
+        BaseClass::BuildInternal();
+    }
+
+    void VertexAnimationPass::FrameBeginInternal(FramePrepareParams params)
+    {
+        m_shaderResourceGroup->SetConstant(m_frameNumberNameIndex, m_frameNumber++);
+        m_shaderResourceGroup->SetConstant(m_vertexCountPerInstanceNameIndex, m_vertexCountPerInstance);
+        m_shaderResourceGroup->SetConstant(m_targetVertexStridePerInstanceNameIndex, m_targetVertexStridePerInstance);
+
+        BaseClass::FrameBeginInternal(params);
+    }
+} // namespace AZ::Render

--- a/Gem/Code/Source/Passes/VertexAnimationPass.cpp
+++ b/Gem/Code/Source/Passes/VertexAnimationPass.cpp
@@ -30,6 +30,11 @@ namespace AZ::Render
         m_targetBuffer = targetBuffer;
     }
 
+    void VertexAnimationPass::SetInstanceOffsetBuffer(Data::Instance<RPI::Buffer> instanceOffsetBuffer)
+    {
+        m_instanceOffsetBuffer = instanceOffsetBuffer;
+    }
+
     void VertexAnimationPass::SetInstanceCount(u32 instanceCount)
     {
         m_instanceCount = instanceCount;
@@ -49,6 +54,7 @@ namespace AZ::Render
     {
         AttachBufferToSlot("SourceData", m_sourceBuffer);
         AttachBufferToSlot("TargetData", m_targetBuffer);
+        AttachBufferToSlot("InstanceOffsetData", m_instanceOffsetBuffer);
 
         RHI::BufferViewDescriptor sourceBufferView;
         sourceBufferView.m_elementOffset = 0;
@@ -61,6 +67,12 @@ namespace AZ::Render
         targetBufferView.m_elementCount = m_targetVertexStridePerInstance * m_instanceCount;
         targetBufferView.m_elementSize = 12;
         FindAttachmentBinding(Name{ "TargetData" })->m_unifiedScopeDesc.SetAsBuffer(targetBufferView);
+
+        RHI::BufferViewDescriptor instanceOffsetBufferView;
+        instanceOffsetBufferView.m_elementOffset = 0;
+        instanceOffsetBufferView.m_elementCount = m_instanceCount;
+        instanceOffsetBufferView.m_elementSize = 12;
+        FindAttachmentBinding(Name{ "InstanceOffsetData" })->m_unifiedScopeDesc.SetAsBuffer(instanceOffsetBufferView);
 
         BaseClass::BuildInternal();
     }

--- a/Gem/Code/Source/Passes/VertexAnimationPass.cpp
+++ b/Gem/Code/Source/Passes/VertexAnimationPass.cpp
@@ -18,6 +18,7 @@ namespace AZ::Render
     VertexAnimationPass::VertexAnimationPass(const RPI::PassDescriptor& descriptor)
         : BaseClass{ descriptor }
     {
+        m_frameTimer.Stamp();
     }
 
     void VertexAnimationPass::SetSourceBuffer(Data::Instance<RPI::Buffer> sourceBuffer)
@@ -79,9 +80,11 @@ namespace AZ::Render
 
     void VertexAnimationPass::FrameBeginInternal(FramePrepareParams params)
     {
-        m_shaderResourceGroup->SetConstant(m_frameNumberNameIndex, m_frameNumber++);
+        m_shaderResourceGroup->SetConstant(m_frameTimeNameIndex, m_frameTime);
         m_shaderResourceGroup->SetConstant(m_vertexCountPerInstanceNameIndex, m_vertexCountPerInstance);
         m_shaderResourceGroup->SetConstant(m_targetVertexStridePerInstanceNameIndex, m_targetVertexStridePerInstance);
+
+        m_frameTime += m_frameTimer.StampAndGetDeltaTimeInSeconds();
 
         BaseClass::FrameBeginInternal(params);
     }

--- a/Gem/Code/Source/Passes/VertexAnimationPass.h
+++ b/Gem/Code/Source/Passes/VertexAnimationPass.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Public/Pass/ComputePass.h>
+
+namespace AZ::Render
+{
+    class VertexAnimationPass : public RPI::ComputePass
+    {
+        using BaseClass = RPI::ComputePass;
+
+    public:
+        AZ_RTTI(VertexAnimationPass, "{5796A3AC-E306-4F0C-8B2D-DDC25EE446F8}", BaseClass);
+        AZ_CLASS_ALLOCATOR(VertexAnimationPass, SystemAllocator, 0);
+        static RPI::Ptr<VertexAnimationPass> Create(const RPI::PassDescriptor& descriptor);
+
+        void SetSourceBuffer(Data::Instance<RPI::Buffer> sourceBuffer);
+        void SetTargetBuffer(Data::Instance<RPI::Buffer> targetBuffer);
+        void SetInstanceCount(u32 instanceCount);
+        void SetVertexCountPerInstance(u32 vertexCountPerInstance);
+        void SetTargetVertexStridePerInstance(u32 targetVertexStridePerInstance);
+
+    protected:
+        explicit VertexAnimationPass(const RPI::PassDescriptor& descriptor);
+
+        void BuildInternal() override;
+        void FrameBeginInternal(FramePrepareParams params) override;
+
+    private:
+        Data::Instance<RPI::Buffer> m_sourceBuffer;
+        Data::Instance<RPI::Buffer> m_targetBuffer;
+        u32 m_instanceCount;
+        u32 m_vertexCountPerInstance;
+        u32 m_targetVertexStridePerInstance;
+
+        RHI::ShaderInputNameIndex m_frameNumberNameIndex{ "m_frameNumber" };
+        RHI::ShaderInputNameIndex m_vertexCountPerInstanceNameIndex{ "m_vertexCountPerInstance" };
+        RHI::ShaderInputNameIndex m_targetVertexStridePerInstanceNameIndex{ "m_targetVertexStridePerInstance" };
+        unsigned m_frameNumber{ 0 };
+    };
+} // namespace AZ::Render

--- a/Gem/Code/Source/Passes/VertexAnimationPass.h
+++ b/Gem/Code/Source/Passes/VertexAnimationPass.h
@@ -23,6 +23,7 @@ namespace AZ::Render
 
         void SetSourceBuffer(Data::Instance<RPI::Buffer> sourceBuffer);
         void SetTargetBuffer(Data::Instance<RPI::Buffer> targetBuffer);
+        void SetInstanceOffsetBuffer(Data::Instance<RPI::Buffer> instanceOffsetBuffer);
         void SetInstanceCount(u32 instanceCount);
         void SetVertexCountPerInstance(u32 vertexCountPerInstance);
         void SetTargetVertexStridePerInstance(u32 targetVertexStridePerInstance);
@@ -36,6 +37,7 @@ namespace AZ::Render
     private:
         Data::Instance<RPI::Buffer> m_sourceBuffer;
         Data::Instance<RPI::Buffer> m_targetBuffer;
+        Data::Instance<RPI::Buffer> m_instanceOffsetBuffer;
         u32 m_instanceCount;
         u32 m_vertexCountPerInstance;
         u32 m_targetVertexStridePerInstance;

--- a/Gem/Code/Source/Passes/VertexAnimationPass.h
+++ b/Gem/Code/Source/Passes/VertexAnimationPass.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <Atom/RPI.Public/Pass/ComputePass.h>
+#include <AzCore/Debug/Timer.h>
 
 namespace AZ::Render
 {
@@ -42,9 +43,10 @@ namespace AZ::Render
         u32 m_vertexCountPerInstance;
         u32 m_targetVertexStridePerInstance;
 
-        RHI::ShaderInputNameIndex m_frameNumberNameIndex{ "m_frameNumber" };
+        RHI::ShaderInputNameIndex m_frameTimeNameIndex{ "m_frameTime" };
         RHI::ShaderInputNameIndex m_vertexCountPerInstanceNameIndex{ "m_vertexCountPerInstance" };
         RHI::ShaderInputNameIndex m_targetVertexStridePerInstanceNameIndex{ "m_targetVertexStridePerInstance" };
-        unsigned m_frameNumber{ 0 };
+        Debug::Timer m_frameTimer;
+        float m_frameTime{ 0 };
     };
 } // namespace AZ::Render

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Performance/RayTracingVertexAnimationExampleComponent.h>
+#include <SampleComponentConfig.h>
+#include <SampleComponentManager.h>
+
+#include <Atom/Bootstrap/BootstrapNotificationBus.h>
+#include <Atom/Component/DebugCamera/ArcBallControllerComponent.h>
+#include <Atom/RHI/RayTracingBufferPools.h>
+#include <Atom/RPI.Public/Pass/PassFilter.h>
+#include <AzCore/Math/Geometry3DUtils.h>
+
+AZ_DECLARE_BUDGET(AtomSampleViewer);
+
+namespace AtomSampleViewer
+{
+    using namespace AZ;
+
+    void RayTracingVertexAnimationExampleComponent::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext{ azrtti_cast<AZ::SerializeContext*>(context) })
+        {
+            serializeContext->Class<RayTracingVertexAnimationExampleComponent, Base>()->Version(0);
+        }
+    }
+
+    RayTracingVertexAnimationExampleComponent::RayTracingVertexAnimationExampleComponent()
+    {
+        m_sampleName = "RayTracingVertexAnimation";
+    }
+
+    void RayTracingVertexAnimationExampleComponent::Activate()
+    {
+        InitLightingPresets(true);
+
+        auto& rayTracingDebugFeatureProcessor{ GetRayTracingDebugFeatureProcessor() };
+        rayTracingDebugFeatureProcessor.OnRayTracingDebugComponentAdded();
+        rayTracingDebugFeatureProcessor.GetSettingsInterface()->SetDebugViewMode(AZ::Render::RayTracingDebugViewMode::Normals);
+
+        EBUS_EVENT_ID(GetCameraEntityId(), Debug::CameraControllerRequestBus, Enable, azrtti_typeid<Debug::ArcBallControllerComponent>());
+        EBUS_EVENT_ID(GetCameraEntityId(), Debug::ArcBallControllerRequestBus, SetDistance, 10.f);
+        EBUS_EVENT_ID(GetCameraEntityId(), Debug::ArcBallControllerRequestBus, SetPitch, DegToRad(-20.f));
+        EBUS_EVENT_ID(GetCameraEntityId(), Debug::ArcBallControllerRequestBus, SetPan, AZ::Vector3{ 0.2f, 0.6f, 1.2f });
+
+        CreateRayTracingGeometry();
+
+        RPI::SceneNotificationBus::Handler::BusConnect(RPI::Scene::GetSceneForEntityContextId(GetEntityContextId())->GetId());
+
+        Render::Bootstrap::NotificationBus::Broadcast(&Render::Bootstrap::NotificationBus::Handler::OnBootstrapSceneReady, m_scene);
+    }
+
+    void RayTracingVertexAnimationExampleComponent::Deactivate()
+    {
+        RPI::SceneNotificationBus::Handler::BusDisconnect();
+
+        for (const RayTracingMesh& rayTracingMesh : m_rayTracingData)
+        {
+            GetRayTracingFeatureProcessor().RemoveMesh(rayTracingMesh.m_uuid);
+        }
+
+        GetRayTracingDebugFeatureProcessor().OnRayTracingDebugComponentRemoved();
+
+        ShutdownLightingPresets();
+    }
+
+    void RayTracingVertexAnimationExampleComponent::OnRenderPipelineChanged(
+        AZ::RPI::RenderPipeline* renderPipeline, RenderPipelineChangeType changeType)
+    {
+        if (!renderPipeline->GetScene() || renderPipeline != renderPipeline->GetScene()->GetDefaultRenderPipeline().get())
+        {
+            return;
+        }
+
+        AddVertexAnimationPass(renderPipeline);
+    }
+
+    RayTracingVertexAnimationExampleComponent::BasicGeometry RayTracingVertexAnimationExampleComponent::GenerateBasicGeometry()
+    {
+        BasicGeometry geometry;
+
+        AZStd::vector<AZ::Vector3> vertices{ Geometry3dUtils::GenerateIcoSphere(2) };
+
+        for (const Vector3& unpackedVertex : vertices)
+        {
+            geometry.m_positions.emplace_back(unpackedVertex);
+        }
+
+        for (size_t i{ 0 }; i < vertices.size(); i += 3)
+        {
+            AZ::Vector3 normal{ (vertices[i + 1] - vertices[i]).Cross(vertices[i + 2] - vertices[i]).GetNormalized() };
+            geometry.m_normals.emplace_back(normal);
+            geometry.m_normals.emplace_back(normal);
+            geometry.m_normals.emplace_back(normal);
+        }
+
+        geometry.m_indices.resize(vertices.size());
+        AZStd::ranges::iota(geometry.m_indices, 0);
+
+        return geometry;
+    }
+
+    void RayTracingVertexAnimationExampleComponent::CreateRayTracingGeometry()
+    {
+        for (const RayTracingMesh& rayTracingMesh : m_rayTracingData)
+        {
+            GetRayTracingFeatureProcessor().RemoveMesh(rayTracingMesh.m_uuid);
+        }
+        m_rayTracingData.clear();
+
+        constexpr AZ::RHI::VertexFormat PositionStreamFormat{ AZ::RHI::VertexFormat::R32G32B32_FLOAT };
+        constexpr AZ::RHI::VertexFormat NormalStreamFormat{ AZ::RHI::VertexFormat::R32G32B32_FLOAT };
+        constexpr AZ::RHI::IndexFormat IndexStreamFormat{ AZ::RHI::IndexFormat::Uint32 };
+        const uint32_t PositionSize{ AZ::RHI::GetVertexFormatSize(PositionStreamFormat) };
+        const uint32_t NormalSize{ AZ::RHI::GetVertexFormatSize(NormalStreamFormat) };
+        const uint32_t IndexSize{ AZ::RHI::GetIndexFormatSize(IndexStreamFormat) };
+
+        BasicGeometry geometry{ GenerateBasicGeometry() };
+
+        u32 vertexCount{ aznumeric_cast<u32>(geometry.m_positions.size()) };
+        u32 indexCount{ vertexCount };
+
+        u32 positionByteOffset{ 0 };
+        u32 normalByteOffset{ positionByteOffset + vertexCount * PositionSize };
+        u32 indexByteOffset{ normalByteOffset + vertexCount * NormalSize };
+        u32 sourceBufferSize{ AZ::SizeAlignUp(indexByteOffset + indexCount * IndexSize, PositionSize) };
+
+        u32 targetBufferSizePerInstance{ vertexCount * PositionSize };
+        u32 targetBufferSize{ targetBufferSizePerInstance * m_geometryCount };
+
+        m_vertexCountPerInstance = vertexCount;
+        m_targetVertexStridePerInstance = targetBufferSizePerInstance / PositionSize;
+
+        AZStd::vector<AZStd::byte> geometryBuffer(sourceBufferSize);
+        memcpy(geometryBuffer.data() + positionByteOffset, geometry.m_positions.data(), vertexCount * PositionSize);
+        memcpy(geometryBuffer.data() + normalByteOffset, geometry.m_normals.data(), vertexCount * NormalSize);
+        memcpy(geometryBuffer.data() + indexByteOffset, geometry.m_indices.data(), indexCount * IndexSize);
+
+        AZ::RPI::CommonBufferDescriptor sourceBufferDescriptor;
+        sourceBufferDescriptor.m_bufferName = "RayTracingExampleComponentSourceGeometry";
+        sourceBufferDescriptor.m_poolType = AZ::RPI::CommonBufferPoolType::ReadWrite;
+        sourceBufferDescriptor.m_byteCount = sourceBufferSize;
+        sourceBufferDescriptor.m_elementSize = 1;
+        sourceBufferDescriptor.m_bufferData = geometryBuffer.data();
+        m_sourceGeometryBuffer = AZ::RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(sourceBufferDescriptor);
+
+        AZ::RPI::CommonBufferDescriptor targetBufferDescriptor;
+        targetBufferDescriptor.m_bufferName = "RayTracingExampleComponentTargetGeometry";
+        targetBufferDescriptor.m_poolType = AZ::RPI::CommonBufferPoolType::ReadWrite;
+        targetBufferDescriptor.m_byteCount = targetBufferSize;
+        targetBufferDescriptor.m_elementSize = 1;
+        m_targetGeometryBuffer = AZ::RPI::BufferSystemInterface::Get()->CreateBufferFromCommonPool(targetBufferDescriptor);
+
+        auto sourceRhiGeometryBuffer{ m_sourceGeometryBuffer->GetRHIBuffer() };
+        auto targetRhiGeometryBuffer{ m_targetGeometryBuffer->GetRHIBuffer() };
+        auto sourceShaderBufferView{ sourceRhiGeometryBuffer->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, sourceBufferSize)) };
+        auto targetShaderBufferView{ targetRhiGeometryBuffer->GetBufferView(
+            RHI::BufferViewDescriptor::CreateRaw(0, targetBufferSize)) };
+
+        int gridWidth{ aznumeric_cast<int>(AZStd::ceil(AZStd::sqrt(m_geometryCount))) };
+        float gridSpacing{ 2.3f };
+
+        for (int i{ 0 }; i < m_geometryCount; i++)
+        {
+            auto& data{ m_rayTracingData.emplace_back() };
+            data.m_uuid = AZ::Uuid::CreateRandom();
+
+            // m_assetId needs to be unique for each instance, otherwise BLASes are not unique
+            data.m_rtMesh.m_assetId = Data::AssetId{ Uuid::CreateRandom() };
+            data.m_rtMesh.m_transform.SetTranslation(
+                AZ::Vector3{ (i % gridWidth - (gridWidth - 1) / 2.f) * gridSpacing, (i / gridWidth) * gridSpacing, 0.f });
+            data.m_rtMesh.m_isSkinnedMesh = true; // Skinned mesh BLASes are updated every frame
+            data.m_rtMesh.m_instanceMask |=
+                static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::STATIC_MESH);
+
+            auto& subMesh{ data.m_rtSubMeshes.emplace_back() };
+
+            // Use position data from target buffer with unique offset per instance
+            subMesh.m_positionFormat = PositionStreamFormat;
+            subMesh.m_positionShaderBufferView = targetShaderBufferView;
+            subMesh.m_positionVertexBufferView = RHI::StreamBufferView{ *targetRhiGeometryBuffer, targetBufferSizePerInstance * i,
+                                                                        vertexCount * PositionSize, PositionSize };
+
+            // Use normal data from source buffer
+            subMesh.m_normalFormat = NormalStreamFormat;
+            subMesh.m_normalShaderBufferView = sourceShaderBufferView;
+            subMesh.m_normalVertexBufferView =
+                RHI::StreamBufferView{ *sourceRhiGeometryBuffer, normalByteOffset, vertexCount * NormalSize, NormalSize };
+
+            // Use index data from source data
+            subMesh.m_indexShaderBufferView = sourceShaderBufferView;
+            subMesh.m_indexBufferView =
+                RHI::IndexBufferView{ *sourceRhiGeometryBuffer, indexByteOffset, indexCount * IndexSize, IndexStreamFormat };
+
+            // Dont need to set material since the DebugRayTracingPass is used to visualize the geometry
+
+            GetRayTracingFeatureProcessor().AddMesh(data.m_uuid, data.m_rtMesh, data.m_rtSubMeshes);
+        }
+    }
+
+    void RayTracingVertexAnimationExampleComponent::AddVertexAnimationPass(AZ::RPI::RenderPipeline* renderPipeline)
+    {
+        Name passName{ "VertexAnimationPass" };
+        auto filter{ AZ::RPI::PassFilter::CreateWithPassName(passName, renderPipeline) };
+        if (RPI::PassSystemInterface::Get()->FindFirstPass(filter))
+        {
+            return;
+        }
+
+        auto pass{ RPI::PassSystemInterface::Get()->CreatePassFromTemplate(Name{ "VertexAnimationTemplate" }, passName) };
+        if (!pass)
+        {
+            AZ_Assert(false, "Failed to create VertexAnimationPass");
+            return;
+        }
+        m_vertexAnimationPass = AZStd::static_pointer_cast<Render::VertexAnimationPass>(pass);
+        if (!m_vertexAnimationPass)
+        {
+            AZ_Assert(false, "VertexAnimationPass is not a ComputePass");
+            return;
+        }
+
+        m_vertexAnimationPass->SetTargetThreadCounts(m_vertexCountPerInstance * m_geometryCount, 1, 1);
+        m_vertexAnimationPass->SetSourceBuffer(m_sourceGeometryBuffer);
+        m_vertexAnimationPass->SetTargetBuffer(m_targetGeometryBuffer);
+        m_vertexAnimationPass->SetVertexCountPerInstance(m_vertexCountPerInstance);
+        m_vertexAnimationPass->SetTargetVertexStridePerInstance(m_targetVertexStridePerInstance);
+        m_vertexAnimationPass->SetInstanceCount(m_geometryCount);
+
+        renderPipeline->AddPassBefore(m_vertexAnimationPass, Name{ "RayTracingAccelerationStructurePass" });
+    }
+
+    Render::RayTracingFeatureProcessorInterface& RayTracingVertexAnimationExampleComponent::GetRayTracingFeatureProcessor()
+    {
+        if (!m_rayTracingFeatureProcessor)
+        {
+            RPI::Scene* scene{ RPI::Scene::GetSceneForEntityContextId(GetEntityContextId()) };
+            auto featureProcessor{ scene->GetFeatureProcessor<Render::RayTracingFeatureProcessorInterface>() };
+            AZ_Assert(featureProcessor != nullptr, "RayTracingDebugFeatureProcessor not found");
+            m_rayTracingFeatureProcessor = featureProcessor;
+        }
+        return *m_rayTracingFeatureProcessor;
+    }
+
+    Render::RayTracingDebugFeatureProcessorInterface& RayTracingVertexAnimationExampleComponent::GetRayTracingDebugFeatureProcessor()
+    {
+        if (!m_rayTracingDebugFeatureProcessor)
+        {
+            RPI::Scene* scene{ RPI::Scene::GetSceneForEntityContextId(GetEntityContextId()) };
+            auto featureProcessor{ scene->GetFeatureProcessor<Render::RayTracingDebugFeatureProcessorInterface>() };
+            AZ_Assert(featureProcessor != nullptr, "RayTracingDebugFeatureProcessor not found");
+            m_rayTracingDebugFeatureProcessor = featureProcessor;
+        }
+        return *m_rayTracingDebugFeatureProcessor;
+    }
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
@@ -564,9 +564,11 @@ namespace AtomSampleViewer
                 for (const auto& [deviceIndex, dataPointer] : clusterStreamOffsetsMapResponse.m_data)
                 {
                     auto* clusterOffsetInfo{ reinterpret_cast<RHI::RayTracingClasClusterOffsetInfo*>(dataPointer) + i };
-                    clusterOffsetInfo->m_indexBufferOffset = indexBufferSizePerCluster * clusterId; // Use same index data for all clusters
-                    clusterOffsetInfo->m_positionBufferOffset = targetBufferSizePerCluster * i; // Use unique position data for each cluster
-                    clusterOffsetInfo->m_normalBufferOffset = 0; // Use same normal data for all clusters
+                    clusterOffsetInfo->m_indexOffset = indexBufferSizePerCluster * clusterId; // Use same index data for all clusters
+                    clusterOffsetInfo->m_positionOffset = targetBufferSizePerCluster * i; // Use unique position data for each cluster
+                    clusterOffsetInfo->m_positionStride = 0; // Tightly pack positions
+                    clusterOffsetInfo->m_normalOffset = 0; // Use same normal data for all clusters
+                    clusterOffsetInfo->m_normalStride = 0; // Tightly pack normals
                 }
             }
             bufferPools.GetSrcInfosArrayBufferPool()->UnmapBuffer(*m_srcInfosArrayBuffer);

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
@@ -110,6 +110,10 @@ namespace AtomSampleViewer
         for (const RayTracingMesh& rayTracingMesh : m_rayTracingData)
         {
             GetRayTracingFeatureProcessor().RemoveMesh(rayTracingMesh.m_uuid);
+            for (const auto& subMesh : rayTracingMesh.m_rtSubMeshes)
+            {
+                GetMeshFeatureProcessor().ReleaseMeshInfoEntry(subMesh.m_meshInfoHandle);
+            }
         }
 
         GetRayTracingDebugFeatureProcessor().OnRayTracingDebugComponentRemoved();
@@ -327,6 +331,10 @@ namespace AtomSampleViewer
         for (const RayTracingMesh& rayTracingMesh : m_rayTracingData)
         {
             GetRayTracingFeatureProcessor().RemoveMesh(rayTracingMesh.m_uuid);
+            for (const auto& subMesh : rayTracingMesh.m_rtSubMeshes)
+            {
+                GetMeshFeatureProcessor().ReleaseMeshInfoEntry(subMesh.m_meshInfoHandle);
+            }
         }
         m_rayTracingData.clear();
 
@@ -389,8 +397,6 @@ namespace AtomSampleViewer
 
         auto sourceRhiGeometryBuffer{ m_sourceGeometryBuffer->GetRHIBuffer() };
         auto targetRhiGeometryBuffer{ m_targetGeometryBuffer->GetRHIBuffer() };
-        auto sourceShaderBufferView{ sourceRhiGeometryBuffer->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, sourceBufferSize)) };
-        auto targetShaderBufferView{ targetRhiGeometryBuffer->GetBufferView(RHI::BufferViewDescriptor::CreateRaw(0, targetBufferSize)) };
 
         {
             int gridWidth{ aznumeric_cast<int>(AZStd::ceil(AZStd::sqrt(m_geometryCount))) };
@@ -429,23 +435,29 @@ namespace AtomSampleViewer
                     static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::STATIC_MESH);
 
                 auto& subMesh{ data.m_rtSubMeshes.emplace_back() };
+                subMesh.m_meshInfoHandle = GetMeshFeatureProcessor().AcquireMeshInfoEntry();
 
-                // Use position data from target buffer with unique offset per instance
-                subMesh.m_positionFormat = PositionStreamFormat;
-                subMesh.m_positionShaderBufferView = targetShaderBufferView;
-                subMesh.m_positionVertexBufferView = RHI::StreamBufferView{ *targetRhiGeometryBuffer, targetBufferSizePerInstance * i,
-                                                                            vertexCount * PositionSize, PositionSize };
+                GetMeshFeatureProcessor().UpdateMeshInfoEntry(
+                    subMesh.m_meshInfoHandle,
+                    [&](Render::MeshInfoEntry* meshInfoEntry)
+                    {
+                        // Use index data from source data;
+                        meshInfoEntry->m_indexBuffer = Render::IndexBufferViewIndexAndOffset::Create(
+                            RHI::IndexBufferView{ *sourceRhiGeometryBuffer, indexByteOffset, indexCount * IndexSize, IndexStreamFormat });
 
-                // Use normal data from source buffer
-                subMesh.m_normalFormat = NormalStreamFormat;
-                subMesh.m_normalShaderBufferView = sourceShaderBufferView;
-                subMesh.m_normalVertexBufferView =
-                    RHI::StreamBufferView{ *sourceRhiGeometryBuffer, normalByteOffset, vertexCount * NormalSize, NormalSize };
+                        // Use position data from target buffer with unique offset per instance
+                        meshInfoEntry->m_meshBuffers[RHI::ShaderSemantic{ "POSITION" }] = Render::BufferViewIndexAndOffset::Create(
+                            RHI::StreamBufferView{ *targetRhiGeometryBuffer, targetBufferSizePerInstance * i, vertexCount * PositionSize,
+                                                   PositionSize },
+                            PositionStreamFormat);
 
-                // Use index data from source data
-                subMesh.m_indexShaderBufferView = sourceShaderBufferView;
-                subMesh.m_indexBufferView =
-                    RHI::IndexBufferView{ *sourceRhiGeometryBuffer, indexByteOffset, indexCount * IndexSize, IndexStreamFormat };
+                        // Use normal data from source buffer
+                        meshInfoEntry->m_meshBuffers[RHI::ShaderSemantic{ "NORMAL" }] = Render::BufferViewIndexAndOffset::Create(
+                            RHI::StreamBufferView{ *sourceRhiGeometryBuffer, normalByteOffset, vertexCount * NormalSize, NormalSize },
+                            NormalStreamFormat);
+
+                        return true;
+                    });
 
                 // Dont need to set material since the DebugRayTracingPass is used to visualize the geometry
                 GetRayTracingFeatureProcessor().AddMesh(data.m_uuid, data.m_rtMesh, data.m_rtSubMeshes);
@@ -462,24 +474,34 @@ namespace AtomSampleViewer
             data.m_rtMesh.m_instanceMask |=
                 static_cast<uint32_t>(AZ::RHI::RayTracingAccelerationStructureInstanceInclusionMask::STATIC_MESH);
 
-            Render::RayTracingFeatureProcessorInterface::SubMesh subMesh;
+            auto updateMeshInfoBuffers{
+                [&](const Render::MeshInfoHandle& meshInfoHandle, const RHI::Ptr<RHI::BufferView>& clusterOffsetBufferView)
+                {
+                    GetMeshFeatureProcessor().UpdateMeshInfoEntry(
+                        meshInfoHandle,
+                        [&](Render::MeshInfoEntry* meshInfoEntry)
+                        {
+                            // Use index data from source data;
+                            meshInfoEntry->m_indexBuffer = Render::IndexBufferViewIndexAndOffset::Create(
+                                RHI::IndexBufferView{ *sourceRhiGeometryBuffer, indexByteOffset, indexCount * IndexSize,
+                                                      IndexStreamFormat });
 
-            // Use position data from target buffer with unique offset per instance
-            subMesh.m_positionFormat = PositionStreamFormat;
-            subMesh.m_positionShaderBufferView = targetShaderBufferView;
-            subMesh.m_positionVertexBufferView =
-                RHI::StreamBufferView{ *targetRhiGeometryBuffer, 0, vertexCount * PositionSize, PositionSize };
+                            // Use position data from target buffer with unique offset per instance
+                            meshInfoEntry->m_meshBuffers[RHI::ShaderSemantic{ "POSITION" }] = Render::BufferViewIndexAndOffset::Create(
+                                RHI::StreamBufferView{ *targetRhiGeometryBuffer, 0, vertexCount * PositionSize, PositionSize },
+                                PositionStreamFormat);
 
-            // Use normal data from source buffer
-            subMesh.m_normalFormat = NormalStreamFormat;
-            subMesh.m_normalShaderBufferView = sourceShaderBufferView;
-            subMesh.m_normalVertexBufferView =
-                RHI::StreamBufferView{ *sourceRhiGeometryBuffer, normalByteOffset, vertexCount * NormalSize, NormalSize };
+                            // Use normal data from source buffer
+                            meshInfoEntry->m_meshBuffers[RHI::ShaderSemantic{ "NORMAL" }] = Render::BufferViewIndexAndOffset::Create(
+                                RHI::StreamBufferView{ *sourceRhiGeometryBuffer, normalByteOffset, vertexCount * NormalSize, NormalSize },
+                                NormalStreamFormat);
 
-            // Use index data from source data
-            subMesh.m_indexShaderBufferView = sourceShaderBufferView;
-            subMesh.m_indexBufferView =
-                RHI::IndexBufferView{ *sourceRhiGeometryBuffer, indexByteOffset, indexCount * IndexSize, IndexStreamFormat };
+                            meshInfoEntry->m_clusterOffsetBuffer = clusterOffsetBufferView;
+
+                            return true;
+                        });
+                }
+            };
 
             auto& bufferPools{ GetRayTracingFeatureProcessor().GetBufferPools() };
             int clusterCountPerInstance{ geometry.GetClusterCount() };
@@ -564,11 +586,18 @@ namespace AtomSampleViewer
                 for (const auto& [deviceIndex, dataPointer] : clusterStreamOffsetsMapResponse.m_data)
                 {
                     auto* clusterOffsetInfo{ reinterpret_cast<RHI::RayTracingClasClusterOffsetInfo*>(dataPointer) + i };
-                    clusterOffsetInfo->m_indexOffset = indexBufferSizePerCluster * clusterId; // Use same index data for all clusters
-                    clusterOffsetInfo->m_positionOffset = targetBufferSizePerCluster * i; // Use unique position data for each cluster
-                    clusterOffsetInfo->m_positionStride = 0; // Tightly pack positions
-                    clusterOffsetInfo->m_normalOffset = 0; // Use same normal data for all clusters
-                    clusterOffsetInfo->m_normalStride = 0; // Tightly pack normals
+
+                    // Use same index data for all clusters
+                    clusterOffsetInfo->m_indexOffset = indexByteOffset + indexBufferSizePerCluster * clusterId;
+                    clusterOffsetInfo->m_indexStride = RHI::GetIndexFormatSize(IndexStreamFormat); // Tightly pack indices
+
+                    // Use unique position data for each cluster
+                    clusterOffsetInfo->m_positionOffset = positionByteOffset + targetBufferSizePerCluster * i;
+                    clusterOffsetInfo->m_positionStride = RHI::GetVertexFormatSize(PositionStreamFormat); // Tightly pack positions
+
+                    // Use same normal data for all clusters
+                    clusterOffsetInfo->m_normalOffset = normalByteOffset;
+                    clusterOffsetInfo->m_normalStride = RHI::GetVertexFormatSize(NormalStreamFormat); // Tightly pack normals
                 }
             }
             bufferPools.GetSrcInfosArrayBufferPool()->UnmapBuffer(*m_srcInfosArrayBuffer);
@@ -592,29 +621,36 @@ namespace AtomSampleViewer
                 clusterDescriptor.m_maxTotalVertexCount *= m_geometryCount;
                 clusterDescriptor.m_maxClusterCount *= m_geometryCount;
             }
-            subMesh.m_clusterBlasDescriptor = clusterDescriptor;
 
             if (m_separateClusterBlasForEachInstance)
             {
                 for (int i{ 0 }; i < m_geometryCount; i++)
                 {
+                    auto& subMesh{ data.m_rtSubMeshes.emplace_back() };
+                    subMesh.m_meshInfoHandle = GetMeshFeatureProcessor().AcquireMeshInfoEntry();
+                    subMesh.m_clusterBlasDescriptor = clusterDescriptor;
                     subMesh.m_clusterBlasDescriptor->m_srcInfosArrayBufferView = m_srcInfosArrayBuffer->GetBufferView(
                         RHI::BufferViewDescriptor::CreateStructured(
                             i * clusterCountPerInstance, clusterCountPerInstance, sizeof(RHI::RayTracingClasBuildTriangleClusterInfo)));
-                    subMesh.m_clusterOffsetBufferView = m_clusterStreamOffsets->GetBufferView(
+
+                    auto clusterOffsetBufferView{ m_clusterStreamOffsets->GetBufferView(
                         RHI::BufferViewDescriptor::CreateRaw(
                             i * clusterCountPerInstance * sizeof(RHI::RayTracingClasClusterOffsetInfo),
-                            clusterCountPerInstance * sizeof(RHI::RayTracingClasClusterOffsetInfo)));
-                    data.m_rtSubMeshes.push_back(subMesh);
+                            clusterCountPerInstance * sizeof(RHI::RayTracingClasClusterOffsetInfo))) };
+                    updateMeshInfoBuffers(subMesh.m_meshInfoHandle, clusterOffsetBufferView);
                 }
             }
             else
             {
+                auto& subMesh{ data.m_rtSubMeshes.emplace_back() };
+                subMesh.m_meshInfoHandle = GetMeshFeatureProcessor().AcquireMeshInfoEntry();
+                subMesh.m_clusterBlasDescriptor = clusterDescriptor;
                 subMesh.m_clusterBlasDescriptor->m_srcInfosArrayBufferView = m_srcInfosArrayBuffer->GetBufferView(
                     RHI::BufferViewDescriptor::CreateStructured(0, totalClusterCount, sizeof(RHI::RayTracingClasBuildTriangleClusterInfo)));
-                subMesh.m_clusterOffsetBufferView = m_clusterStreamOffsets->GetBufferView(
-                    RHI::BufferViewDescriptor::CreateRaw(0, totalClusterCount * sizeof(RHI::RayTracingClasClusterOffsetInfo)));
-                data.m_rtSubMeshes.push_back(subMesh);
+
+                auto clusterOffsetBufferView{ m_clusterStreamOffsets->GetBufferView(
+                    RHI::BufferViewDescriptor::CreateRaw(0, totalClusterCount * sizeof(RHI::RayTracingClasClusterOffsetInfo))) };
+                updateMeshInfoBuffers(subMesh.m_meshInfoHandle, clusterOffsetBufferView);
             }
 
             GetRayTracingFeatureProcessor().AddMesh(data.m_uuid, data.m_rtMesh, data.m_rtSubMeshes);
@@ -788,13 +824,25 @@ namespace AtomSampleViewer
         }
     }
 
+    Render::MeshFeatureProcessorInterface& RayTracingVertexAnimationExampleComponent::GetMeshFeatureProcessor()
+    {
+        if (!m_meshFeatureProcessor)
+        {
+            RPI::Scene* scene{ RPI::Scene::GetSceneForEntityContextId(GetEntityContextId()) };
+            auto featureProcessor{ scene->GetFeatureProcessor<Render::MeshFeatureProcessorInterface>() };
+            AZ_Assert(featureProcessor != nullptr, "MeshFeatureProcessor not found");
+            m_meshFeatureProcessor = featureProcessor;
+        }
+        return *m_meshFeatureProcessor;
+    }
+
     Render::RayTracingFeatureProcessorInterface& RayTracingVertexAnimationExampleComponent::GetRayTracingFeatureProcessor()
     {
         if (!m_rayTracingFeatureProcessor)
         {
             RPI::Scene* scene{ RPI::Scene::GetSceneForEntityContextId(GetEntityContextId()) };
             auto featureProcessor{ scene->GetFeatureProcessor<Render::RayTracingFeatureProcessorInterface>() };
-            AZ_Assert(featureProcessor != nullptr, "RayTracingDebugFeatureProcessor not found");
+            AZ_Assert(featureProcessor != nullptr, "RayTracingFeatureProcessor not found");
             m_rayTracingFeatureProcessor = featureProcessor;
         }
         return *m_rayTracingFeatureProcessor;

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -93,7 +93,9 @@ namespace AtomSampleViewer
         ImGuiSidebar m_imguiSidebar;
         AccelerationStructureType m_accelerationStructureType{ AccelerationStructureType::TriangleBLAS };
         ImGuiHistogramQueue m_imGuiFrameTimer{ 60, 60 };
-        ImGuiHistogramQueue m_accelerationStructureTimer{ 60, 60 };
+        ImGuiHistogramQueue m_accelerationStructurePassTimer{ 60, 60 };
+        ImGuiHistogramQueue m_rayTracingPassTimer{ 60, 60 };
         AZ::RHI::Ptr<AZ::RPI::Pass> m_rayTracingAccelerationStructurePass;
+        AZ::RHI::Ptr<AZ::RPI::Pass> m_debugRayTracingPass;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -114,7 +114,7 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_clusterStreamOffsets;
         AZStd::vector<RayTracingMesh> m_rayTracingData;
         int m_geometryCount{ 100 };
-        bool m_separateClusterBlasForEachInstance{ false };
+        bool m_separateClusterBlasForEachInstance{ true };
         AZ::u32 m_vertexCountPerInstance;
         AZ::u32 m_targetVertexStridePerInstance;
         AZ::RPI::Ptr<AZ::Render::VertexAnimationPass> m_vertexAnimationPass;

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -35,6 +35,17 @@ namespace AtomSampleViewer
             CLAS_ClusterBLAS,
         };
 
+        struct PerformanceConfiguration
+        {
+            int m_geometryCount;
+            AccelerationStructureType m_accelerationStructureType;
+        };
+        struct PerformanceResult
+        {
+            float m_buildTime;
+            float m_traceRayTime;
+        };
+
     public:
         AZ_COMPONENT(RayTracingVertexAnimationExampleComponent, "{9B43FED7-8BD0-4159-BDEC-BBF7EA39C1EC}", Base);
 
@@ -70,11 +81,15 @@ namespace AtomSampleViewer
 
         void SaveVSyncStateAndDisableVsync();
         void RestoreVSyncState();
+        void GeneratePerformanceConfigurations();
         BasicGeometry GenerateBasicGeometry();
         void CreateBufferPools();
         void CreateRayTracingGeometry();
         void AddVertexAnimationPass(AZ::RPI::RenderPipeline* renderPipeline);
+        void SetVertexAnimationPassData();
         void DrawSidebar();
+        void UpdatePerformanceData();
+        void PrintPerformanceResults();
 
         AZ::Render::RayTracingFeatureProcessorInterface& GetRayTracingFeatureProcessor();
         AZ::Render::RayTracingDebugFeatureProcessorInterface& GetRayTracingDebugFeatureProcessor();
@@ -100,10 +115,16 @@ namespace AtomSampleViewer
         ImGuiSidebar m_imguiSidebar;
         AccelerationStructureType m_accelerationStructureType{ AccelerationStructureType::TriangleBLAS };
         AZ::Render::RayTracingDebugViewMode m_rayTracingDebugViewMode{ AZ::Render::RayTracingDebugViewMode::Barycentrics };
-        ImGuiHistogramQueue m_imGuiFrameTimer{ 60, 60 };
-        ImGuiHistogramQueue m_accelerationStructurePassTimer{ 60, 60 };
-        ImGuiHistogramQueue m_rayTracingPassTimer{ 60, 60 };
+        unsigned m_histogramSampleCount{ 60 };
+        ImGuiHistogramQueue m_imGuiFrameTimer{ m_histogramSampleCount, m_histogramSampleCount };
+        ImGuiHistogramQueue m_accelerationStructurePassTimer{ m_histogramSampleCount, m_histogramSampleCount };
+        ImGuiHistogramQueue m_rayTracingPassTimer{ m_histogramSampleCount, m_histogramSampleCount };
         AZ::RHI::Ptr<AZ::RPI::Pass> m_rayTracingAccelerationStructurePass;
         AZ::RHI::Ptr<AZ::RPI::Pass> m_debugRayTracingPass;
+
+        AZStd::vector<PerformanceConfiguration> m_performanceConfigurations;
+        AZStd::vector<PerformanceResult> m_performanceResults;
+        int m_measureTicks{ 0 };
+        int m_currentPerformanceConfiguration{ -1 };
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -14,6 +14,8 @@
 #include <AzCore/Math/PackedVector3.h>
 #include <CommonSampleComponentBase.h>
 #include <Passes/VertexAnimationPass.h>
+#include <Utils/ImGuiHistogramQueue.h>
+#include <Utils/ImGuiSidebar.h>
 
 namespace AtomSampleViewer
 {
@@ -23,6 +25,7 @@ namespace AtomSampleViewer
     class RayTracingVertexAnimationExampleComponent
         : public CommonSampleComponentBase
         , public AZ::RPI::SceneNotificationBus::Handler
+        , public AZ::TickBus::Handler
     {
         using Base = CommonSampleComponentBase;
 
@@ -35,6 +38,7 @@ namespace AtomSampleViewer
 
         void Activate() override;
         void Deactivate() override;
+        void OnTick(float deltaTime, AZ::ScriptTimePoint timePoint) override;
 
         void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* renderPipeline, RenderPipelineChangeType changeType) override;
 
@@ -58,6 +62,8 @@ namespace AtomSampleViewer
         void CreateBufferPools();
         void CreateRayTracingGeometry();
         void AddVertexAnimationPass(AZ::RPI::RenderPipeline* renderPipeline);
+        void DrawSidebar();
+
         AZ::Render::RayTracingFeatureProcessorInterface& GetRayTracingFeatureProcessor();
         AZ::Render::RayTracingDebugFeatureProcessorInterface& GetRayTracingDebugFeatureProcessor();
 
@@ -74,5 +80,11 @@ namespace AtomSampleViewer
         AZ::u32 m_vertexCountPerInstance;
         AZ::u32 m_targetVertexStridePerInstance;
         AZ::RPI::Ptr<AZ::Render::VertexAnimationPass> m_vertexAnimationPass;
+
+        ImGuiSidebar m_imguiSidebar;
+        int m_accelerationStructureType{ 0 };
+        ImGuiHistogramQueue m_imGuiFrameTimer{ 60, 60 };
+        ImGuiHistogramQueue m_accelerationStructureTimer{ 60, 60 };
+        AZ::RHI::Ptr<AZ::RPI::Pass> m_rayTracingAccelerationStructurePass;
     };
 } // namespace AtomSampleViewer

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -62,6 +62,10 @@ namespace AtomSampleViewer
             AZStd::vector<AZ::PackedVector3f> m_positions;
             AZStd::vector<AZ::PackedVector3f> m_normals;
             AZStd::vector<AZ::u32> m_indices;
+
+            int GetVertexCount() const;
+            int GetIndexCount() const;
+            int GetTriangleCount() const;
         };
 
         void SaveVSyncStateAndDisableVsync();
@@ -84,6 +88,9 @@ namespace AtomSampleViewer
         AZ::Data::Asset<AZ::RPI::ResourcePoolAsset> m_geometryDataBufferPoolAsset;
         AZ::Data::Instance<AZ::RPI::Buffer> m_sourceGeometryBuffer;
         AZ::Data::Instance<AZ::RPI::Buffer> m_targetGeometryBuffer;
+        AZ::Data::Instance<AZ::RPI::Buffer> m_instanceOffsetDataBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_srcInfosArrayBuffer;
+        AZ::RHI::Ptr<AZ::RHI::Buffer> m_clusterStreamOffsets;
         AZStd::vector<RayTracingMesh> m_rayTracingData;
         int m_geometryCount{ 1024 };
         AZ::u32 m_vertexCountPerInstance;
@@ -92,6 +99,7 @@ namespace AtomSampleViewer
 
         ImGuiSidebar m_imguiSidebar;
         AccelerationStructureType m_accelerationStructureType{ AccelerationStructureType::TriangleBLAS };
+        AZ::Render::RayTracingDebugViewMode m_rayTracingDebugViewMode{ AZ::Render::RayTracingDebugViewMode::Barycentrics };
         ImGuiHistogramQueue m_imGuiFrameTimer{ 60, 60 };
         ImGuiHistogramQueue m_accelerationStructurePassTimer{ 60, 60 };
         ImGuiHistogramQueue m_rayTracingPassTimer{ 60, 60 };

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -10,6 +10,7 @@
 
 #include <Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h>
 #include <Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h>
+#include <Atom/RPI.Public/Buffer/BufferPool.h>
 #include <AzCore/Math/PackedVector3.h>
 #include <CommonSampleComponentBase.h>
 #include <Passes/VertexAnimationPass.h>
@@ -54,6 +55,7 @@ namespace AtomSampleViewer
         };
 
         BasicGeometry GenerateBasicGeometry();
+        void CreateBufferPools();
         void CreateRayTracingGeometry();
         void AddVertexAnimationPass(AZ::RPI::RenderPipeline* renderPipeline);
         AZ::Render::RayTracingFeatureProcessorInterface& GetRayTracingFeatureProcessor();
@@ -62,6 +64,9 @@ namespace AtomSampleViewer
         AZ::Render::RayTracingFeatureProcessorInterface* m_rayTracingFeatureProcessor{ nullptr };
         AZ::Render::RayTracingDebugFeatureProcessorInterface* m_rayTracingDebugFeatureProcessor{ nullptr };
 
+        AZ::RHI::BufferBindFlags m_geometryDataBufferBindFlags{ AZ::RHI::BufferBindFlags::ShaderReadWrite |
+                                                                AZ::RHI::BufferBindFlags::DynamicInputAssembly };
+        AZ::Data::Asset<AZ::RPI::ResourcePoolAsset> m_geometryDataBufferPoolAsset;
         AZ::Data::Instance<AZ::RPI::Buffer> m_sourceGeometryBuffer;
         AZ::Data::Instance<AZ::RPI::Buffer> m_targetGeometryBuffer;
         AZStd::vector<RayTracingMesh> m_rayTracingData;

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -29,6 +29,12 @@ namespace AtomSampleViewer
     {
         using Base = CommonSampleComponentBase;
 
+        enum class AccelerationStructureType : int
+        {
+            TriangleBLAS,
+            CLAS_ClusterBLAS,
+        };
+
     public:
         AZ_COMPONENT(RayTracingVertexAnimationExampleComponent, "{9B43FED7-8BD0-4159-BDEC-BBF7EA39C1EC}", Base);
 
@@ -58,6 +64,8 @@ namespace AtomSampleViewer
             AZStd::vector<AZ::u32> m_indices;
         };
 
+        void SaveVSyncStateAndDisableVsync();
+        void RestoreVSyncState();
         BasicGeometry GenerateBasicGeometry();
         void CreateBufferPools();
         void CreateRayTracingGeometry();
@@ -69,6 +77,7 @@ namespace AtomSampleViewer
 
         AZ::Render::RayTracingFeatureProcessorInterface* m_rayTracingFeatureProcessor{ nullptr };
         AZ::Render::RayTracingDebugFeatureProcessorInterface* m_rayTracingDebugFeatureProcessor{ nullptr };
+        uint32_t m_preActivateVSyncInterval{ 0 };
 
         AZ::RHI::BufferBindFlags m_geometryDataBufferBindFlags{ AZ::RHI::BufferBindFlags::ShaderReadWrite |
                                                                 AZ::RHI::BufferBindFlags::DynamicInputAssembly };
@@ -82,7 +91,7 @@ namespace AtomSampleViewer
         AZ::RPI::Ptr<AZ::Render::VertexAnimationPass> m_vertexAnimationPass;
 
         ImGuiSidebar m_imguiSidebar;
-        int m_accelerationStructureType{ 0 };
+        AccelerationStructureType m_accelerationStructureType{ AccelerationStructureType::TriangleBLAS };
         ImGuiHistogramQueue m_imGuiFrameTimer{ 60, 60 };
         ImGuiHistogramQueue m_accelerationStructureTimer{ 60, 60 };
         AZ::RHI::Ptr<AZ::RPI::Pass> m_rayTracingAccelerationStructurePass;

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -73,10 +73,16 @@ namespace AtomSampleViewer
             AZStd::vector<AZ::PackedVector3f> m_positions;
             AZStd::vector<AZ::PackedVector3f> m_normals;
             AZStd::vector<AZ::u32> m_indices;
+            int m_verticesPerCluster{ 0 };
+            int m_trianglesPerCluster{ 0 };
 
             int GetVertexCount() const;
+            int GetVertexCountPerCluster() const;
             int GetIndexCount() const;
+            int GetIndexCountPerCluster() const;
             int GetTriangleCount() const;
+            int GetTriangleCountPerCluster() const;
+            int GetClusterCount() const;
         };
 
         void SaveVSyncStateAndDisableVsync();
@@ -107,7 +113,8 @@ namespace AtomSampleViewer
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_srcInfosArrayBuffer;
         AZ::RHI::Ptr<AZ::RHI::Buffer> m_clusterStreamOffsets;
         AZStd::vector<RayTracingMesh> m_rayTracingData;
-        int m_geometryCount{ 1024 };
+        int m_geometryCount{ 100 };
+        bool m_separateClusterBlasForEachInstance{ false };
         AZ::u32 m_vertexCountPerInstance;
         AZ::u32 m_targetVertexStridePerInstance;
         AZ::RPI::Ptr<AZ::Render::VertexAnimationPass> m_vertexAnimationPass;

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/Feature/Debug/RayTracingDebugFeatureProcessorInterface.h>
+#include <Atom/Feature/RayTracing/RayTracingFeatureProcessorInterface.h>
+#include <AzCore/Math/PackedVector3.h>
+#include <CommonSampleComponentBase.h>
+#include <Passes/VertexAnimationPass.h>
+
+namespace AtomSampleViewer
+{
+    //! This test adds many instances of a basic shape to the ray-tracing scene and animates the shapes' vertices each frame. The
+    //! visualization is done with the DebugRayTracingPass. The goal of this test is to benchmark the ray tracing acceleration structure
+    //! build/update time for animated meshes.
+    class RayTracingVertexAnimationExampleComponent
+        : public CommonSampleComponentBase
+        , public AZ::RPI::SceneNotificationBus::Handler
+    {
+        using Base = CommonSampleComponentBase;
+
+    public:
+        AZ_COMPONENT(RayTracingVertexAnimationExampleComponent, "{9B43FED7-8BD0-4159-BDEC-BBF7EA39C1EC}", Base);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        RayTracingVertexAnimationExampleComponent();
+
+        void Activate() override;
+        void Deactivate() override;
+
+        void OnRenderPipelineChanged(AZ::RPI::RenderPipeline* renderPipeline, RenderPipelineChangeType changeType) override;
+
+    private:
+        AZ_DISABLE_COPY_MOVE(RayTracingVertexAnimationExampleComponent);
+
+        struct RayTracingMesh
+        {
+            AZ::Uuid m_uuid;
+            AZ::Render::RayTracingFeatureProcessorInterface::Mesh m_rtMesh;
+            AZ::Render::RayTracingFeatureProcessorInterface::SubMeshVector m_rtSubMeshes;
+        };
+        struct BasicGeometry
+        {
+            AZStd::vector<AZ::PackedVector3f> m_positions;
+            AZStd::vector<AZ::PackedVector3f> m_normals;
+            AZStd::vector<AZ::u32> m_indices;
+        };
+
+        BasicGeometry GenerateBasicGeometry();
+        void CreateRayTracingGeometry();
+        void AddVertexAnimationPass(AZ::RPI::RenderPipeline* renderPipeline);
+        AZ::Render::RayTracingFeatureProcessorInterface& GetRayTracingFeatureProcessor();
+        AZ::Render::RayTracingDebugFeatureProcessorInterface& GetRayTracingDebugFeatureProcessor();
+
+        AZ::Render::RayTracingFeatureProcessorInterface* m_rayTracingFeatureProcessor{ nullptr };
+        AZ::Render::RayTracingDebugFeatureProcessorInterface* m_rayTracingDebugFeatureProcessor{ nullptr };
+
+        AZ::Data::Instance<AZ::RPI::Buffer> m_sourceGeometryBuffer;
+        AZ::Data::Instance<AZ::RPI::Buffer> m_targetGeometryBuffer;
+        AZStd::vector<RayTracingMesh> m_rayTracingData;
+        int m_geometryCount{ 1024 };
+        AZ::u32 m_vertexCountPerInstance;
+        AZ::u32 m_targetVertexStridePerInstance;
+        AZ::RPI::Ptr<AZ::Render::VertexAnimationPass> m_vertexAnimationPass;
+    };
+} // namespace AtomSampleViewer

--- a/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
+++ b/Gem/Code/Source/Performance/RayTracingVertexAnimationExampleComponent.h
@@ -97,9 +97,11 @@ namespace AtomSampleViewer
         void UpdatePerformanceData();
         void PrintPerformanceResults();
 
+        AZ::Render::MeshFeatureProcessorInterface& GetMeshFeatureProcessor();
         AZ::Render::RayTracingFeatureProcessorInterface& GetRayTracingFeatureProcessor();
         AZ::Render::RayTracingDebugFeatureProcessorInterface& GetRayTracingDebugFeatureProcessor();
 
+        AZ::Render::MeshFeatureProcessorInterface* m_meshFeatureProcessor{ nullptr };
         AZ::Render::RayTracingFeatureProcessorInterface* m_rayTracingFeatureProcessor{ nullptr };
         AZ::Render::RayTracingDebugFeatureProcessorInterface* m_rayTracingDebugFeatureProcessor{ nullptr };
         uint32_t m_preActivateVSyncInterval{ 0 };

--- a/Gem/Code/Source/SampleComponentManager.cpp
+++ b/Gem/Code/Source/SampleComponentManager.cpp
@@ -74,6 +74,7 @@
 
 #include <Performance/100KDrawable_SingleView_ExampleComponent.h>
 #include <Performance/100KDraw_10KDrawable_MultiView_ExampleComponent.h>
+#include <Performance/RayTracingVertexAnimationExampleComponent.h>
 
 #include <AreaLightExampleComponent.h>
 #include <AssetLoadTestComponent.h>
@@ -137,6 +138,7 @@
 #include <AzFramework/Scene/SceneSystemInterface.h>
 
 #include <Passes/RayTracingAmbientOcclusionPass.h>
+#include <Passes/VertexAnimationPass.h>
 
 #include <Utils/Utils.h>
 
@@ -344,6 +346,7 @@ namespace AtomSampleViewer
             NewFeaturesSample<TransparencyExampleComponent>("Transparency"),
             NewPerfSample<_100KDrawableExampleComponent>("100KDrawable_SingleView"),
             NewPerfSample<_100KDraw10KDrawableExampleComponent>("100KDraw_10KDrawable_MultiView"),
+            NewPerfSample<RayTracingVertexAnimationExampleComponent>("RayTracingVertexAnimation", []() { return Utils::GetRHIDevice()->GetFeatures().m_rayTracing; }),
         };
     }
 
@@ -410,6 +413,7 @@ namespace AtomSampleViewer
         AZ_Assert(passSystem, "Cannot get the pass system.");
 
         passSystem->AddPassCreator(Name("RayTracingAmbientOcclusionPass"), &AZ::Render::RayTracingAmbientOcclusionPass::Create);
+        passSystem->AddPassCreator(Name("VertexAnimationPass"), &AZ::Render::VertexAnimationPass::Create);
     }
 
     void SampleComponentManager::ActivateInternal()

--- a/Gem/Code/atomsampleviewergem_private_files.cmake
+++ b/Gem/Code/atomsampleviewergem_private_files.cmake
@@ -93,6 +93,8 @@ set(FILES
     Source/RHI/VariableRateShadingExampleComponent.h
     Source/Performance/HighInstanceExampleComponent.cpp
     Source/Performance/HighInstanceExampleComponent.h
+    Source/Performance/RayTracingVertexAnimationExampleComponent.cpp
+    Source/Performance/RayTracingVertexAnimationExampleComponent.h
     Source/Performance/100KDrawable_SingleView_ExampleComponent.cpp
     Source/Performance/100KDrawable_SingleView_ExampleComponent.h
     Source/Performance/100KDraw_10KDrawable_MultiView_ExampleComponent.cpp
@@ -155,6 +157,8 @@ set(FILES
     Source/ParallaxMappingExampleComponent.h
     Source/Passes/RayTracingAmbientOcclusionPass.cpp
     Source/Passes/RayTracingAmbientOcclusionPass.h
+    Source/Passes/VertexAnimationPass.cpp
+    Source/Passes/VertexAnimationPass.h
     Source/ParallaxMappingExampleComponent.h
     Source/ProceduralSkinnedMesh.cpp
     Source/ProceduralSkinnedMesh.h

--- a/Passes/ASV/PassTemplates.azasset
+++ b/Passes/ASV/PassTemplates.azasset
@@ -131,6 +131,10 @@
             {
                 "Name": "SubpassesPipelineTemplate",
                 "Path": "Passes/SubpassExample/SubpassesPipeline.pass"
+            },
+            {
+                "Name": "VertexAnimationTemplate",
+                "Path": "Passes/VertexAnimation.pass"
             }
         ]
     }

--- a/Passes/VertexAnimation.pass
+++ b/Passes/VertexAnimation.pass
@@ -18,6 +18,12 @@
                   "ShaderInputName": "m_targetVertexData",
                   "SlotType": "InputOutput",
                   "ScopeAttachmentUsage": "Shader"
+              },
+              {
+                "Name": "InstanceOffsetData",
+                "ShaderInputName": "m_instanceOffsetData",
+                "SlotType": "Input",
+                "ScopeAttachmentUsage": "Shader"
               }
           ],
           "PassData": {

--- a/Passes/VertexAnimation.pass
+++ b/Passes/VertexAnimation.pass
@@ -1,0 +1,31 @@
+{
+  "Type": "JsonSerialization",
+  "Version": 1,
+  "ClassName": "PassAsset",
+  "ClassData": {
+      "PassTemplate": {
+          "Name": "VertexAnimationTemplate",
+          "PassClass": "VertexAnimationPass",
+          "Slots": [
+              {
+                  "Name": "SourceData",
+                  "ShaderInputName": "m_sourceVertexData",
+                  "SlotType": "Input",
+                  "ScopeAttachmentUsage": "Shader"
+              },
+              {
+                  "Name": "TargetData",
+                  "ShaderInputName": "m_targetVertexData",
+                  "SlotType": "InputOutput",
+                  "ScopeAttachmentUsage": "Shader"
+              }
+          ],
+          "PassData": {
+              "$type": "ComputePassData",
+              "ShaderAsset": {
+                  "FilePath": "Shaders/VertexAnimation.shader"
+              }
+           }
+        }
+    }
+}

--- a/Shaders/VertexAnimation.azsl
+++ b/Shaders/VertexAnimation.azsl
@@ -76,7 +76,7 @@ void AnimateVertices(uint3 dispatchId : SV_DispatchThreadID)
 
     // Animated the vertices by displacing each vertex in a random direction by a random amount
     float3 animationMoveDirection = rng.GetRandomUnitSphereDirection();
-    float animationMoveAmount = rng.GetRandomNormalizedFloat() * 0.1f;
+    float animationMoveAmount = rng.GetRandomNormalizedFloat() * 0.02f;
 
     // Need to move vertices per instance in the compute shader since CLAS does not have a separate transform
     float3 vertexBaseLocation = PassSrg::m_instanceOffsetData[instanceIndex] + PassSrg::m_sourceVertexData[inputIndex];

--- a/Shaders/VertexAnimation.azsl
+++ b/Shaders/VertexAnimation.azsl
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Atom/Features/SrgSemantics.azsli>
+#include <Atom/RPI/Math.azsli>
+
+ShaderResourceGroup PassSrg : SRG_PerPass
+{
+    StructuredBuffer<float3> m_sourceVertexData;
+    RWStructuredBuffer<float3> m_targetVertexData;
+    uint m_frameNumber;
+    uint m_vertexCountPerInstance;
+    uint m_targetVertexStridePerInstance;
+}
+
+class ContinuousSineRng
+{
+    uint m_seed;
+    uint m_timeshift;
+
+    void Initialize(float3 position, uint instanceIndex, uint timeshift)
+    {
+        m_seed = 0;
+        m_seed ^= asuint(position.x);
+        Xorshift(m_seed);
+        m_seed ^= asuint(position.y);
+        Xorshift(m_seed);
+        m_seed ^= asuint(position.z);
+        Xorshift(m_seed);
+
+        m_seed ^= instanceIndex;
+        Xorshift(m_seed);
+
+        m_timeshift = timeshift;
+    }
+
+    float GetRandomNormalizedFloat()
+    {
+        // Duration in frames after which the animation repeats
+        float animationDuration = Xorshift(m_seed) % 40 + 120;
+
+        // The float values passed to the sin-function should not be too large, otherwise the result is not continuous
+        uint seedSmall = m_seed % 1024;
+        float timeshiftSmall = (m_timeshift % animationDuration) / animationDuration * TWO_PI;
+        return sin(seedSmall + timeshiftSmall) * 0.5f + 0.5f;
+    }
+
+    float3 GetRandomUnitSphereDirection()
+    {
+        float z = GetRandomNormalizedFloat() * 2.f - 1.f;
+        float phi = GetRandomNormalizedFloat() * TWO_PI;
+
+        float rxy = sqrt(1.f - z * z);
+        float x = rxy * cos(phi);
+        float y = rxy * sin(phi);
+
+        return normalize(float3(x, y, z));
+    }
+};
+
+[numthreads(64, 1, 1)]
+void AnimateVertices(uint3 dispatchId : SV_DispatchThreadID)
+{
+    uint instanceIndex = dispatchId.x / PassSrg::m_vertexCountPerInstance;
+    uint inputIndex = dispatchId.x % PassSrg::m_vertexCountPerInstance;
+    uint outputIndex = instanceIndex * PassSrg::m_targetVertexStridePerInstance + inputIndex;
+
+    ContinuousSineRng rng;
+    rng.Initialize(PassSrg::m_sourceVertexData[inputIndex], instanceIndex, PassSrg::m_frameNumber);
+
+    // Animated the vertices by displacing each vertex in a random direction by a random amount
+    float3 moveDirection = rng.GetRandomUnitSphereDirection();
+    float moveAmount = rng.GetRandomNormalizedFloat() * 0.1f;
+
+    PassSrg::m_targetVertexData[outputIndex] = PassSrg::m_sourceVertexData[inputIndex] + moveDirection * moveAmount;
+}

--- a/Shaders/VertexAnimation.azsl
+++ b/Shaders/VertexAnimation.azsl
@@ -14,7 +14,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass
     StructuredBuffer<float3> m_sourceVertexData;
     RWStructuredBuffer<float3> m_targetVertexData;
     StructuredBuffer<float3> m_instanceOffsetData;
-    uint m_frameNumber;
+    float m_frameTime;
     uint m_vertexCountPerInstance;
     uint m_targetVertexStridePerInstance;
 }
@@ -22,9 +22,9 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 class ContinuousSineRng
 {
     uint m_seed;
-    uint m_timeshift;
+    float m_timeshift;
 
-    void Initialize(float3 position, uint instanceIndex, uint timeshift)
+    void Initialize(float3 position, uint instanceIndex, float timeshift)
     {
         m_seed = 0;
         m_seed ^= asuint(position.x);
@@ -42,8 +42,8 @@ class ContinuousSineRng
 
     float GetRandomNormalizedFloat()
     {
-        // Duration in frames after which the animation repeats
-        float animationDuration = Xorshift(m_seed) % 40 + 120;
+        // Duration in seconds after which the animation repeats
+        float animationDuration = (Xorshift(m_seed) % 60 + 120) / 60.f;
 
         // The float values passed to the sin-function should not be too large, otherwise the result is not continuous
         uint seedSmall = m_seed % 1024;
@@ -72,7 +72,7 @@ void AnimateVertices(uint3 dispatchId : SV_DispatchThreadID)
     uint outputIndex = instanceIndex * PassSrg::m_targetVertexStridePerInstance + inputIndex;
 
     ContinuousSineRng rng;
-    rng.Initialize(PassSrg::m_sourceVertexData[inputIndex], instanceIndex, PassSrg::m_frameNumber);
+    rng.Initialize(PassSrg::m_sourceVertexData[inputIndex], instanceIndex, PassSrg::m_frameTime);
 
     // Animated the vertices by displacing each vertex in a random direction by a random amount
     float3 animationMoveDirection = rng.GetRandomUnitSphereDirection();

--- a/Shaders/VertexAnimation.azsl
+++ b/Shaders/VertexAnimation.azsl
@@ -13,6 +13,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass
 {
     StructuredBuffer<float3> m_sourceVertexData;
     RWStructuredBuffer<float3> m_targetVertexData;
+    StructuredBuffer<float3> m_instanceOffsetData;
     uint m_frameNumber;
     uint m_vertexCountPerInstance;
     uint m_targetVertexStridePerInstance;
@@ -74,8 +75,11 @@ void AnimateVertices(uint3 dispatchId : SV_DispatchThreadID)
     rng.Initialize(PassSrg::m_sourceVertexData[inputIndex], instanceIndex, PassSrg::m_frameNumber);
 
     // Animated the vertices by displacing each vertex in a random direction by a random amount
-    float3 moveDirection = rng.GetRandomUnitSphereDirection();
-    float moveAmount = rng.GetRandomNormalizedFloat() * 0.1f;
+    float3 animationMoveDirection = rng.GetRandomUnitSphereDirection();
+    float animationMoveAmount = rng.GetRandomNormalizedFloat() * 0.1f;
 
-    PassSrg::m_targetVertexData[outputIndex] = PassSrg::m_sourceVertexData[inputIndex] + moveDirection * moveAmount;
+    // Need to move vertices per instance in the compute shader since CLAS does not have a separate transform
+    float3 vertexBaseLocation = PassSrg::m_instanceOffsetData[instanceIndex] + PassSrg::m_sourceVertexData[inputIndex];
+
+    PassSrg::m_targetVertexData[outputIndex] = vertexBaseLocation + animationMoveDirection * animationMoveAmount;
 }

--- a/Shaders/VertexAnimation.shader
+++ b/Shaders/VertexAnimation.shader
@@ -1,0 +1,11 @@
+{
+    "Source": "./VertexAnimation.azsl",
+    "ProgramSettings": {
+        "EntryPoints": [
+            {
+                "name": "AnimateVertices",
+                "type": "Compute"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This PR adds a sample which shows how the performance of the new Cluster-level acceleration structure (CLAS) feature, which is introduced in O3DE [PR19218](https://github.com/o3de/o3de/pull/19218) could be improved for animated scenes:

The sample generates some ico-spheres, subdivides them a few times, animates each vertex position each frame, and updates the ray tracing acceleration structure each frame. For visualization the "Debug Ray Tracing" component is used.
Some visualization options (Normals and UV coordinates with CLAS) do not work out of the box, since the current DXC version cannot supply the `ClusterIDNV` input, which is required for getting the proper geometry data in the hit shaders.

(This PR does not compile without [PR715](https://github.com/o3de/o3de-atom-sampleviewer/pull/715), since PR715 also updates the ray tracing RHI sample due to an API change introduced by the CLAS PR (One more parmeter was added to `CommandList::BuildTopLevelAccelerationStructure`)).

The sample should look like this:
<img alt="Ray tracing vertex animation sample" src="https://github.com/user-attachments/assets/c282cac3-55f3-4818-8807-297e7b1c0051" />

## Performance evaluation

The sample has a "Start benchmark" button, which measures acceleration structure build + ray tracing time of BLAS/CLAS with a number of different geometric complexities. The table shows that especially for larger animated scenes, CLAS performs better than BLAS (RTX 3090, times in ms). It is important to note that triangle BLASes are by default only rebuilt each 8 frames (`RayTracingAccelerationStructurePass::SKINNED_BLAS_REBUILD_FRAME_INTERVAL`), and upadted in all other instances, which is a lot faster than rebuilding them each frame. Changing the rebuild interval of BLAS to 1 (rebuild each time) would increase the BLAS build time column to [0.40, 0.87, 1.65, 4.90, 9.72, 16.33], which would be much slower in all cases.

Geometry count   | BLAS build | CLAS build | BLAS trace | CLAS trace | BLAS sum  | CLAS sum
-------- | ----- | ----- | ----- | ----- | ---- | ----
1     | 0.11  | 0.28  | 0.13  | 0.14  | 0.23 | 0.41
5     | 0.28  | 0.37  | 0.15  | 0.19  | 0.44 | 0.56
10    | 0.42  | 0.45  | 0.18  | 0.25  | 0.60 | 0.70
30    | 0.94  | 0.80  | 0.23  | 0.42  | 1.17 | 1.21
60    | 1.74  | 1.28  | 0.27  | 0.51  | 2.01 | 1.79
100    | 2.90  | 1.97  | 0.30  | 0.60  | 3.20 | 2.57