### PR TITLE
Cherry-pick C++20 fixes to stabilization/25100

### DIFF
--- a/Gem/Code/Source/ExposureExampleComponent.cpp
+++ b/Gem/Code/Source/ExposureExampleComponent.cpp
@@ -146,7 +146,7 @@ namespace AtomSampleViewer
         m_pointLight = lightHandle;
     }
 
-    void ExposureExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
+    void ExposureExampleComponent::OnModelReady([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Model> model)
     {
         m_sponzaAssetLoaded = true;
 

--- a/Gem/Code/Source/RHI/CopyQueueComponent.cpp
+++ b/Gem/Code/Source/RHI/CopyQueueComponent.cpp
@@ -227,7 +227,7 @@ namespace AtomSampleViewer
 
             RHI::EmptyCompileFunction<ScopeData> compileFunction;
 
-            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 
                 RHI::CommandList* commandList = context.GetCommandList();

--- a/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/MultiGPUExampleComponent.cpp
@@ -599,7 +599,7 @@ namespace AtomSampleViewer
                 m_shaderResourceGroupComposite->Compile(m_shaderResourceGroupDataComposite);
             };
 
-            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/SphericalHarmonicsExampleComponent.cpp
@@ -308,7 +308,7 @@ namespace AtomSampleViewer
                 }
             };
 
-            const auto executeFunction = [=]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/Texture3dExampleComponent.cpp
@@ -206,7 +206,7 @@ namespace AtomSampleViewer
                 m_shaderResourceGroup->Compile();
             };
 
-            const auto executeFunction = [=]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this]([[maybe_unused]] const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/RHI/TextureExampleComponent.cpp
+++ b/Gem/Code/Source/RHI/TextureExampleComponent.cpp
@@ -221,7 +221,7 @@ namespace AtomSampleViewer
                 }
             };
 
-            const auto executeFunction = [=](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
+            const auto executeFunction = [this](const RHI::FrameGraphExecuteContext& context, [[maybe_unused]] const ScopeData& scopeData)
             {
                 RHI::CommandList* commandList = context.GetCommandList();
 

--- a/Gem/Code/Source/SsaoExampleComponent.cpp
+++ b/Gem/Code/Source/SsaoExampleComponent.cpp
@@ -88,7 +88,7 @@ namespace AtomSampleViewer
 
     // --- World Model ---
 
-    void SsaoExampleComponent::OnModelReady(AZ::Data::Instance<AZ::RPI::Model> model)
+    void SsaoExampleComponent::OnModelReady([[maybe_unused]] AZ::Data::Instance<AZ::RPI::Model> model)
     {
         m_worldModelAssetLoaded = true;
     }


### PR DESCRIPTION
I noticed that there are some C++20-related errors blocking the `stabilization/25100` branch of Atom Sample Viewer to be built with O3DE 25.10 preview. This PR cherry-picks C++20 fixes from `development` to `stabilization/25100`. After this PR, the `stabilization/25100` could be successfully built against O3DE 25.10 preview. 